### PR TITLE
修改幻灵铁砧特性

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
+++ b/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
@@ -34,7 +34,6 @@ import net.minecraft.server.packs.repository.PackSource;
 import net.minecraft.util.Unit;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.common.NeoForge;
@@ -65,9 +64,8 @@ public class AnvilCraft {
         .getConfig();
 
     public static final Registrate REGISTRATE = Registrate.create(MOD_ID);
-    private final Logger logger = LoggerFactory.getLogger("AnvilCraft");
 
-    public AnvilCraft(IEventBus modEventBus, ModContainer container) {
+    public AnvilCraft(IEventBus modEventBus) {
         ModItemGroups.register(modEventBus);
         ModBlocks.register();
         ModFluids.register(modEventBus);
@@ -90,11 +88,11 @@ public class AnvilCraft {
         AnvilCraftDatagen.init();
 
         registerEvents(modEventBus);
-        logger.info("Ciallo～(∠・ω< )⌒★");
-        logger.info("let's 0721!");
+        LOGGER.info("Ciallo～(∠・ω< )⌒★");
+        LOGGER.info("let's 0721!");
     }
 
-    private static void registerEvents(IEventBus eventBus) {
+    private static void registerEvents(@NotNull IEventBus eventBus) {
         NeoForge.EVENT_BUS.addListener(AnvilCraft::registerCommand);
         NeoForge.EVENT_BUS.addListener(AnvilCraft::addReloadListeners);
         NeoForge.EVENT_BUS.addListener(AnvilCraft::addItemTooltips);
@@ -112,16 +110,16 @@ public class AnvilCraft {
         ModCommands.register(event.getDispatcher());
     }
 
-    public static void registerPayload(RegisterPayloadHandlersEvent event) {
+    public static void registerPayload(@NotNull RegisterPayloadHandlersEvent event) {
         PayloadRegistrar registrar = event.registrar("1");
         ModNetworks.init(registrar);
     }
 
-    public static void addItemTooltips(ItemTooltipEvent event) {
+    public static void addItemTooltips(@NotNull ItemTooltipEvent event) {
         ItemTooltipManager.addTooltip(event.getItemStack(), event.getToolTip());
     }
 
-    public static void addReloadListeners(AddReloadListenerEvent event) {
+    public static void addReloadListeners(@NotNull AddReloadListenerEvent event) {
         RecipeManager recipeManager = event.getServerResources().getRecipeManager();
         event.addListener(
             (
@@ -136,7 +134,7 @@ public class AnvilCraft {
         );
     }
 
-    public static void loadComplete(FMLLoadCompleteEvent event) {
+    public static void loadComplete(@NotNull FMLLoadCompleteEvent event) {
         event.enqueueWork(() -> {
             ModInteractionMap.initInteractionMap();
             if (Util.isLoaded("theoneprobe")) {
@@ -146,7 +144,7 @@ public class AnvilCraft {
         });
     }
 
-    public static void packSetup(AddPackFindersEvent event) {
+    public static void packSetup(@NotNull AddPackFindersEvent event) {
         event.addPackFinders(
             of("resourcepacks/transparent_cauldron"),
             PackType.CLIENT_RESOURCES,

--- a/src/main/java/dev/dubhe/anvilcraft/block/MagnetBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/MagnetBlock.java
@@ -81,7 +81,7 @@ public class MagnetBlock extends Block implements IHammerRemovable {
             if (bl) {
                 level.scheduleTick(pos, this, 4);
             } else {
-                level.setBlock(pos, state.cycle(LIT), 2);
+                level.setBlockAndUpdate(pos, state.cycle(LIT));
             }
         }
     }
@@ -156,7 +156,7 @@ public class MagnetBlock extends Block implements IHammerRemovable {
         BlockPos pos,
         RandomSource random) {
         if (state.getValue(LIT) && !level.hasNeighborSignal(pos)) {
-            level.setBlock(pos, state.cycle(LIT), 2);
+            level.setBlockAndUpdate(pos, state.cycle(LIT));
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.block;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.entity.FallingSpectralBlockEntity;
 
+import dev.dubhe.anvilcraft.util.MagnetUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -56,7 +57,8 @@ public class SpectralAnvilBlock extends Block implements IHammerRemovable {
     public SpectralAnvilBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(
-            this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(POWERED, false));
+            this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(POWERED, false)
+        );
     }
 
     @Override
@@ -141,13 +143,13 @@ public class SpectralAnvilBlock extends Block implements IHammerRemovable {
         BlockPos neighborPos,
         boolean movedByPiston
     ) {
-        boolean hasNeighborSignal = level.hasNeighborSignal(pos);
+        boolean hasNeighborSignal = MagnetUtil.hasMagnetism(level, pos);
         boolean currentPowered = state.getValue(POWERED);
         if (hasNeighborSignal && !currentPowered) {
-            level.scheduleTick(pos, this, 4);
-            level.setBlock(pos, state.setValue(POWERED, Boolean.TRUE), 2);
+            level.setBlockAndUpdate(pos, state.setValue(POWERED, true));
         } else if (!hasNeighborSignal && currentPowered) {
-            level.setBlock(pos, state.setValue(POWERED, Boolean.FALSE), 2);
+            level.scheduleTick(pos, this, 4);
+            level.setBlockAndUpdate(pos, state.setValue(POWERED, false));
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
@@ -148,8 +148,7 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
         if (dist < 0) {
             return false;
         }
-        Predicate<Entity> predicate =
-            EntitySelector.NO_CREATIVE_OR_SPECTATOR.and(EntitySelector.LIVING_ENTITY_STILL_ALIVE);
+        Predicate<Entity> predicate = EntitySelector.NO_CREATIVE_OR_SPECTATOR.and(EntitySelector.LIVING_ENTITY_STILL_ALIVE);
         float f = (float) Math.min(Mth.floor((float) dist * 2), 40);
         this.level().getEntities(this, this.getBoundingBox(), predicate).forEach(entity -> entity.hurt(source, f));
         boolean isAnvil = this.blockState.is(BlockTags.ANVIL);
@@ -177,8 +176,9 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
     /**
      * 落下幻灵实体
      */
-    public static FallingSpectralBlockEntity fall(
-        Level level, BlockPos pos, BlockState blockState, boolean updateBlock, boolean isGhostEntity) {
+    public static @NotNull FallingSpectralBlockEntity fall(
+        Level level, BlockPos pos, BlockState blockState, boolean updateBlock, boolean isGhostEntity
+    ) {
         FallingSpectralBlockEntity fallingBlockEntity = new FallingSpectralBlockEntity(
             level,
             (double) pos.getX() + 0.5,

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EndPortalBlock;
 import net.minecraft.world.level.block.Portal;
 import net.minecraft.world.level.block.state.BlockState;
@@ -20,21 +21,36 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(EndPortalBlock.class)
 abstract class EndPortalBlockMixin {
     @Inject(
-            method = "entityInside",
-            at =
-                    @At(
-                            value = "INVOKE",
-                            target =
-                                    "Lnet/minecraft/world/entity/Entity;setAsInsidePortal(Lnet/minecraft/world/level/block/Portal;Lnet/minecraft/core/BlockPos;)V"),
-            cancellable = true)
+        method = "entityInside",
+        at =
+        @At(
+            value = "INVOKE",
+            target =
+                "Lnet/minecraft/world/entity/Entity;setAsInsidePortal(Lnet/minecraft/world/level/block/Portal;Lnet/minecraft/core/BlockPos;)V"),
+        cancellable = true)
     private void fallBlockEntityInside(
-            BlockState pState, Level pLevel, BlockPos pPos, Entity pEntity, CallbackInfo ci) {
+        BlockState pState, Level pLevel, BlockPos pPos, Entity pEntity, CallbackInfo ci) {
         if (pEntity instanceof FallingBlockEntity fallingBlockEntity
-                && !fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)) {
+            && !fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)) {
+            fallingBlockEntity.blockState = ModBlocks.END_DUST.getDefaultState();
+            anvil:
             if (fallingBlockEntity.blockState.is(BlockTags.ANVIL)) {
+                double rand = pLevel.random.nextDouble();
+                if (fallingBlockEntity.blockState.is(Blocks.DAMAGED_ANVIL) && rand >= 0.01) {
+                    break anvil;
+                } else if (fallingBlockEntity.blockState.is(Blocks.CHIPPED_ANVIL) && rand >= 0.02) {
+                    break anvil;
+                } else if (fallingBlockEntity.blockState.is(Blocks.ANVIL) && rand >= 0.03) {
+                    break anvil;
+                } else if (fallingBlockEntity.blockState.is(ModBlocks.ROYAL_ANVIL) && rand >= 0.5) {
+                    break anvil;
+                } else if (fallingBlockEntity.blockState.is(ModBlocks.EMBER_ANVIL)) {
+                    fallingBlockEntity.blockState = ModBlocks.SPECTRAL_ANVIL.getDefaultState();
+                    break anvil;
+                } else if (rand >= 0.03) {
+                    break anvil;
+                }
                 fallingBlockEntity.blockState = ModBlocks.SPECTRAL_ANVIL.getDefaultState();
-            } else {
-                fallingBlockEntity.blockState = ModBlocks.END_DUST.getDefaultState();
             }
             fallingBlockEntity.setAsInsidePortal((Portal) this, pPos);
             ci.cancel();

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/HopperBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/HopperBlockMixin.java
@@ -17,17 +17,19 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(HopperBlock.class)
-public class HopperBlockMixin implements IHammerChangeable {
+abstract class HopperBlockMixin implements IHammerChangeable {
     @Shadow
     @Final
     public static DirectionProperty FACING;
 
     @Override
+    @SuppressWarnings("AddedMixinMembersNamePattern")
     public boolean change(Player player, BlockPos blockPos, @NotNull Level level, ItemStack anvilHammer) {
         return level.setBlockAndUpdate(blockPos, level.getBlockState(blockPos).cycle(FACING));
     }
 
     @Override
+    @SuppressWarnings("AddedMixinMembersNamePattern")
     public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
         return FACING;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/compat/EmbChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/compat/EmbChunkBuilderMeshingTaskMixin.java
@@ -9,11 +9,12 @@ import org.embeddedt.embeddium.api.render.chunk.BlockRenderContext;
 import org.embeddedt.embeddium.impl.render.chunk.compile.ChunkBuildBuffers;
 import org.embeddedt.embeddium.impl.render.chunk.compile.pipeline.BlockRenderer;
 import org.embeddedt.embeddium.impl.render.chunk.compile.tasks.ChunkBuilderMeshingTask;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ChunkBuilderMeshingTask.class)
-public class EmbChunkBuilderMeshingTaskMixin {
+abstract class EmbChunkBuilderMeshingTaskMixin {
     @WrapOperation(
         method = "execute(Lorg/embeddedt/embeddium/impl/render/chunk/compile/ChunkBuildContext;Lorg/embeddedt/embeddium/impl/util/task/CancellationToken;)Lorg/embeddedt/embeddium/impl/render/chunk/compile/ChunkBuildOutput;",
         at = @At(
@@ -23,7 +24,7 @@ public class EmbChunkBuilderMeshingTaskMixin {
     )
     void skipBlock(
         BlockRenderer instance,
-        BlockRenderContext context,
+        @NotNull BlockRenderContext context,
         ChunkBuildBuffers consumer,
         Operation<Void> original
     ) {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/compat/SodiumChunkBuilderMeshingTaskMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/compat/SodiumChunkBuilderMeshingTaskMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(ChunkBuilderMeshingTask.class)
-public class SodiumChunkBuilderMeshingTaskMixin {
+abstract class SodiumChunkBuilderMeshingTaskMixin {
     @WrapOperation(
         method = "execute(Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildContext;Lnet/caffeinemc/mods/sodium/client/util/task/CancellationToken;)Lnet/caffeinemc/mods/sodium/client/render/chunk/compile/ChunkBuildOutput;",
         at = @At(

--- a/src/main/java/dev/dubhe/anvilcraft/util/MagnetUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/MagnetUtil.java
@@ -1,0 +1,17 @@
+package dev.dubhe.anvilcraft.util;
+
+import dev.dubhe.anvilcraft.block.MagnetBlock;
+import dev.dubhe.anvilcraft.init.ModBlockTags;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class MagnetUtil {
+    public static boolean hasMagnetism(@NotNull Level level, @NotNull BlockPos pos) {
+        BlockState state = level.getBlockState(pos.above());
+        return (state.is(ModBlockTags.MAGNET) || state.getBlock() instanceof MagnetBlock)
+            && state.hasProperty(MagnetBlock.LIT)
+            && !state.getValue(MagnetBlock.LIT);
+    }
+}


### PR DESCRIPTION
- 幻灵铁砧不再接受红石信号，当其上方的磁铁块（包括空心磁铁块、铁芯磁铁块）消磁时，制造一个分身
- 铁砧穿过末地门时成功变化为幻灵铁砧的概率（如失败则直接消失）：
  - 损坏的铁砧：`1%`
  - 开裂的铁砧：`2%`
  - 铁砧：`3%`
  - 皇家铁砧：`50%`
  - 余烬铁砧：`100%`
  - 其他模组铁砧皆为`3%`
- resolved #1220 