### PR TITLE
改进NBT合成

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/data/generator/recipe/VanillaRecipesGenerator.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/generator/recipe/VanillaRecipesGenerator.java
@@ -55,12 +55,12 @@ public abstract class VanillaRecipesGenerator {
                 .unlockedBy(MyRecipesGenerator.hasItem(ModItems.MAGNET_INGOT), FabricRecipeProvider.has(ModItems.MAGNET_INGOT))
                 .unlockedBy(MyRecipesGenerator.hasItem(Items.ENDER_PEARL), FabricRecipeProvider.has(Items.ENDER_PEARL))
                 .save(exporter);
-        ShapedTagRecipeBuilder.shaped(RecipeCategory.TOOLS, ModItems.AMETHYST_PICKAXE)
+        ShapedTagRecipeBuilder.shaped(RecipeCategory.TOOLS, ModItems.AMETHYST_PICKAXE.getDefaultInstance())
                 .pattern("AAA")
                 .pattern(" B ")
                 .pattern(" B ")
                 .define('A', Items.AMETHYST_SHARD)
-                .define('B', Items.BAMBOO)
+          .define('B', Items.STICK)
                 .unlockedBy(MyRecipesGenerator.hasItem(Items.AMETHYST_SHARD), FabricRecipeProvider.has(Items.AMETHYST_SHARD))
                 .unlockedBy(MyRecipesGenerator.hasItem(Items.BAMBOO), FabricRecipeProvider.has(Items.BAMBOO))
                 .save(exporter);

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/crafting_table/ShapedTagRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/crafting_table/ShapedTagRecipe.java
@@ -11,16 +11,16 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.CraftingBookCategory;
-import net.minecraft.world.item.crafting.CustomRecipe;
-import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
-@SuppressWarnings("deprecation")
+/**
+ * @deprecated {@link ShapedRecipe}
+ */
+@Deprecated
 public class ShapedTagRecipe extends CustomRecipe {
     @Getter
     final int width;

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/crafting_table/ShapedTagRecipeBuilder.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/crafting_table/ShapedTagRecipeBuilder.java
@@ -33,20 +33,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-@SuppressWarnings("unused")
+@Getter
 public class ShapedTagRecipeBuilder extends ShapedRecipeBuilder {
-    @Getter
     private final RecipeCategory category;
-    @Getter
     private final ItemStack stackResult;
-    @Getter
     private final List<String> rows = Lists.newArrayList();
-    @Getter
     private final Map<Character, TagIngredient> key = Maps.newLinkedHashMap();
-    @Getter
     private final Advancement.Builder advancement = Advancement.Builder.recipeAdvancement();
-    @Nullable
-    private String group;
+    private @Nullable String group;
     private boolean showNotification = true;
 
     public ShapedTagRecipeBuilder(RecipeCategory category, @NotNull ItemStack stack) {
@@ -197,7 +191,7 @@ public class ShapedTagRecipeBuilder extends ShapedRecipeBuilder {
 
         @Override
         public @NotNull RecipeSerializer<?> getType() {
-            return ShapedTagRecipe.Serializer.INSTANCE;
+            return RecipeSerializer.SHAPED_RECIPE;
         }
 
         @Nullable

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModItemGroups.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModItemGroups.java
@@ -24,10 +24,6 @@ public class ModItemGroups {
                 entries.accept(ModItems.CHANGEABLE_PICKAXE_FORTUNE.getDefaultInstance());
                 entries.accept(ModItems.CHANGEABLE_PICKAXE_SILK_TOUCH.getDefaultInstance());
                 entries.accept(ModItems.AMETHYST_PICKAXE.getDefaultInstance());
-                entries.accept(ModItems.AMETHYST_AXE.getDefaultInstance());
-                entries.accept(ModItems.AMETHYST_HOE.getDefaultInstance());
-                entries.accept(ModItems.AMETHYST_SWORD.getDefaultInstance());
-                entries.accept(ModItems.AMETHYST_SHOVEL.getDefaultInstance());
                 entries.accept(ModItems.PROTOCOL_EMPTY.getDefaultInstance());
                 entries.accept(ModItems.PROTOCOL_PROTECT.getDefaultInstance());
                 entries.accept(ModItems.PROTOCOL_REPAIR.getDefaultInstance());

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModRecipeTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModRecipeTypes.java
@@ -15,9 +15,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("unused")
 public class ModRecipeTypes {
     private static final Map<String, Pair<RecipeSerializer<?>, RecipeType<?>>> RECIPE_TYPES = new HashMap<>();
+    /**
+     * @deprecated {@link RecipeType#CRAFTING} {@link RecipeSerializer#SHAPED_RECIPE}
+     */
+    @Deprecated
     public static final @Nullable RecipeType<ShapedTagRecipe> TAG_CRAFTING_SHAPED = ModRecipeTypes.registerRecipeType("tag_crafting_shaped", ShapedTagRecipe.Serializer.INSTANCE, null);
     public static final RecipeType<ItemAnvilRecipe> ANVIL_ITEM = ModRecipeTypes.registerRecipeType("anvil_item_processing", ItemAnvilRecipe.Serializer.INSTANCE, ItemAnvilRecipe.Type.INSTANCE);
     public static final RecipeType<BlockAnvilRecipe> ANVIL_BLOCK = ModRecipeTypes.registerRecipeType("anvil_block_processing", BlockAnvilRecipe.Serializer.INSTANCE, BlockAnvilRecipe.Type.INSTANCE);

--- a/src/main/java/dev/dubhe/anvilcraft/item/ModTiers.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ModTiers.java
@@ -16,6 +16,7 @@ public enum ModTiers implements Tier {
     private final float speed;
     private final float damage;
     private final int enchantmentValue;
+    @SuppressWarnings("deprecation")
     private final LazyLoadedValue<Ingredient> repairIngredient;
 
     private ModTiers(int j, int k, float f, float g, int l, Supplier<Ingredient> supplier) {
@@ -24,6 +25,7 @@ public enum ModTiers implements Tier {
         this.speed = f;
         this.damage = g;
         this.enchantmentValue = l;
+        //noinspection deprecation
         this.repairIngredient = new LazyLoadedValue<>(supplier);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/item/ModTiers.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ModTiers.java
@@ -1,6 +1,6 @@
 package dev.dubhe.anvilcraft.item;
 
-import net.minecraft.util.LazyLoadedValue;
+import com.google.common.base.Suppliers;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.Tier;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -16,17 +16,14 @@ public enum ModTiers implements Tier {
     private final float speed;
     private final float damage;
     private final int enchantmentValue;
-    @SuppressWarnings("deprecation")
-    private final LazyLoadedValue<Ingredient> repairIngredient;
-
-    private ModTiers(int j, int k, float f, float g, int l, Supplier<Ingredient> supplier) {
-        this.level = j;
-        this.uses = k;
-        this.speed = f;
-        this.damage = g;
-        this.enchantmentValue = l;
-        //noinspection deprecation
-        this.repairIngredient = new LazyLoadedValue<>(supplier);
+    private final Supplier<Ingredient> repairIngredient;
+    ModTiers(int level, int uses, float speed, float damage, int enchantmentValue, Supplier<Ingredient> supplier) {
+        this.level = level;
+        this.uses = uses;
+        this.speed = speed;
+        this.damage = damage;
+        this.enchantmentValue = enchantmentValue;
+        this.repairIngredient = Suppliers.memoize(supplier::get);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ShapedRecipeMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ShapedRecipeMixin.java
@@ -1,0 +1,32 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.nbt.TagParser;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ShapedRecipe.class)
+abstract class ShapedRecipeMixin {
+    @ModifyExpressionValue(method = "itemStackFromJson", at = @At(value = "INVOKE", target = "Lcom/google/gson/JsonObject;has(Ljava/lang/String;)Z"))
+    private static boolean validNbt(boolean original) {
+        return false;
+    }
+    @ModifyExpressionValue(method = "itemStackFromJson", at = @At(value = "NEW", target = "(Lnet/minecraft/world/level/ItemLike;I)Lnet/minecraft/world/item/ItemStack;"))
+    private static ItemStack readNbt(ItemStack original, JsonObject stackObject) {
+        if (stackObject.has("data")) {
+            String sNBT = GsonHelper.getAsString(stackObject, "data");
+            try {
+                original.setTag(TagParser.parseTag(sNBT));
+            } catch (CommandSyntaxException e) {
+                throw new JsonParseException(e);
+            }
+        }
+        return original;
+    }
+}

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -8,6 +8,7 @@
     "ClientboundUpdateRecipesPacketMixin",
     "ItemEntityMixin",
     "ItemStackInjector",
+    "ShapedRecipeMixin",
     "event.FallingBlockEntityMixin",
     "event.LightningBoltMixin",
     "event.MinecraftServerMixin"


### PR DESCRIPTION
- 用mixin原版有序合成代替自定义NBT合成。
- 把紫水晶镐的竹子改成木棍。
- 把其它紫水晶工具从创造模式物品栏删除。