### PR TITLE
Fix cullface of several blocks and block entity of thermoelectric converter  添加方块剔除面，修复热电转换器方块实体

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/chargecollector/ThermoManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/chargecollector/ThermoManager.java
@@ -76,22 +76,12 @@ public class ThermoManager {
 
     ThermoManager(Level level) {
         this.level = level;
-        register(ThermoEntry.simple(
-            256,
-            ModBlocks.INCANDESCENT_NETHERITE.get(),
-            ModBlocks.GLOWING_NETHERITE.get(),
-            true
-        ));
+        register(ThermoEntry.simple(256, ModBlocks.INCANDESCENT_NETHERITE.get(), ModBlocks.GLOWING_NETHERITE.get(), true));
         register(ThermoEntry.simple(64, ModBlocks.GLOWING_NETHERITE.get(), ModBlocks.REDHOT_NETHERITE.get(), true));
         register(ThermoEntry.simple(16, ModBlocks.REDHOT_NETHERITE.get(), ModBlocks.HEATED_NETHERITE.get(), true));
         register(ThermoEntry.simple(4, ModBlocks.HEATED_NETHERITE.get(), Blocks.NETHERITE_BLOCK, true));
 
-        register(ThermoEntry.simple(
-            256,
-            ModBlocks.INCANDESCENT_TUNGSTEN.get(),
-            ModBlocks.GLOWING_TUNGSTEN.get(),
-            true
-        ));
+        register(ThermoEntry.simple(256, ModBlocks.INCANDESCENT_TUNGSTEN.get(), ModBlocks.GLOWING_TUNGSTEN.get(), true));
         register(ThermoEntry.simple(64, ModBlocks.GLOWING_TUNGSTEN.get(), ModBlocks.REDHOT_TUNGSTEN.get(), true));
         register(ThermoEntry.simple(16, ModBlocks.REDHOT_TUNGSTEN.get(), ModBlocks.HEATED_TUNGSTEN.get(), true));
         register(ThermoEntry.simple(4, ModBlocks.HEATED_TUNGSTEN.get(), ModBlocks.TUNGSTEN_BLOCK.get(), true));

--- a/src/main/java/dev/dubhe/anvilcraft/api/chargecollector/ThermoManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/chargecollector/ThermoManager.java
@@ -117,14 +117,15 @@ public class ThermoManager {
             BlockPos blockPos = block.pos;
             BlockState state = this.level.getBlockState(blockPos);
             Optional<ThermoEntry> optional =
-                thermoEntries.stream().filter(it -> it.accepts(state) > 0).findFirst();
+                    thermoEntries.stream().filter(it -> it.accepts(state) > 0).findFirst();
             if (optional.isPresent()) {
                 ThermoEntry entry = optional.get();
                 if (block.ttl % 2 == 0) {
                     charge(entry.accepts(state), blockPos);
                 }
-                if (entry.isCanIrritated()) {
-                    if (HeatedBlockRecorder.getInstance(level).requireLightLevel(blockPos, entry.getCharge() / 2)) {
+                if (entry.isCanIrritated() && (HeatedBlockRecorder.TRANSFORMS.get(state.getBlock())) != null) {
+                    int requiredLevel = HeatedBlockRecorder.TRANSFORMS.get(state.getBlock()).remainCurrentTier();
+                    if (HeatedBlockRecorder.getInstance(level).requireLightLevel(blockPos, requiredLevel)) {
                         if (block.ttl % 2 == 0) {
                             block.ttl = Mth.clamp(block.ttl - 1, 0, 2);
                         } else {

--- a/src/main/java/dev/dubhe/anvilcraft/block/RubyLaserBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/RubyLaserBlock.java
@@ -62,8 +62,8 @@ public class RubyLaserBlock extends BaseEntityBlock implements IHammerRemovable,
         this.registerDefaultState(this.stateDefinition
             .any()
             .setValue(FACING, Direction.DOWN)
-            .setValue(OVERLOAD, false)
-            .setValue(SWITCH, Switch.OFF));
+            .setValue(OVERLOAD, true)
+            .setValue(SWITCH, Switch.ON));
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/ThermoelectricConverterBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ThermoelectricConverterBlock.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public class ThermoelectricConverterBlock extends BaseEntityBlock implements IHammerRemovable {
-    public static final Direction[] DIRECTIONS = {Direction.SOUTH, Direction.NORTH, Direction.EAST, Direction.WEST};
+    public static final Direction[] DIRECTIONS = Direction.values();
 
     public ThermoelectricConverterBlock(Properties properties) {
         super(properties);
@@ -69,6 +69,7 @@ public class ThermoelectricConverterBlock extends BaseEntityBlock implements IHa
         BlockState newState,
         boolean movedByPiston) {
         Arrays.stream(DIRECTIONS).map(pos::relative).forEach(ThermoManager.getInstance(level)::removeThermalBlock);
+        super.onRemove(state, level, pos, newState, movedByPiston);
     }
 
     @Nullable

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ChargeCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ChargeCollectorBlockEntity.java
@@ -7,6 +7,8 @@ import dev.dubhe.anvilcraft.init.ModBlockEntities;
 
 import dev.dubhe.anvilcraft.network.ChargeCollectorIncomingChargePacket;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -74,11 +76,27 @@ public class ChargeCollectorBlockEntity extends BlockEntity implements IPowerPro
         return this.power;
     }
 
+    @Override
+    public void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
+        super.loadAdditional(tag, registries);
+        this.cooldownCount = tag.getInt("cooldownCount");
+        this.chargeCount = tag.getDouble("chargeCount");
+        this.power = tag.getInt("power");
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {
+        super.loadAdditional(tag, registries);
+        tag.putInt("cooldownCount", this.cooldownCount);
+        tag.putDouble("chargeCount", this.chargeCount);
+        tag.putInt("power", this.power);
+    }
+
     /**
      * 方块实体tick
      */
     public void tick() {
-        if (this.cooldownCount > 0) {
+        if (this.cooldownCount > 1) {
             this.cooldownCount -= 1;
             return;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemCollectorBlockEntity.java
@@ -120,6 +120,7 @@ public class ItemCollectorBlockEntity extends BlockEntity
         itemHandler.deserializeNBT(provider, tag.getCompound("Inventory"));
         cooldown.fromIndex(tag.getInt("Cooldown"));
         rangeRadius.fromIndex(tag.getInt("RangeRadius"));
+        cd = tag.getInt("cd");
     }
 
     @Override
@@ -128,6 +129,7 @@ public class ItemCollectorBlockEntity extends BlockEntity
         tag.put("Inventory", this.itemHandler.serializeNBT(provider));
         tag.putInt("Cooldown", cooldown.index());
         tag.putInt("RangeRadius", rangeRadius.index());
+        tag.putInt("cd", cd);
     }
 
     @Nullable

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemCollectorBlockEntity.java
@@ -74,7 +74,7 @@ public class ItemCollectorBlockEntity extends BlockEntity
         15,
         60
     );
-    private int cd = rangeRadius.get();
+    private int cd = cooldown.get();
 
     private final FilteredItemStackHandler itemHandler = new FilteredItemStackHandler(9) {
         @Override
@@ -156,7 +156,7 @@ public class ItemCollectorBlockEntity extends BlockEntity
         if (level == null || level.isClientSide) return;
         BlockState state = level.getBlockState(getBlockPos());
         if (state.hasProperty(ItemCollectorBlock.POWERED) && state.getValue(ItemCollectorBlock.POWERED)) return;
-        if (cd - 1 != 0) {
+        if (cd > 1) {
             cd--;
             return;
         }

--- a/src/main/resources/assets/anvilcraft/models/block/heliostats_base.json
+++ b/src/main/resources/assets/anvilcraft/models/block/heliostats_base.json
@@ -29,7 +29,7 @@
 				"south": {"uv": [0, 15, 4, 16], "texture": "#1"},
 				"west": {"uv": [0, 15, 4, 16], "texture": "#1"},
 				"up": {"uv": [0, 11, 4, 15], "texture": "#1"},
-				"down": {"uv": [0, 11, 4, 15], "texture": "#1"}
+				"down": {"uv": [0, 11, 4, 15], "texture": "#1", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/anvilcraft/models/block/sliding_rail.json
+++ b/src/main/resources/assets/anvilcraft/models/block/sliding_rail.json
@@ -20,7 +20,7 @@
 				"south": {"uv": [0, 10, 16, 16], "texture": "#0"},
 				"west": {"uv": [0, 10, 16, 16], "texture": "#2"},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#3"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#1"}
+				"down": {"uv": [0, 0, 16, 16], "texture": "#1", "cullface": "down"}
 			}
 		},
 		{

--- a/src/main/resources/assets/anvilcraft/models/block/sliding_rail_stop.json
+++ b/src/main/resources/assets/anvilcraft/models/block/sliding_rail_stop.json
@@ -18,7 +18,7 @@
 				"south": {"uv": [0, 10, 16, 16], "texture": "#1"},
 				"west": {"uv": [0, 10, 16, 16], "texture": "#1"},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#2"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#0"}
+				"down": {"uv": [0, 0, 16, 16], "texture": "#0", "cullface": "down"}
 			}
 		},
 		{


### PR DESCRIPTION
- 为一些方块添加了底面的cullface，优化渲染。
- 修复了热电转换器的方块实体在方块被破坏后未移除的问题。 (Fix #1184)
- 调整了部分代码的排版，使其排版方式更加一致。
- 修复了集电器的工作周期和物品收集器的冷却初始化。
- 为集电器增加了数据序列化，增加了物品收集器的剩余冷却时间的序列化。
- 修复了激光器的默认方块状态（默认`OVERLOAD`为`true`， 避免激光器刚放置时，不需要供电也能短暂地射出一段时间的激光）
- 重构了定日镜加热方块的代码逻辑，使得查找加热后方块状态的代码更加简洁。
- 修复了对定日镜数量要求的修改，未同步到`ThermoManager`类中的问题。(Fix #1187)