### PR TITLE
修复合成器过滤与锁定

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/inventory/IFilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/inventory/IFilterScreen.java
@@ -78,7 +78,7 @@ public interface IFilterScreen {
             if (index >= 9) break logic;
             ItemStack itemStack = this.getFilter().get(index);
             if (itemStack.isEmpty()) {
-                if (getDisabled().get(index)) {
+                if (isRecord() && getDisabled().get(index)) {
                     guiGraphics.renderTooltip(getFont(), List.of(Component.translatable("screen.anvilcraft.button.record.tooltip")), Optional.empty(), x, y);
                 }
             } else {

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
@@ -143,9 +143,15 @@ public abstract class AutoCrafterMenu extends BaseMachineMenu implements IFilter
             super.setRecord(record);
             if (record) {
                 for (int i = 0; i < getBlockEntity().getFilter().size(); i++) {
-                    if (getSlot(i).getItem().isEmpty()) {
+                    ItemStack slotStack = getSlot(i).getItem();
+                    if (slotStack.isEmpty()) {
                         getBlockEntity().getDisabled().set(i, true);
                         new SlotDisableChangePack(i, true).send(getPlayer());
+                        getBlockEntity().setChanged();
+                    } else {
+                        getBlockEntity().getFilter().set(i, slotStack.copy());
+                        new SlotFilterChangePack(i, slotStack).send(getPlayer());
+                        getBlockEntity().setChanged();
                     }
                 }
             }


### PR DESCRIPTION
修复：
- 在非过滤模式下放入的物品在开启过滤模式后用自动合成消耗完毕后不会留下过滤物品。
- 锁定槽位在非过滤模式下仍显示工具提示。