### PR TITLE
修复发射器使用空桶操作非流体方块导致栈溢出崩溃

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/mixin/DispenseItemEmptyBucketBehaviorMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/DispenseItemEmptyBucketBehaviorMixin.java
@@ -34,10 +34,7 @@ public abstract class DispenseItemEmptyBucketBehaviorMixin extends DefaultDispen
         ServerLevel level = source.getLevel();
         ServerLevel levelAccessor = source.getLevel();
         List<Cow> entities = level.getEntities(EntityTypeTest.forClass(Cow.class), new AABB(blockPos), Entity::isAlive).stream().toList();
-        if (entities.isEmpty()) {
-            cir.setReturnValue(super.dispense(source, stack));
-            return;
-        }
+        if (entities.isEmpty()) return;
         levelAccessor.gameEvent(null, GameEvent.FLUID_PICKUP, blockPos);
         Item item = Items.MILK_BUCKET;
         stack.shrink(1);

--- a/src/main/java/dev/dubhe/anvilcraft/util/IBucketPickupInjector.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/IBucketPickupInjector.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 public interface IBucketPickupInjector extends BucketPickup {
     @Override
     default @NotNull ItemStack pickupBlock(LevelAccessor level, BlockPos pos, @NotNull BlockState state) {
-        System.out.println(state);
         if (state.is(Blocks.LAVA_CAULDRON)) {
             level.setBlock(pos, Blocks.CAULDRON.defaultBlockState(), 3);
             return Items.LAVA_BUCKET.getDefaultInstance();


### PR DESCRIPTION
fixed #94 