### PR TITLE
Fix conversion chance of spectral anvil 修复幻灵铁砧的转换概率

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
@@ -39,7 +39,7 @@ abstract class EndPortalBlockMixin {
             BlockState newState = ModBlocks.END_DUST.getDefaultState();
             if (fallingBlockEntity.blockState.is(BlockTags.ANVIL)) {
                 double rand = pLevel.random.nextDouble();
-                if(rand < SpectralAnvilConversionUtil.chance(fallingBlockEntity.blockState.getBlock())){
+                if (rand < SpectralAnvilConversionUtil.chance(fallingBlockEntity.blockState.getBlock())) {
                     newState = ModBlocks.SPECTRAL_ANVIL.getDefaultState();
                 }
             }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
@@ -3,12 +3,12 @@ package dev.dubhe.anvilcraft.mixin;
 import dev.dubhe.anvilcraft.init.ModBlockTags;
 import dev.dubhe.anvilcraft.init.ModBlocks;
 
+import dev.dubhe.anvilcraft.util.SpectralAnvilConversionUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EndPortalBlock;
 import net.minecraft.world.level.block.Portal;
 import net.minecraft.world.level.block.state.BlockState;
@@ -17,6 +17,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 
 @Mixin(EndPortalBlock.class)
 abstract class EndPortalBlockMixin {
@@ -36,24 +37,11 @@ abstract class EndPortalBlockMixin {
                 && !fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)
         ) {
             BlockState newState = ModBlocks.END_DUST.getDefaultState();
-            anvil:
             if (fallingBlockEntity.blockState.is(BlockTags.ANVIL)) {
                 double rand = pLevel.random.nextDouble();
-                if (fallingBlockEntity.blockState.is(Blocks.DAMAGED_ANVIL) && rand >= 0.01) {
-                    break anvil;
-                } else if (fallingBlockEntity.blockState.is(Blocks.CHIPPED_ANVIL) && rand >= 0.02) {
-                    break anvil;
-                } else if (fallingBlockEntity.blockState.is(Blocks.ANVIL) && rand >= 0.03) {
-                    break anvil;
-                } else if (fallingBlockEntity.blockState.is(ModBlocks.ROYAL_ANVIL) && rand >= 0.5) {
-                    break anvil;
-                } else if (fallingBlockEntity.blockState.is(ModBlocks.EMBER_ANVIL)) {
+                if(rand < SpectralAnvilConversionUtil.chance(fallingBlockEntity.blockState.getBlock())){
                     newState = ModBlocks.SPECTRAL_ANVIL.getDefaultState();
-                    break anvil;
-                } else if (rand >= 0.03) {
-                    break anvil;
                 }
-                newState = ModBlocks.SPECTRAL_ANVIL.getDefaultState();
             }
             fallingBlockEntity.blockState = newState;
             fallingBlockEntity.setAsInsidePortal((Portal) this, pPos);

--- a/src/main/java/dev/dubhe/anvilcraft/util/SpectralAnvilConversionUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/SpectralAnvilConversionUtil.java
@@ -17,7 +17,7 @@ public class SpectralAnvilConversionUtil {
         SPECTRAL_ANVIL_CONVERSION_CHANCE.put(ModBlocks.EMBER_ANVIL.get(), 1.0);
     }
 
-    public static double chance(Block block){
+    public static double chance(Block block) {
         return SPECTRAL_ANVIL_CONVERSION_CHANCE.getOrDefault(block, 0.03);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/SpectralAnvilConversionUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/SpectralAnvilConversionUtil.java
@@ -1,0 +1,23 @@
+package dev.dubhe.anvilcraft.util;
+
+import dev.dubhe.anvilcraft.init.ModBlocks;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+
+public class SpectralAnvilConversionUtil {
+    private static final Object2DoubleMap<Block> SPECTRAL_ANVIL_CONVERSION_CHANCE = new Object2DoubleOpenHashMap<>();
+
+    static {
+        SPECTRAL_ANVIL_CONVERSION_CHANCE.put(Blocks.DAMAGED_ANVIL, 0.01);
+        SPECTRAL_ANVIL_CONVERSION_CHANCE.put(Blocks.CHIPPED_ANVIL, 0.02);
+        SPECTRAL_ANVIL_CONVERSION_CHANCE.put(Blocks.ANVIL, 0.03);
+        SPECTRAL_ANVIL_CONVERSION_CHANCE.put(ModBlocks.ROYAL_ANVIL.get(), 0.5);
+        SPECTRAL_ANVIL_CONVERSION_CHANCE.put(ModBlocks.EMBER_ANVIL.get(), 1.0);
+    }
+
+    public static double chance(Block block){
+        return SPECTRAL_ANVIL_CONVERSION_CHANCE.getOrDefault(block, 0.03);
+    }
+}


### PR DESCRIPTION
- 此前版本中，所有铁砧在试图转换为幻灵铁砧时，由于经历了以下的额外检查：
```java
else if (rand >= 0.03) {
                    break anvil;
                }
```
该检查本意是为其他模组添加的铁砧设定默认转化概率，但也导致所有铁砧的转化概率无法高于0.03，这使得皇家铁砧的转化成功率不符合预期。将概率判断修改为`Map#getOrDefault`后，解决了这个问题。