### PR TITLE
修复通过除UI内点击按钮以外的方式改变自动合成器与溜槽的方块状态方向时，不能改变其方块实体输出物品的方向

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/AutoCrafterBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/AutoCrafterBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.block.entity;
 
 import dev.dubhe.anvilcraft.block.AutoCrafterBlock;
+import dev.dubhe.anvilcraft.block.ChuteBlock;
 import dev.dubhe.anvilcraft.init.ModBlockEntities;
 import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.inventory.AutoCrafterMenu;
@@ -44,7 +45,6 @@ public class AutoCrafterBlockEntity extends BaseMachineBlockEntity implements Cr
 
     public AutoCrafterBlockEntity(BlockPos pos, BlockState blockState) {
         super(ModBlockEntities.AUTO_CRAFTER, pos, blockState, 9);
-        this.direction = blockState.getValue(AutoCrafterBlock.FACING);
     }
 
     @Override
@@ -89,7 +89,7 @@ public class AutoCrafterBlockEntity extends BaseMachineBlockEntity implements Cr
         if (!itemStack.isItemEnabled(level.enabledFeatures())) return;
         Container result = new SimpleContainer(1);
         result.setItem(0, itemStack);
-        if (!entity.insertOrDropItem(entity.direction, level, entity.getBlockPos(), result, 0, false, true, false)) {
+        if (!entity.insertOrDropItem(entity.getDirection(), level, entity.getBlockPos(), result, 0, false, true, false)) {
             return;
         }
         for (int i = 0; i < 9; i++) {
@@ -102,7 +102,7 @@ public class AutoCrafterBlockEntity extends BaseMachineBlockEntity implements Cr
             container1.setItem(i, nonNullList.get(i));
         }
         for (int i = 0; i < nonNullList.size(); i++) {
-            entity.insertOrDropItem(entity.direction, level, entity.getBlockPos(), container1, i, true, true, false);
+            entity.insertOrDropItem(entity.getDirection(), level, entity.getBlockPos(), container1, i, true, true, false);
         }
         level.updateNeighborsAt(entity.getBlockPos(), ModBlocks.AUTO_CRAFTER);
     }
@@ -151,8 +151,15 @@ public class AutoCrafterBlockEntity extends BaseMachineBlockEntity implements Cr
     }
 
     @Override
+    public Direction getDirection() {
+        if (this.level == null) return Direction.UP;
+        BlockState state = this.level.getBlockState(this.getBlockPos());
+        if (state.is(ModBlocks.AUTO_CRAFTER)) return state.getValue(AutoCrafterBlock.FACING);
+        return Direction.UP;
+    }
+
+    @Override
     public void setDirection(Direction direction) {
-        super.setDirection(direction);
         BlockPos pos = this.getBlockPos();
         Level level = this.getLevel();
         if (null == level) return;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseMachineBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseMachineBlockEntity.java
@@ -1,7 +1,9 @@
 package dev.dubhe.anvilcraft.block.entity;
 
+import dev.dubhe.anvilcraft.block.AutoCrafterBlock;
+import dev.dubhe.anvilcraft.block.ChuteBlock;
+import dev.dubhe.anvilcraft.init.ModBlocks;
 import lombok.Getter;
-import lombok.Setter;
 import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
@@ -11,7 +13,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.StringTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -27,27 +28,28 @@ import org.jetbrains.annotations.NotNull;
 @Getter
 public abstract class BaseMachineBlockEntity extends RandomizableContainerBlockEntity {
     protected NonNullList<ItemStack> items;
-    @Setter
-    protected Direction direction = Direction.DOWN;
 
     protected BaseMachineBlockEntity(BlockEntityType<? extends BaseMachineBlockEntity> type, BlockPos pos, BlockState blockState, int size) {
         super(type, pos, blockState);
         items = NonNullList.withSize(size, ItemStack.EMPTY);
     }
 
+    public abstract Direction getDirection();
+
+    public abstract void setDirection(Direction direction);
+
     @Override
     public void load(CompoundTag tag) {
         super.load(tag);
         this.items = NonNullList.withSize(this.getContainerSize(), ItemStack.EMPTY);
         ContainerHelper.loadAllItems(tag, this.items);
-        this.direction = Direction.valueOf(tag.getString("direction").toUpperCase());
     }
 
     @Override
     protected void saveAdditional(CompoundTag tag) {
         super.saveAdditional(tag);
         ContainerHelper.saveAllItems(tag, this.items);
-        tag.put("direction", StringTag.valueOf(this.direction.getName().toLowerCase()));
+//        tag.put("direction", StringTag.valueOf(this.direction.getName().toLowerCase()));
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ChuteBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.block.entity;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.block.AutoCrafterBlock;
 import dev.dubhe.anvilcraft.block.ChuteBlock;
 import dev.dubhe.anvilcraft.init.ModBlockEntities;
 import dev.dubhe.anvilcraft.init.ModBlocks;
@@ -39,7 +40,6 @@ public class ChuteBlockEntity extends BaseMachineBlockEntity implements IFilterB
 
     public ChuteBlockEntity(BlockPos pos, BlockState blockState) {
         super(ModBlockEntities.CHUTE, pos, blockState, 9);
-        this.direction = blockState.getValue(ChuteBlock.FACING);
     }
 
     @Override
@@ -77,7 +77,7 @@ public class ChuteBlockEntity extends BaseMachineBlockEntity implements IFilterB
         for (int i = this.items.size() - 1; i >= 0; i--) {
             ItemStack stack = this.items.get(i);
             if (stack.isEmpty()) continue;
-            if (this.insertOrDropItem(this.direction, level, pos, this, i, false, false, true)) return;
+            if (this.insertOrDropItem(this.getDirection(), level, pos, this, i, false, false, true)) return;
         }
     }
 
@@ -156,9 +156,16 @@ public class ChuteBlockEntity extends BaseMachineBlockEntity implements IFilterB
     }
 
     @Override
+    public Direction getDirection() {
+        if (this.level == null) return Direction.UP;
+        BlockState state = this.level.getBlockState(this.getBlockPos());
+        if (state.is(ModBlocks.CHUTE)) return state.getValue(ChuteBlock.FACING);
+        return Direction.UP;
+    }
+
+    @Override
     public void setDirection(Direction direction) {
         if (direction == Direction.UP) return;
-        super.setDirection(direction);
         BlockPos pos = this.getBlockPos();
         Level level = this.getLevel();
         if (null == level) return;


### PR DESCRIPTION
fixed #111 