### PR TITLE
[修复] 铁砧砸物品后客户端物品数量不变

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/anvil/item/ItemAnvilRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/anvil/item/ItemAnvilRecipe.java
@@ -27,12 +27,13 @@ import net.minecraft.world.level.block.LayeredCauldronBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.phys.AABB;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 @Getter
 public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
@@ -43,7 +44,6 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
     private final List<ItemStack> results;
     private final Location resultLocation;
     private final boolean isAnvilDamage;
-
     public ItemAnvilRecipe(ResourceLocation id, NonNullList<TagIngredient> recipeItems, Location location, NonNullList<Component> components, List<ItemStack> results, Location resultLocation, boolean isAnvilDamage) {
         this.id = id;
         this.recipeItems = recipeItems;
@@ -53,7 +53,6 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
         this.resultLocation = resultLocation;
         this.isAnvilDamage = isAnvilDamage;
     }
-
     @Override
     public boolean matches(@NotNull AnvilCraftingContainer container, Level level) {
         BlockPos pos = new BlockPos(container.pos());
@@ -79,7 +78,6 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
         });
         return recipeItems.isEmpty();
     }
-
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean craft(@NotNull AnvilCraftingContainer container, Level level) {
         if (!this.matches(container, level)) return false;
@@ -87,18 +85,23 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
         if (this.location == Location.IN) pos = pos.below();
         if (this.location == Location.UNDER) pos = pos.below(2);
         List<ItemEntity> itemEntities = level.getEntities(EntityTypeTest.forClass(ItemEntity.class), new AABB(pos), Entity::isAlive);
-        Map<ItemStack, ItemEntity> itemStackMap = new HashMap<>();
+        List<Pair<ItemEntity, ItemStack>> itemsTraces = new ArrayList<>();
         for (ItemEntity itemEntity : itemEntities) {
-            itemStackMap.put(itemEntity.getItem(), itemEntity);
+            itemsTraces.add(Pair.of(itemEntity, itemEntity.getItem().copy()));//itemStack只有前后不相等才会成功设置并同步到客户端，所以这里需要复制
         }
         NonNullList<TagIngredient> recipeItems = NonNullListUtils.copy(this.recipeItems);
+        Set<Pair<ItemEntity, ItemStack>> modifieds = new HashSet<>();
         for (TagIngredient ingredient : recipeItems) {
-            for (ItemStack itemStack : itemStackMap.keySet()) {
+            for (Pair<ItemEntity, ItemStack> itemTrace : itemsTraces) {
+                ItemStack itemStack = itemTrace.getRight();
                 if (!ingredient.test(itemStack)) continue;
                 itemStack.shrink(1);
-                itemStackMap.get(itemStack).setItem(itemStack.copy());//只有前后不相等才会成功设置并同步到客户端，但是傻逼ItemStack没有重写equals
+                modifieds.add(itemTrace);
                 break;
             }
+        }
+        for (Pair<ItemEntity, ItemStack> itemTrace : modifieds) {
+            itemTrace.getLeft().setItem(itemTrace.getRight());//因为ItemStack没有重写equals，而上面已经复制了，所以保证前后是不相等（不同）的itemStack对象
         }
         BlockState state = level.getBlockState(pos);
         if (state.is(Blocks.WATER_CAULDRON)) {
@@ -110,49 +113,39 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
         }
         return true;
     }
-
     @Override
     public @NotNull ItemStack assemble(AnvilCraftingContainer container, RegistryAccess registryAccess) {
         return this.getResultItem(registryAccess).copy();
     }
-
     @Override
     public boolean canCraftInDimensions(int width, int height) {
         return true;
     }
-
     @Override
     public @NotNull ItemStack getResultItem(RegistryAccess registryAccess) {
         return this.results.isEmpty() ? ItemStack.EMPTY : this.results.get(0);
     }
-
     @Override
     public @NotNull RecipeSerializer<?> getSerializer() {
         return Serializer.INSTANCE;
     }
-
     @Override
     public @NotNull RecipeType<?> getType() {
         return Type.INSTANCE;
     }
-
     public @NotNull NonNullList<TagIngredient> getTagIngredients() {
         return this.recipeItems;
     }
-
     public static class Type implements RecipeType<ItemAnvilRecipe> {
         public static final Type INSTANCE = new Type();
-
         private Type() {
         }
     }
-
+    
     public static class Serializer implements RecipeSerializerBase<ItemAnvilRecipe> {
         public static final Serializer INSTANCE = new Serializer();
-
         private Serializer() {
         }
-
         @Override
         public @NotNull ItemAnvilRecipe fromJson(ResourceLocation id, JsonObject json) {
             NonNullList<TagIngredient> input = shapelessFromJson(GsonHelper.getAsJsonArray(json, "ingredients"));
@@ -167,7 +160,6 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
             boolean isAnvilDamage = json.has("is_anvil_damage") && json.get("is_anvil_damage").getAsBoolean();
             return new ItemAnvilRecipe(id, input, location, components, results, resultLocation, isAnvilDamage);
         }
-
         @Override
         public @NotNull ItemAnvilRecipe fromNetwork(ResourceLocation id, @NotNull FriendlyByteBuf buffer) {
             NonNullList<TagIngredient> ingredients = NonNullList.withSize(buffer.readVarInt(), TagIngredient.EMPTY);
@@ -184,7 +176,6 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
             boolean isAnvilDamage = buffer.readBoolean();
             return new ItemAnvilRecipe(id, ingredients, location, components, results, resultLocation, isAnvilDamage);
         }
-
         @Override
         public void toNetwork(@NotNull FriendlyByteBuf buffer, @NotNull ItemAnvilRecipe recipe) {
             buffer.writeVarInt(recipe.getTagIngredients().size());
@@ -204,14 +195,12 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
             buffer.writeBoolean(recipe.isAnvilDamage);
         }
     }
-
+    
     public enum Location {
         UP, UNDER, IN;
-
         public @NotNull String getId() {
             return this.name().toLowerCase();
         }
-
         public static Location byId(@NotNull String id) {
             return Location.valueOf(id.toUpperCase());
         }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/anvil/item/ItemAnvilRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/anvil/item/ItemAnvilRecipe.java
@@ -29,7 +29,10 @@ import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Getter
 public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
@@ -93,7 +96,7 @@ public class ItemAnvilRecipe implements Recipe<AnvilCraftingContainer> {
             for (ItemStack itemStack : itemStackMap.keySet()) {
                 if (!ingredient.test(itemStack)) continue;
                 itemStack.shrink(1);
-                itemStackMap.get(itemStack).setItem(itemStack);
+                itemStackMap.get(itemStack).setItem(itemStack.copy());//只有前后不相等才会成功设置并同步到客户端，但是傻逼ItemStack没有重写equals
                 break;
             }
         }


### PR DESCRIPTION
原先bug原因：用`ItemEntity#setItem`设置物品，必须与原先的物品不同，才会成功设置并同步到客户端（`SynchedEntityData#set`），而原先的代码里只是设置了`itemStack`的数量，然后把同一个对象设置回物品实体，所以没有通过不相等检验，因此没有同步到客户端。