### PR TITLE
Fix sound of Anvil Hammer rocket jump 修复铁砧锤火箭跳声音问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/hammer/HammerRotateBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/hammer/HammerRotateBehavior.java
@@ -78,14 +78,10 @@ public interface HammerRotateBehavior extends IHammerChangeable {
     default Property<?> getChangeableProperty(BlockState state){
         if (state.hasProperty(FACING)) {
             return FACING;
-        } else {
-            if (state.hasProperty(FACING_HOPPER)) {
-                return FACING_HOPPER;
-            } else {
-                if (state.hasProperty(HORIZONTAL_FACING)) {
-                    return HORIZONTAL_FACING;
-                }
-            }
+        } else if (state.hasProperty(FACING_HOPPER)) {
+            return FACING_HOPPER;
+        } else if (state.hasProperty(HORIZONTAL_FACING)) {
+            return HORIZONTAL_FACING;
         }
         return null;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/AnvilHammerItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/AnvilHammerItem.java
@@ -121,14 +121,10 @@ public class AnvilHammerItem extends Item implements Equipable, IEngineerGoggles
         }
         if (state.hasProperty(FACING)) {
             return FACING;
-        } else {
-            if (state.hasProperty(FACING_HOPPER)) {
-                return FACING_HOPPER;
-            } else {
-                if (state.hasProperty(HORIZONTAL_FACING)) {
-                    return HORIZONTAL_FACING;
-                }
-            }
+        } else if (state.hasProperty(FACING_HOPPER)) {
+            return FACING_HOPPER;
+        } else if (state.hasProperty(HORIZONTAL_FACING)) {
+            return HORIZONTAL_FACING;
         }
         return null;
     }
@@ -186,7 +182,7 @@ public class AnvilHammerItem extends Item implements Equipable, IEngineerGoggles
                 0.5,
                 0,
                 0.05);
-            level.playSound(null, blockPos, SoundEvents.FIREWORK_ROCKET_LAUNCH, SoundSource.PLAYERS);
+            level.playSound(null, blockPos, SoundEvents.FIREWORK_ROCKET_LAUNCH, SoundSource.AMBIENT, 3.0f, 1.0f);
             return true;
         }
         return false;


### PR DESCRIPTION
- 此前版本中，使用飞行时间3的烟花火箭进行铁砧锤的火箭跳时，会出现声音播放不完整的问题（体感为声音半路被突然掐断），这是由于玩家在声音播放中途距离声音源位置过远。仿照原版烟花火箭代码设定`volume = 3` 可加大声音播放范围，从而解决这个问题。
- 调整火箭跳声音类型为`SoundSource.AMBIENT`，与原版烟花火箭同步。
- 调整了一些代码的排版，消除不必要的代码嵌套。