### PR TITLE
升级fabric loom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.5-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ sourceSets {
 // configure the maven publication
 publishing {
     publications {
+        //noinspection GroovyAssignabilityCheck
         mavenJava(MavenPublication) {
             from components.java
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl = https\://services.gradle.org/distributions/gradle-8.6-bin.zip

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/crafting_table/ShapedTagRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/crafting_table/ShapedTagRecipe.java
@@ -11,13 +11,17 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.item.crafting.CraftingBookCategory;
+import net.minecraft.world.item.crafting.CustomRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
-public class ShapedTagRecipe extends CustomRecipe implements CraftingRecipe {
+@SuppressWarnings("deprecation")
+public class ShapedTagRecipe extends CustomRecipe {
     @Getter
     final int width;
     @Getter
@@ -65,7 +69,7 @@ public class ShapedTagRecipe extends CustomRecipe implements CraftingRecipe {
 
     @Override
     public @NotNull NonNullList<Ingredient> getIngredients() {
-        return NonNullList.of(Ingredient.EMPTY, (Ingredient[]) this.recipeItems.stream().map(TagIngredient::toVanilla).toArray());
+        return NonNullList.of(Ingredient.EMPTY, this.recipeItems.stream().map(TagIngredient::toVanilla).toArray(Ingredient[]::new));
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModRecipeTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModRecipeTypes.java
@@ -10,6 +10,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,11 +18,10 @@ import java.util.Map;
 @SuppressWarnings("unused")
 public class ModRecipeTypes {
     private static final Map<String, Pair<RecipeSerializer<?>, RecipeType<?>>> RECIPE_TYPES = new HashMap<>();
-    public static final RecipeType<ShapedTagRecipe> TAG_CRAFTING_SHAPED = ModRecipeTypes.registerRecipeType("tag_crafting_shaped", ShapedTagRecipe.Serializer.INSTANCE, null);
+    public static final @Nullable RecipeType<ShapedTagRecipe> TAG_CRAFTING_SHAPED = ModRecipeTypes.registerRecipeType("tag_crafting_shaped", ShapedTagRecipe.Serializer.INSTANCE, null);
     public static final RecipeType<ItemAnvilRecipe> ANVIL_ITEM = ModRecipeTypes.registerRecipeType("anvil_item_processing", ItemAnvilRecipe.Serializer.INSTANCE, ItemAnvilRecipe.Type.INSTANCE);
     public static final RecipeType<BlockAnvilRecipe> ANVIL_BLOCK = ModRecipeTypes.registerRecipeType("anvil_block_processing", BlockAnvilRecipe.Serializer.INSTANCE, BlockAnvilRecipe.Type.INSTANCE);
-
-    private static <T extends Recipe<?>> RecipeType<T> registerRecipeType(String id, RecipeSerializer<T> serializer, RecipeType<T> type) {
+    private static <T extends Recipe<?>> @Nullable RecipeType<T> registerRecipeType(String id, @Nullable RecipeSerializer<T> serializer, @Nullable RecipeType<T> type) {
         RECIPE_TYPES.put(id, new Pair<>(serializer, type));
         return type;
     }


### PR DESCRIPTION
- loom 1.6改进了反编译，现在会尽可能利用缓存，而不是每次修改AW和变更库后都重新全部反编译一遍。
- 一点小修复。