### PR TITLE
数值调整

### DIFF
--- a/common/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -131,7 +131,8 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         }
         int removeCurseNumber = 0;
         Iterator<Enchantment> iterator = curseMap.keySet().iterator();
-        while ((goldNumber >= 3 && curseNumber > 0)) {
+        final int needGold = 16;
+        while (goldNumber >= needGold && curseNumber > 0 && goldUsed + needGold < 64) {
             Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(result);
             map.remove(iterator.next());
             ItemStack itemStack = result.copy();
@@ -140,7 +141,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
             EnchantmentHelper.setEnchantments(map, itemStack);
             result = itemStack.copy();
             curseNumber -= 1;
-            goldUsed += 3;
+            goldUsed += needGold;
             removeCurseNumber += 1;
         }
         if (result.is(Items.ENCHANTED_BOOK) && EnchantmentHelper.getEnchantments(result).isEmpty()) {
@@ -170,6 +171,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
                     this.getSlot(index).setByPlayer(ItemStack.EMPTY);
                 }
             } else {
+                ItemStack gold;
                 if (itemStack.isDamageableItem() || itemStack.is(Items.ENCHANTED_BOOK) || itemStack.isEnchanted()) {
                     if (!this.getSlot(0).hasItem()) {
                         this.getSlot(0).setByPlayer(itemStack);
@@ -181,6 +183,16 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
                     if (!this.getSlot(1).hasItem()) {
                         this.getSlot(1).setByPlayer(itemStack);
                         this.getSlot(index).setByPlayer(ItemStack.EMPTY);
+                    } else if (
+                        (gold = this.getSlot(1).getItem()).is(Items.GOLD_INGOT)
+                            && gold.getCount() < gold.getMaxStackSize()
+                    ) {
+                        int canSet = gold.getMaxStackSize() - gold.getCount();
+                        canSet = Math.min(itemStack.getCount(), canSet);
+                        gold.grow(canSet);
+                        itemStack.shrink(canSet);
+                        this.getSlot(1).setByPlayer(gold);
+                        this.getSlot(index).setByPlayer(itemStack);
                     } else {
                         return ItemStack.EMPTY;
                     }

--- a/common/src/main/java/dev/dubhe/anvilcraft/item/ModFoods.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/item/ModFoods.java
@@ -6,16 +6,15 @@ import net.minecraft.world.food.FoodProperties;
 
 public class ModFoods {
     public static final FoodProperties CHOCOLATE = new FoodProperties.Builder()
-        .nutrition(2).saturationMod(10.0f).alwaysEat().fast().build();
+        .nutrition(2).saturationMod(4.0f).alwaysEat().fast().build();
     public static final FoodProperties CHOCOLATE_BLACK = new FoodProperties.Builder()
         .nutrition(2).saturationMod(2.0f).alwaysEat().fast()
-        .effect(new MobEffectInstance(MobEffects.DIG_SPEED, 1200), 1.0f).build();
+        .effect(new MobEffectInstance(MobEffects.DIG_SPEED, 600, 1), 1.0f).build();
     public static final FoodProperties CHOCOLATE_WHITE = new FoodProperties.Builder()
         .nutrition(2).saturationMod(2.0f).alwaysEat().fast()
-        .effect(new MobEffectInstance(MobEffects.JUMP, 1200), 1.0f).build();
+        .effect(new MobEffectInstance(MobEffects.JUMP, 600, 1), 1.0f).build();
     public static final FoodProperties CREAMY_BREAD_ROLL = new FoodProperties.Builder()
         .nutrition(8).saturationMod(0.5f).build();
     public static final FoodProperties BEEF_MUSHROOM_STEW = new FoodProperties.Builder()
-        .nutrition(10).saturationMod(0.8f)
-        .effect(new MobEffectInstance(MobEffects.SATURATION, 100), 1.0f).build();
+        .nutrition(10).saturationMod(0.8f).build();
 }

--- a/common/src/main/java/dev/dubhe/anvilcraft/item/UtusanItem.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/item/UtusanItem.java
@@ -60,7 +60,7 @@ public class UtusanItem extends Item {
             bl = true;
         }
         if (!bl) {
-            livingEntity.addEffect(new MobEffectInstance(MobEffects.POISON, 200, 2));
+            livingEntity.addEffect(new MobEffectInstance(MobEffects.POISON, 600, 4));
             return;
         }
         for (MobEffect effect : effects) livingEntity.removeEffect(effect);

--- a/common/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -65,7 +65,7 @@ abstract class ItemEntityMixin extends Entity {
         if (itemStack.getCount() != 1) return;
         if (!this.anvilcraft$needMagnetization) return;
         this.anvilcraft$needMagnetization = false;
-        if (this.level().random.nextInt(100) <= 5) {
+        if (this.level().random.nextInt(100) <= 10) {
             this.setItem(new ItemStack(ModItems.MAGNET_INGOT));
         }
     }


### PR DESCRIPTION
resolved #357
1. 巧克力（普通巧克力）回复的饱和度（不是饱食度）改为16（8个金鸡腿）（当前版本写饱和度是写饱食度的倍率，所以倍率改为8）
2. 黑巧克力提供的效果改为急迫2（注意代码中0代表1级，1代表2级，所以写成1），时间改为30秒
3. 白巧克力提供的效果改为跳跃提升2，时间改为30秒
4. 牛肉炖蘑菇不再提供效果
5. 五毒散的中毒效果改为等级5，时间持续30秒
6. 在皇家砂轮上去除诅咒附魔时，每个诅咒附魔转化的金锭由3改为16
7. 向空心磁铁锭扔铁锭磁化的概率乘2