### PR TITLE
[Hotfix] Tesla Tower crash the game and implement cross sliding rail [热修] 修复特斯拉塔使游戏崩溃的问题，实装十字形滑轨

### DIFF
--- a/src/generated/resources/assets/anvilcraft/blockstates/sliding_rail.json
+++ b/src/generated/resources/assets/anvilcraft/blockstates/sliding_rail.json
@@ -5,7 +5,7 @@
       "y": 90
     },
     "axis=y": {
-      "model": "anvilcraft:block/sliding_rail"
+      "model": "anvilcraft:block/sliding_rail_cross"
     },
     "axis=z": {
       "model": "anvilcraft:block/sliding_rail"

--- a/src/main/java/dev/dubhe/anvilcraft/block/SlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SlidingRailBlock.java
@@ -63,6 +63,14 @@ public class SlidingRailBlock extends Block implements IHammerChangeable, IHamme
             Block.box(0, 12, 0, 5, 16, 16),
             Block.box(11, 6, 0, 14, 12, 16)
         ).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+    public static final VoxelShape AABB_Y =
+        Stream.of(
+            Block.box(0, 0, 0, 16, 6, 16),
+            Block.box(11, 6, 11, 16, 16, 16),
+            Block.box(0, 6, 11, 5, 16, 16),
+            Block.box(0, 6, 0, 5, 16, 5),
+            Block.box(11, 6, 0, 16, 16, 5)
+        ).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
     public static final EnumProperty<Direction.Axis> AXIS = BlockStateProperties.AXIS;
     public static final HashMap<BlockPos, PistonPushInfo> MOVING_PISTON_MAP = new HashMap<>();
 
@@ -99,8 +107,9 @@ public class SlidingRailBlock extends Block implements IHammerChangeable, IHamme
             case X:
                 yield AABB_X;
             case Z:
-            default:
                 yield AABB_Z;
+            case Y:
+                yield AABB_Y;
         };
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
@@ -157,17 +157,17 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
 
         if (!(level instanceof ServerLevel serverLevel)) return;
         updateLaserLevel(calculateLaserLevel());
-        AABB trackBoundingBox = new AABB(
-            getBlockPos()
-                .relative(direction)
-                .getCenter()
-                .add(-0.0625, -0.0625, -0.0625),
-            irradiateBlockPos.relative(direction.getOpposite())
-                .getCenter()
-                .add(0.0625, 0.0625, 0.0625)
-        );
         int hurt = Math.min(16, laserLevel - 4);
         if (hurt > 0) {
+            AABB trackBoundingBox = new AABB(
+                getBlockPos()
+                    .relative(direction)
+                    .getCenter()
+                    .add(-0.0625, -0.0625, -0.0625),
+                irradiateBlockPos.relative(direction.getOpposite())
+                    .getCenter()
+                    .add(0.0625, 0.0625, 0.0625)
+            );
             level.getEntities(
                 EntityTypeTest.forClass(LivingEntity.class),
                 trackBoundingBox,
@@ -180,16 +180,16 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
             );
         }
         BlockState irradiateBlock = level.getBlockState(irradiateBlockPos);
-        List<ItemStack> drops = Block.getDrops(
-            irradiateBlock,
-            serverLevel,
-            irradiateBlockPos,
-            level.getBlockEntity(irradiateBlockPos)
-        );
         int cooldown = COOLDOWNS[Math.clamp(laserLevel / 4, 0, 4)];
         if (tickCount >= cooldown) {
             tickCount = 0;
             if (irradiateBlock.is(Tags.Blocks.ORES)) {
+                List<ItemStack> drops = Block.getDrops(
+                    irradiateBlock,
+                    serverLevel,
+                    irradiateBlockPos,
+                    level.getBlockEntity(irradiateBlockPos)
+                );
                 Vec3 blockPos = getBlockPos().relative(direction.getOpposite()).getCenter();
                 IItemHandler cap = getLevel()
                     .getCapability(
@@ -216,16 +216,12 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
                 });
                 if (irradiateBlock.is(Blocks.ANCIENT_DEBRIS)) {
                     level.setBlockAndUpdate(irradiateBlockPos, Blocks.NETHERRACK.defaultBlockState());
+                } else if (irradiateBlock.is(Tags.Blocks.ORES_IN_GROUND_DEEPSLATE)) {
+                    level.setBlockAndUpdate(irradiateBlockPos, Blocks.DEEPSLATE.defaultBlockState());
+                } else if (irradiateBlock.is(Tags.Blocks.ORES_IN_GROUND_NETHERRACK)) {
+                    level.setBlockAndUpdate(irradiateBlockPos, Blocks.NETHERRACK.defaultBlockState());
                 } else {
-                    if (irradiateBlock.is(Tags.Blocks.ORES_IN_GROUND_DEEPSLATE))
-                        level.setBlockAndUpdate(irradiateBlockPos, Blocks.DEEPSLATE.defaultBlockState());
-                    else {
-                        if (irradiateBlock.is(Tags.Blocks.ORES_IN_GROUND_NETHERRACK)) {
-                            level.setBlockAndUpdate(irradiateBlockPos, Blocks.NETHERRACK.defaultBlockState());
-                        } else {
-                            level.setBlockAndUpdate(irradiateBlockPos, Blocks.STONE.defaultBlockState());
-                        }
-                    }
+                    level.setBlockAndUpdate(irradiateBlockPos, Blocks.STONE.defaultBlockState());
                 }
                 /* else {
                     if (level.getBlockState(irradiateBlockPos).getBlock().defaultDestroyTime() >= 0

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/TeslaTowerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/TeslaTowerBlockEntity.java
@@ -98,7 +98,7 @@ public class TeslaTowerBlockEntity extends BlockEntity
         if (!this.getBlockState().is(ModBlocks.TESLA_TOWER.get())) return PowerComponentType.INVALID;
         if (this.getBlockState().getValue(TeslaTowerBlock.HALF) != Vertical4PartHalf.BOTTOM)
             return PowerComponentType.INVALID;
-        return PowerComponentType.TRANSMITTER;
+        return PowerComponentType.CONSUMER;
     }
                                  
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/BlockCompressRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/BlockCompressRecipeLoader.java
@@ -44,6 +44,11 @@ public class BlockCompressRecipeLoader {
             .input(Blocks.DIRT)
             .result(Blocks.MYCELIUM)
             .save(provider);
+        BlockCompressRecipe.builder()
+            .input(ModBlocks.VOID_MATTER_BLOCK.get())
+            .input(ModBlocks.SUPERCRITICAL_NESTING_SHULKER_BOX.get())
+            .result(ModBlocks.SPACE_OVERCOMPRESSOR.get())
+            .save(provider);
     }
 
     private static void blockCompress(RegistrateRecipeProvider provider, Block block1, Block block2, Block result) {

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModBlocks.java
@@ -1335,7 +1335,9 @@ public class ModBlocks {
                         .modelFile(DangerUtil.genModModelFile("block/sliding_rail").get())
                         .rotationY(90)
                         .buildLast()};
-                case Z, Y -> DangerUtil.genConfiguredModel("block/sliding_rail")
+                case Z -> DangerUtil.genConfiguredModel("block/sliding_rail")
+                    .get();
+                case Y -> DangerUtil.genConfiguredModel("block/sliding_rail_cross")
                     .get();
             });
         })


### PR DESCRIPTION
- 修复了特斯拉塔导致游戏崩溃的问题。
    - 在最新构建版本中，由于`TeslaTowerBlockEntity`没有实现`IPowerTransmitter`接口，但是在`getComponentType()`方法中返回了`PowerComponentType.TRANSMITTER`电网元件类型，这导致加载包含特斯拉塔的存档会引发CCE(`ClassCastException`)。
- 调整了`BaseLaserBlockEntity`的部分代码排版。
- 实装了十字形滑轨，现在可以在游戏中使用铁砧锤将滑轨调整为十字形（对应方块状态`[axis=y]`)。