### PR TITLE
Fix hitbox and rendering of spectral anvil 修复幻灵铁砧的碰撞箱与渲染问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
@@ -44,9 +44,9 @@ public class SpectralAnvilBlock extends TransparentBlock implements IHammerRemov
     public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
     private static final Component CONTAINER_TITLE = Component.translatable("container.repair");
     private static final VoxelShape BASE = Block.box(2.0, 0.0, 2.0, 14.0, 4.0, 14.0);
-    private static final VoxelShape X_LEG1 = Block.box(3.0, 4.0, 4.0, 13.0, 5.0, 12.0);
+    private static final VoxelShape X_LEG1 = Block.box(4.0, 4.0, 5.0, 12.0, 10.0, 11.0);
     private static final VoxelShape X_TOP = Block.box(0.0, 10.0, 3.0, 16.0, 16.0, 13.0);
-    private static final VoxelShape Z_LEG1 = Block.box(4.0, 4.0, 3.0, 12.0, 5.0, 13.0);
+    private static final VoxelShape Z_LEG1 = Block.box(5.0, 4.0, 4.0, 11.0, 10.0, 12.0);
     private static final VoxelShape Z_TOP = Block.box(3.0, 10.0, 0.0, 13.0, 16.0, 16.0);
     private static final VoxelShape X_AXIS_AABB = Shapes.or(BASE, X_LEG1, X_TOP);
     private static final VoxelShape Z_AXIS_AABB = Shapes.or(BASE, Z_LEG1, Z_TOP);

--- a/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.TransparentBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -39,7 +38,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class SpectralAnvilBlock extends TransparentBlock implements IHammerRemovable {
+public class SpectralAnvilBlock extends Block implements IHammerRemovable {
     public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
     public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
     private static final Component CONTAINER_TITLE = Component.translatable("container.repair");
@@ -64,6 +63,11 @@ public class SpectralAnvilBlock extends TransparentBlock implements IHammerRemov
     public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         Direction direction = state.getValue(FACING);
         return direction.getAxis() == Direction.Axis.X ? X_AXIS_AABB : Z_AXIS_AABB;
+    }
+
+    @Override
+    protected VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return Shapes.empty();
     }
 
     @Override


### PR DESCRIPTION
- 修复了幻灵铁砧的碰撞箱与视觉体积不一致的问题。
  - fixed #1281 
- 由于原版的`HalfTransparentBlock`类重写的`skipRendering`方法会在相邻方块是同一方块时不渲染相邻面，该类不适合被不完整的透明方块继承。修改`SpectralAnvilBlock`基类后，修复了幻灵铁砧渲染时剔除面错误的问题。
  - fixed #1282 