### PR TITLE
修复合成器GUI

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/inventory/AutoCrafterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/inventory/AutoCrafterScreen.java
@@ -3,7 +3,6 @@ package dev.dubhe.anvilcraft.client.gui.screen.inventory;
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.gui.component.RecordMaterialButton;
-import dev.dubhe.anvilcraft.inventory.AutoCrafterContainer;
 import dev.dubhe.anvilcraft.inventory.AutoCrafterMenu;
 import dev.dubhe.anvilcraft.inventory.component.AutoCrafterSlot;
 import dev.dubhe.anvilcraft.network.MachineRecordMaterialPack;
@@ -16,15 +15,10 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickType;
-import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.CraftingRecipe;
-import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 public class AutoCrafterScreen extends BaseMachineScreen<AutoCrafterMenu> {
@@ -110,7 +104,6 @@ public class AutoCrafterScreen extends BaseMachineScreen<AutoCrafterMenu> {
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         this.renderBackground(guiGraphics);
         super.render(guiGraphics, mouseX, mouseY, partialTick);
-        this.renderResultItem(guiGraphics, 134, 54);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
     }
 
@@ -119,23 +112,5 @@ public class AutoCrafterScreen extends BaseMachineScreen<AutoCrafterMenu> {
         int i = (this.width - this.imageWidth) / 2;
         int j = (this.height - this.imageHeight) / 2;
         guiGraphics.blit(CONTAINER_LOCATION, i, j, 0, 0, this.imageWidth, this.imageHeight);
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    protected void renderResultItem(@NotNull GuiGraphics guiGraphics, int x, int y) {
-        NonNullList<ItemStack> stacks = NonNullList.withSize(9, ItemStack.EMPTY);
-        for (int i = 0; i < 9; i++) stacks.set(i, this.menu.slots.get(i).getItem());
-        CraftingContainer container = new AutoCrafterContainer(stacks);
-        Level level = this.menu.getInventory().player.level();
-        Optional<CraftingRecipe> optional = level.getRecipeManager().getRecipeFor(RecipeType.CRAFTING, container, level);
-        if (optional.isEmpty()) return;
-        ItemStack stack = optional.get().assemble(container, level.registryAccess());
-        int i = (this.width - this.imageWidth) / 2 + x;
-        int j = (this.height - this.imageHeight) / 2 + y;
-        guiGraphics.pose().pushPose();
-        guiGraphics.pose().translate(0.0f, 0.0f, 232.0f);
-        guiGraphics.renderItem(stack, i, j);
-        guiGraphics.renderItemDecorations(this.font, stack, i, j, null);
-        guiGraphics.pose().popPose();
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
@@ -4,23 +4,28 @@ import dev.dubhe.anvilcraft.block.entity.AutoCrafterBlockEntity;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.inventory.component.AutoCrafterSlot;
 import lombok.Getter;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class AutoCrafterMenu extends BaseMachineMenu {
     private Inventory inventory;
-
+    private final Slot resultSlot;
     public AutoCrafterMenu(int containerId, Inventory inventory) {
-        this(containerId, inventory, new SimpleContainer(9));
+        this(containerId, inventory, new AutoCrafterContainer(NonNullList.withSize(9, ItemStack.EMPTY)));
         this.inventory = inventory;
     }
-
-    public AutoCrafterMenu(int containerId, @NotNull Inventory inventory, @NotNull Container interactMachine) {
+    public AutoCrafterMenu(int containerId, @NotNull Inventory inventory, @NotNull CraftingContainer interactMachine) {
         super(ModMenuTypes.AUTO_CRAFTER, containerId, interactMachine);
         this.inventory = inventory;
         this.machine.startOpen(inventory.player);
@@ -30,6 +35,7 @@ public class AutoCrafterMenu extends BaseMachineMenu {
                 this.addSlot(new AutoCrafterSlot(this.machine, j + i * 3, 26 + j * 18, 18 + i * 18, this));
             }
         }
+        addSlot(resultSlot = new ReadOnlySlot(new SimpleContainer(1), 0, 8 + 7 * 18, 18 + 2 * 18));
         for (i = 0; i < 3; ++i) {
             for (j = 0; j < 9; ++j) {
                 this.addSlot(new Slot(inventory, j + i * 9 + 9, 8 + j * 18, 84 + i * 18));
@@ -38,26 +44,39 @@ public class AutoCrafterMenu extends BaseMachineMenu {
         for (i = 0; i < 9; ++i) {
             this.addSlot(new Slot(inventory, i, 8 + i * 18, 142));
         }
+        updateResult();
     }
-
     @Override
     public void removed(Player player) {
         super.removed(player);
         this.machine.stopOpen(player);
     }
-
     public void setRecordMaterial(boolean record) {
         if (this.machine instanceof AutoCrafterBlockEntity entity) entity.setRecord(record);
     }
-
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isSlotDisabled(int index) {
         if (!(this.machine instanceof AutoCrafterBlockEntity entity)) return false;
         return entity.getDisabled().get(index);
     }
-
     public void setSlotDisabled(int index, boolean state) {
         if (!(this.machine instanceof AutoCrafterBlockEntity entity)) return;
         entity.getDisabled().set(index, state);
+    }
+    @Override
+    public void slotsChanged(Container container) {
+        super.slotsChanged(container);
+        if (container == getMachine()) {
+            updateResult();
+        }
+    }
+    @Override
+    public CraftingContainer getMachine() {
+        return (CraftingContainer) super.getMachine();
+    }
+    public void updateResult() {
+        Level level = getInventory().player.level();
+        CraftingRecipe recipe = level.getRecipeManager().getRecipeFor(RecipeType.CRAFTING, getMachine(), level).orElse(null);
+        getResultSlot().set(recipe == null ? ItemStack.EMPTY : recipe.assemble(getMachine(), level.registryAccess()));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/BaseMachineMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/BaseMachineMenu.java
@@ -24,7 +24,7 @@ public abstract class BaseMachineMenu extends AbstractContainerMenu {
     @Override
     public @NotNull ItemStack quickMoveStack(Player player, int index) {
         ItemStack itemStack = ItemStack.EMPTY;
-        if (index >= this.machine.getContainerSize()) return itemStack;
+        if (index >= this.slots.size()) return itemStack;
         Slot slot = this.slots.get(index);
         if (!slot.hasItem()) return itemStack;
         ItemStack itemStack2 = slot.getItem();

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/ReadOnlySlot.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/ReadOnlySlot.java
@@ -1,0 +1,20 @@
+package dev.dubhe.anvilcraft.inventory;
+
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+public class ReadOnlySlot extends Slot {
+    public ReadOnlySlot(Container container, int slot, int x, int y) {
+        super(container, slot, x, y);
+    }
+    @Override
+    public boolean mayPlace(ItemStack stack) {
+        return false;
+    }
+    @Override
+    public boolean mayPickup(Player player) {
+        return false;
+    }
+}


### PR DESCRIPTION
修复：
- 不能从玩家快速移动物品到合成器
- 产物没有工具提示、数字深度错误