### PR TITLE
Change icons of creative tabs 更改创造物品栏图标

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/init/ModItemGroups.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModItemGroups.java
@@ -20,7 +20,7 @@ public class ModItemGroups {
 
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_TOOL =
             DF.register("tools", () -> CreativeModeTab.builder()
-                    .icon(ModItems.MAGNET::asStack)
+                    .icon(ModItems.ANVIL_HAMMER::asStack)
                     .displayItems((ctx, entries) -> {})
                     .title(REGISTRATE.addLang("itemGroup", AnvilCraft.of("tools"), "AnvilCraft: Utilities"))
                     .withTabsAfter(
@@ -41,7 +41,7 @@ public class ModItemGroups {
 
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_FUNCTION_BLOCK =
             DF.register("functional_block", () -> CreativeModeTab.builder()
-                    .icon(ModBlocks.MAGNET_BLOCK::asStack)
+                    .icon(ModBlocks.ROYAL_ANVIL::asStack)
                     .displayItems((ctx, entries) -> {
                         entries.accept(Items.IRON_TRAPDOOR.getDefaultInstance());
                         entries.accept(Items.CAULDRON.getDefaultInstance());
@@ -60,7 +60,7 @@ public class ModItemGroups {
 
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_BUILD_BLOCK =
             DF.register("building_block", () -> CreativeModeTab.builder()
-                    .icon(ModBlocks.REINFORCED_CONCRETES.get(Color.BLACK)::asStack)
+                    .icon(ModBlocks.REINFORCED_CONCRETES.get(Color.WHITE)::asStack)
                     .displayItems((ctx, entries) -> {})
                     .title(REGISTRATE.addLang(
                             "itemGroup", AnvilCraft.of("building_block"), "AnvilCraft: Building Block"))


### PR DESCRIPTION
更改以下的物品栏图标，使其更有辨识度：

- ”铁砧工艺：工具与实用物品“：图标由手持磁铁改为铁砧锤
- ”铁砧工艺：功能方块“：图标由磁铁块改为皇家铁砧
- ”铁砧工艺：建筑方块“：图标由黑色钢筋混凝土改为白色钢筋混凝土