### PR TITLE
微调主动消音器ui，修复 #810 #795 #808

### DIFF
--- a/common/src/main/java/dev/dubhe/anvilcraft/block/OverseerBlock.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/block/OverseerBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block;
 
+import dev.dubhe.anvilcraft.api.IHasMultiBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.block.entity.OverseerBlockEntity;
 import dev.dubhe.anvilcraft.block.state.Half;
@@ -29,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 
-public class OverseerBlock extends BaseEntityBlock implements IHammerRemovable {
+public class OverseerBlock extends BaseEntityBlock implements IHammerRemovable, IHasMultiBlock {
 
     private static final VoxelShape OVERSEER_BASE = Shapes.or(
             Block.box(0, 0, 0, 16, 4, 16),
@@ -145,5 +146,15 @@ public class OverseerBlock extends BaseEntityBlock implements IHammerRemovable {
         if (state.getValue(HALF) != Half.BOTTOM) return null;
         return createTickerHelper(type, ModBlockEntities.OVERSEER.get(),
                 (level1, pos, state1, entity) -> entity.tick(level1, pos, state1));
+    }
+
+    @Override
+    public void onRemove(@NotNull Level level, @NotNull BlockPos pos, @NotNull BlockState state) {
+        OverseerBlock.destroyBlock(level, pos, state);
+    }
+
+    @Override
+    public void onPlace(@NotNull Level level, @NotNull BlockPos pos, @NotNull BlockState state) {
+
     }
 }

--- a/common/src/main/java/dev/dubhe/anvilcraft/client/gui/component/SilencerButton.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/client/gui/component/SilencerButton.java
@@ -46,6 +46,8 @@ public class SilencerButton extends Button {
 
     @Override
     public void renderWidget(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        ResourceLocation soundId = parent.getSoundIdAt(index, variant);
+        if (soundId == null) return;
         this.renderTexture(
                 guiGraphics,
                 texture,
@@ -62,8 +64,6 @@ public class SilencerButton extends Button {
         this.setMessage(parent.getSoundTextAt(index, variant));
         this.renderString(guiGraphics, Minecraft.getInstance().font, 16777215 | Mth.ceil(this.alpha * 255.0F) << 24);
         if (this.isHovered()) {
-            ResourceLocation soundId = parent.getSoundIdAt(index, variant);
-            if (soundId == null) return;
             guiGraphics.renderTooltip(
                     Minecraft.getInstance().font,
                     List.of(

--- a/common/src/main/java/dev/dubhe/anvilcraft/event/AnvilEventListener.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/event/AnvilEventListener.java
@@ -115,10 +115,10 @@ public class AnvilEventListener {
         if (!state.hasBlockEntity()) return;
         int honeyLevel = state.getValue(BeehiveBlock.HONEY_LEVEL);
         if (honeyLevel < BeehiveBlock.MAX_HONEY_LEVELS) return;
-        level.setBlockAndUpdate(pos, state.setValue(BeehiveBlock.HONEY_LEVEL, 0));
         BlockPos potPos = pos.below();
         BlockState pot = level.getBlockState(potPos);
         if (pot.is(Blocks.CAULDRON)) {
+            level.setBlockAndUpdate(pos, state.setValue(BeehiveBlock.HONEY_LEVEL, 0));
             level.setBlockAndUpdate(
                     potPos,
                     ModBlocks.HONEY_CAULDRON.getDefaultState()
@@ -131,6 +131,7 @@ public class AnvilEventListener {
         } else {
             if (pot.is(ModBlocks.HONEY_CAULDRON.get())) {
                 int cauldronHoneyLevel = pot.getValue(LayeredCauldronBlock.LEVEL);
+                level.setBlockAndUpdate(pos, state.setValue(BeehiveBlock.HONEY_LEVEL, 0));
                 if (cauldronHoneyLevel < LayeredCauldronBlock.MAX_FILL_LEVEL) {
                     level.setBlockAndUpdate(
                             potPos,

--- a/common/src/main/java/dev/dubhe/anvilcraft/event/PistonMoveBlockListener.java
+++ b/common/src/main/java/dev/dubhe/anvilcraft/event/PistonMoveBlockListener.java
@@ -33,7 +33,7 @@ public class PistonMoveBlockListener {
     public static void onPistonMoveBlocks(@NotNull Level level, @NotNull List<BlockPos> blocks) {
         for (BlockPos pos : blocks) {
             BlockState blockState = level.getBlockState(pos);
-            if (!blockState.is(ModBlocks.MAGNET_BLOCK.get())) continue;
+            if (!(blockState.getBlock() instanceof MagnetBlock)) continue;
             if (blockState.getValue(MagnetBlock.LIT)) continue;
             double n = getChargeNum(level, pos);
             if (n > 0) {


### PR DESCRIPTION
主动消音器ui 按钮滚动到没有对应的声音时不渲染
<img width="451" alt="312e7958cab6884e5258f9596eb64037" src="https://github.com/Anvil-Dev/AnvilCraft/assets/98583550/5de750b8-15fe-482a-b925-1ad14733cc7c">

fixed #810
fixed #795
fixed #808