### PR TITLE
Fix search menu of Tesla Tower 修复特斯拉塔搜索界面

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/component/TeslaTowerButton.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/component/TeslaTowerButton.java
@@ -93,7 +93,7 @@ public class TeslaTowerButton extends Button {
         ChatFormatting originalFormatting
     ) {
         try {
-            String[] parts = original.split(Pattern.quote(hightlighted));
+            String[] parts = original.split(Pattern.quote(hightlighted), -1);
             List<Component> components = new ArrayList<>();
             for (String s : parts) {
                 components.add(Component.literal(s).copy().setStyle(Style.EMPTY.applyFormat(originalFormatting)));

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/TeslaTowerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/TeslaTowerScreen.java
@@ -77,7 +77,7 @@ public class TeslaTowerScreen extends AbstractContainerScreen<TeslaTowerMenu> {
             String search = text.replaceFirst("#", "");
             allFilter.stream()
                     .filter(it -> it.right().contains(search))
-                    .filter(it -> whiteFilters.stream().anyMatch(it2 -> it.left().getId().equals(it2.left().getId()) && it.right().equals(it2.right())))
+                    .filter(it -> whiteFilters.stream().noneMatch(it2 -> it.left().getId().equals(it2.left().getId()) && it.right().equals(it2.right())))
                     .forEach(filteredFilters::add);
         } else {
             if (text.startsWith("~")) {
@@ -85,7 +85,6 @@ public class TeslaTowerScreen extends AbstractContainerScreen<TeslaTowerMenu> {
                     Pattern search = Pattern.compile(text.replaceFirst("~", ""));
                     allFilter.stream()
                             .filter(it -> search.matcher(it.left().getId()).matches())
-                            .filter(it -> whiteFilters.stream().anyMatch(it2 -> it.left().getId().equals(it2.left().getId()) && it.right().equals(it2.right())))
                             .forEach(filteredFilters::add);
                 } catch (Exception ignored) {
                     // intentionally empty
@@ -94,7 +93,7 @@ public class TeslaTowerScreen extends AbstractContainerScreen<TeslaTowerMenu> {
             allFilter.stream()
                     .filter(it -> it.left().title().getString().contains(filterText))
                     .filter(it ->
-                            whiteFilters.stream().noneMatch(it1 -> it1.left().equals(it.first())))
+                            whiteFilters.stream().noneMatch(it2 -> it.left().getId().equals(it2.left().getId()) && it.right().equals(it2.right())))
                     .forEach(filteredFilters::add);
         }
     }


### PR DESCRIPTION
- 通过调用`String.split(regex, -1)`在分割字符串时保留末尾空串，解决搜索时位于字符串末尾的匹配子串不显示的问题。
- 修复`anyMatch`为`noneMatch`，解决`#`或`~`开头的特殊搜索不可用的问题。