### PR TITLE
自动合成器物品闪烁修复

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
@@ -65,23 +65,7 @@ public abstract class AutoCrafterMenu extends BaseMachineMenu implements IFilter
         if (!slot.hasItem()) return itemStack;
         ItemStack itemStack2 = slot.getItem();
         itemStack = itemStack2.copy();
-
-        Boolean needMove;
-        if(index < this.machine.getContainerSize()){
-            needMove = !this.moveItemStackTo(itemStack2, this.machine.getContainerSize(), this.machine.getContainerSize() + 36, true);
-        }else{
-            needMove = false;
-            if (this.getMachine() instanceof AutoCrafterBlockEntity entity) {
-                for (int i = 0; i < this.machine.getContainerSize(); i++) {
-                    ItemStack filter = getFilter(i);
-                    NonNullList<Boolean> disableds = entity.getDisabled();
-                    if (filter.is(itemStack.getItem()) || !disableds.get(i)) {
-                        needMove = !this.moveItemStackTo(itemStack2, i, i + 1, false);
-                    }
-                }
-            }
-        }
-        if (needMove) {
+        if (this.quickMoveFilter(index,itemStack2)) {
             return ItemStack.EMPTY;
         }
         if (itemStack2.isEmpty()) slot.setByPlayer(ItemStack.EMPTY);
@@ -89,6 +73,24 @@ public abstract class AutoCrafterMenu extends BaseMachineMenu implements IFilter
         if (itemStack2.getCount() == itemStack.getCount()) return ItemStack.EMPTY;
         slot.onTake(player, itemStack2);
         return itemStack;
+    }
+
+    private boolean quickMoveFilter(int index,ItemStack itemStack){
+        if(index < this.machine.getContainerSize()){
+            return !this.moveItemStackTo(itemStack, this.machine.getContainerSize(), this.machine.getContainerSize() + 36, true);
+        }else{
+            boolean bl = false;
+            if (this.getMachine() instanceof IFilterBlockEntity entity) {
+                for (int i = 0; i < this.machine.getContainerSize(); i++) {
+                    ItemStack filter = getFilter(i);
+                    NonNullList<Boolean> disableds = entity.getDisabled();
+                    if (filter.is(itemStack.getItem()) || !disableds.get(i)) {
+                        bl = !this.moveItemStackTo(itemStack, i, i + 1, false);
+                    }
+                }
+            }
+            return bl;
+        }
     }
 
     public @Nullable IFilterBlockEntity getEntity() {

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
@@ -57,42 +57,6 @@ public abstract class AutoCrafterMenu extends BaseMachineMenu implements IFilter
         this.updateResult();
     }
 
-    @Override
-    public @NotNull ItemStack quickMoveStack(Player player, int index) {
-        ItemStack itemStack = ItemStack.EMPTY;
-        if (index >= this.slots.size()) return itemStack;
-        Slot slot = this.slots.get(index);
-        if (!slot.hasItem()) return itemStack;
-        ItemStack itemStack2 = slot.getItem();
-        itemStack = itemStack2.copy();
-        if (this.quickMoveFilter(index,itemStack2)) {
-            return ItemStack.EMPTY;
-        }
-        if (itemStack2.isEmpty()) slot.setByPlayer(ItemStack.EMPTY);
-        else slot.setChanged();
-        if (itemStack2.getCount() == itemStack.getCount()) return ItemStack.EMPTY;
-        slot.onTake(player, itemStack2);
-        return itemStack;
-    }
-
-    private boolean quickMoveFilter(int index,ItemStack itemStack){
-        if(index < this.machine.getContainerSize()){
-            return !this.moveItemStackTo(itemStack, this.machine.getContainerSize(), this.machine.getContainerSize() + 36, true);
-        }else{
-            boolean bl = false;
-            if (this.getMachine() instanceof IFilterBlockEntity entity) {
-                for (int i = 0; i < this.machine.getContainerSize(); i++) {
-                    ItemStack filter = getFilter(i);
-                    NonNullList<Boolean> disableds = entity.getDisabled();
-                    if (filter.is(itemStack.getItem()) || !disableds.get(i)) {
-                        bl = !this.moveItemStackTo(itemStack, i, i + 1, false);
-                    }
-                }
-            }
-            return bl;
-        }
-    }
-
     public @Nullable IFilterBlockEntity getEntity() {
         return this.machine instanceof IFilterBlockEntity entity ? entity : null;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/AutoCrafterMenu.java
@@ -56,6 +56,41 @@ public abstract class AutoCrafterMenu extends BaseMachineMenu implements IFilter
         }
         this.updateResult();
     }
+
+    @Override
+    public @NotNull ItemStack quickMoveStack(Player player, int index) {
+        ItemStack itemStack = ItemStack.EMPTY;
+        if (index >= this.slots.size()) return itemStack;
+        Slot slot = this.slots.get(index);
+        if (!slot.hasItem()) return itemStack;
+        ItemStack itemStack2 = slot.getItem();
+        itemStack = itemStack2.copy();
+
+        Boolean needMove;
+        if(index < this.machine.getContainerSize()){
+            needMove = !this.moveItemStackTo(itemStack2, this.machine.getContainerSize(), this.machine.getContainerSize() + 36, true);
+        }else{
+            needMove = false;
+            if (this.getMachine() instanceof AutoCrafterBlockEntity entity) {
+                for (int i = 0; i < this.machine.getContainerSize(); i++) {
+                    ItemStack filter = getFilter(i);
+                    NonNullList<Boolean> disableds = entity.getDisabled();
+                    if (filter.is(itemStack.getItem()) || !disableds.get(i)) {
+                        needMove = !this.moveItemStackTo(itemStack2, i, i + 1, false);
+                    }
+                }
+            }
+        }
+        if (needMove) {
+            return ItemStack.EMPTY;
+        }
+        if (itemStack2.isEmpty()) slot.setByPlayer(ItemStack.EMPTY);
+        else slot.setChanged();
+        if (itemStack2.getCount() == itemStack.getCount()) return ItemStack.EMPTY;
+        slot.onTake(player, itemStack2);
+        return itemStack;
+    }
+
     public @Nullable IFilterBlockEntity getEntity() {
         return this.machine instanceof IFilterBlockEntity entity ? entity : null;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/BaseMachineMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/BaseMachineMenu.java
@@ -1,8 +1,10 @@
 package dev.dubhe.anvilcraft.inventory;
 
 import dev.dubhe.anvilcraft.block.entity.BaseMachineBlockEntity;
+import dev.dubhe.anvilcraft.block.entity.IFilterBlockEntity;
 import lombok.Getter;
 import net.minecraft.core.Direction;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -29,11 +31,7 @@ public abstract class BaseMachineMenu extends AbstractContainerMenu {
         if (!slot.hasItem()) return itemStack;
         ItemStack itemStack2 = slot.getItem();
         itemStack = itemStack2.copy();
-        if (
-                index < this.machine.getContainerSize() ?
-                        !this.moveItemStackTo(itemStack2, this.machine.getContainerSize(), this.machine.getContainerSize() + 36, true) :
-                        !this.moveItemStackTo(itemStack2, 0, this.machine.getContainerSize(), false)
-        ) {
+        if (quickMoveFilter(index,itemStack2)) {
             return ItemStack.EMPTY;
         }
         if (itemStack2.isEmpty()) slot.setByPlayer(ItemStack.EMPTY);
@@ -41,6 +39,24 @@ public abstract class BaseMachineMenu extends AbstractContainerMenu {
         if (itemStack2.getCount() == itemStack.getCount()) return ItemStack.EMPTY;
         slot.onTake(player, itemStack2);
         return itemStack;
+    }
+
+    private boolean quickMoveFilter(int index,ItemStack itemStack){
+        if(index < this.machine.getContainerSize()){
+            return !this.moveItemStackTo(itemStack, this.machine.getContainerSize(), this.machine.getContainerSize() + 36, true);
+        }else{
+            boolean bl = false;
+            if (this.getMachine() instanceof IFilterBlockEntity entity) {
+                for (int i = 0; i < this.machine.getContainerSize(); i++) {
+                    ItemStack filter = entity.getFilter().get(i);
+                    NonNullList<Boolean> disableds = entity.getDisabled();
+                    if (filter.is(itemStack.getItem()) || !disableds.get(i)) {
+                        bl = !this.moveItemStackTo(itemStack, i, i + 1, false);
+                    }
+                }
+            }
+            return bl;
+        }
     }
 
     @Override


### PR DESCRIPTION
修复了 #110 中提到的合成器使用shift点击物品闪烁的问题，溜槽还没有改