### PR TITLE
Add bulging and superheating recipes 增加物品膨发与超级加热配方

### DIFF
--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/black_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/black_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/black_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/black_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/blue_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/blue_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/blue_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/blue_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/brown_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/brown_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/brown_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/brown_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/brown_mushroom_block.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/brown_mushroom_block.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/brown_mushroom_block"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/brown_mushroom_block"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/cyan_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/cyan_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/cyan_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/cyan_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_chiseled_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_chiseled_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_chiseled_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_bulb.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_copper_bulb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_copper_bulb"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_door.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_door.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_copper_door"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_copper_door"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_grate.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_grate.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_copper_grate"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_copper_grate"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_trapdoor.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_copper_trapdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_copper_trapdoor"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_cut_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_cut_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_cut_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_cut_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_cut_copper_slab.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_cut_copper_slab.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_cut_copper_slab"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_cut_copper_slab"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_cut_copper_stairs.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/exposed_cut_copper_stairs.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/exposed_cut_copper_stairs"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/exposed_cut_copper_stairs"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/gray_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/gray_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/gray_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/gray_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/green_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/green_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/green_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/green_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/kelp.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/kelp.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/kelp"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/kelp"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/light_blue_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/light_blue_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/light_blue_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/light_blue_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/light_gray_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/light_gray_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/light_gray_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/light_gray_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/lime_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/lime_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/lime_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/lime_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/magenta_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/magenta_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/magenta_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/magenta_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/orange_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/orange_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/orange_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/orange_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_chiseled_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_chiseled_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_chiseled_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_bulb.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_copper_bulb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_copper_bulb"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_door.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_door.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_copper_door"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_copper_door"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_grate.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_grate.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_copper_grate"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_copper_grate"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_trapdoor.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_copper_trapdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_copper_trapdoor"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_cut_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_cut_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_cut_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_cut_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_cut_copper_slab.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_cut_copper_slab.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_cut_copper_slab"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_cut_copper_slab"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_cut_copper_stairs.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/oxidized_cut_copper_stairs.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/oxidized_cut_copper_stairs"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/oxidized_cut_copper_stairs"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/pink_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/pink_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/pink_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/pink_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/purple_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/purple_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/purple_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/purple_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/red_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/red_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/red_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/red_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/red_mushroom_block.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/red_mushroom_block.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/red_mushroom_block"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/red_mushroom_block"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_chiseled_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_chiseled_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_chiseled_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_bulb.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_copper_bulb"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_copper_bulb"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_door.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_door.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_copper_door"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_copper_door"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_grate.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_grate.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_copper_grate"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_copper_grate"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_trapdoor.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_copper_trapdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_copper_trapdoor"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_cut_copper.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_cut_copper.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_cut_copper"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_cut_copper"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_cut_copper_slab.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_cut_copper_slab.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_cut_copper_slab"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_cut_copper_slab"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_cut_copper_stairs.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/weathered_cut_copper_stairs.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/weathered_cut_copper_stairs"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/weathered_cut_copper_stairs"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/white_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/white_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/white_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/white_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/yellow_concrete.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/bulging/yellow_concrete.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:bulging/yellow_concrete"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:bulging/yellow_concrete"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/super_heating/royal_steel_block.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/super_heating/royal_steel_block.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:super_heating/royal_steel_block"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:super_heating/royal_steel_block"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/black_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/black_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:black_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:black_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/blue_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/blue_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:blue_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:blue_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/brown_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/brown_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:brown_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:brown_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/brown_mushroom_block.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/brown_mushroom_block.json
@@ -1,0 +1,32 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:brown_mushroom"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:brown_mushroom_block"
+      }
+    },
+    {
+      "amount": {
+        "type": "minecraft:binomial",
+        "n": 1.0,
+        "p": 0.1
+      },
+      "stack": {
+        "count": 1,
+        "id": "minecraft:mushroom_stem"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/cyan_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/cyan_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:cyan_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:cyan_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_chiseled_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:chiseled_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_chiseled_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:copper_block"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_bulb.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:copper_bulb"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_copper_bulb"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_door.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_door.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:copper_door"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_copper_door"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_grate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_grate.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:copper_grate"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_copper_grate"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_trapdoor.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:copper_trapdoor"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_copper_trapdoor"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_cut_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_cut_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:cut_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_cut_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_cut_copper_slab.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_cut_copper_slab.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:cut_copper_slab"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_cut_copper_slab"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_cut_copper_stairs.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/exposed_cut_copper_stairs.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:cut_copper_stairs"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:exposed_cut_copper_stairs"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/gray_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/gray_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:gray_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:gray_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/green_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/green_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:green_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:green_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/kelp.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/kelp.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:dried_kelp"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:kelp"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/light_blue_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/light_blue_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:light_blue_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:light_blue_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/light_gray_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/light_gray_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:light_gray_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:light_gray_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/lime_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/lime_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:lime_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:lime_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/magenta_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/magenta_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:magenta_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:magenta_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/orange_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/orange_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:orange_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:orange_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_chiseled_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_chiseled_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_chiseled_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_bulb.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_copper_bulb"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_copper_bulb"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_door.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_door.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_copper_door"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_copper_door"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_grate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_grate.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_copper_grate"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_copper_grate"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_trapdoor.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_copper_trapdoor"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_copper_trapdoor"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_cut_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_cut_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_cut_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_cut_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_cut_copper_slab.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_cut_copper_slab.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_cut_copper_slab"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_cut_copper_slab"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_cut_copper_stairs.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/oxidized_cut_copper_stairs.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:weathered_cut_copper_stairs"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:oxidized_cut_copper_stairs"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/pink_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/pink_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:pink_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:pink_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/purple_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/purple_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:purple_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:purple_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/red_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/red_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:red_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:red_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/red_mushroom_block.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/red_mushroom_block.json
@@ -1,0 +1,32 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:red_mushroom"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:red_mushroom_block"
+      }
+    },
+    {
+      "amount": {
+        "type": "minecraft:binomial",
+        "n": 1.0,
+        "p": 0.1
+      },
+      "stack": {
+        "count": 1,
+        "id": "minecraft:mushroom_stem"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_chiseled_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_chiseled_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_chiseled_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_chiseled_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_bulb.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_bulb.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_copper_bulb"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_copper_bulb"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_door.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_door.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_copper_door"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_copper_door"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_grate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_grate.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_copper_grate"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_copper_grate"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_trapdoor.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_copper_trapdoor.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_copper_trapdoor"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_copper_trapdoor"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_cut_copper.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_cut_copper.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_cut_copper"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_cut_copper"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_cut_copper_slab.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_cut_copper_slab.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_cut_copper_slab"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_cut_copper_slab"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_cut_copper_stairs.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/weathered_cut_copper_stairs.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:exposed_cut_copper_stairs"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:weathered_cut_copper_stairs"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/white_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/white_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:white_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:white_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/bulging/yellow_concrete.json
+++ b/src/generated/resources/data/anvilcraft/recipe/bulging/yellow_concrete.json
@@ -1,0 +1,21 @@
+{
+  "type": "anvilcraft:bulging",
+  "cauldron": "minecraft:water_cauldron",
+  "consume_fluid": false,
+  "from_water": false,
+  "ingredients": [
+    {
+      "item": "minecraft:yellow_concrete_powder"
+    }
+  ],
+  "produce_fluid": false,
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "minecraft:yellow_concrete"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/royal_steel_block.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/royal_steel_block.json
@@ -1,0 +1,35 @@
+{
+  "type": "anvilcraft:super_heating",
+  "ingredients": [
+    {
+      "item": "minecraft:iron_block"
+    },
+    {
+      "item": "minecraft:iron_block"
+    },
+    {
+      "item": "minecraft:iron_block"
+    },
+    {
+      "item": "minecraft:diamond_block"
+    },
+    {
+      "item": "minecraft:amethyst_block"
+    },
+    {
+      "item": "minecraft:amethyst_block"
+    },
+    {
+      "tag": "anvilcraft:gem_blocks"
+    }
+  ],
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 1,
+        "id": "anvilcraft:royal_steel_block"
+      }
+    }
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/BulgingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/BulgingRecipeLoader.java
@@ -1,17 +1,17 @@
 package dev.dubhe.anvilcraft.data.recipe;
 
+import com.tterrag.registrate.providers.RegistrateRecipeProvider;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.block.state.Color;
 import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.recipe.anvil.BulgingRecipe;
-
+import dev.dubhe.anvilcraft.util.VanillaConstants;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-
-import com.tterrag.registrate.providers.RegistrateRecipeProvider;
 
 public class BulgingRecipeLoader {
     public static void init(RegistrateRecipeProvider provider) {
@@ -26,24 +26,48 @@ public class BulgingRecipeLoader {
         bulging(provider, Items.TUBE_CORAL, Items.TUBE_CORAL_BLOCK);
         bulging(provider, ModItems.SPONGE_GEMMULE, Items.WET_SPONGE, true);
         bulging(provider, ModItems.FLOUR, ModItems.DOUGH);
+        bulging(provider, Items.DRIED_KELP, Items.KELP);
         crystallize(provider, ModItems.SEA_HEART_SHELL_SHARD, ModItems.PRISMARINE_CLUSTER, true);
 
+        VanillaConstants.CONCRETE_POWDERS.forEach(block ->bulging(provider, block, block.concrete));
+
+        VanillaConstants.WEATHERING_COPPERS.forEach(weatheringCopper -> {
+            if(!(weatheringCopper instanceof Block block)) return;
+            weatheringCopper.getNext(block.defaultBlockState()).ifPresent(
+                state -> bulging(provider, block, state.getBlock())
+            );
+        });
+
         BulgingRecipe.builder()
-                .cauldron(ModBlocks.CEMENT_CAULDRONS.get(Color.GRAY).get())
-                .requires(ModItems.LIME_POWDER, 4)
-                .requires(ModBlocks.CINERITE)
-                .fromWater(true)
-                .save(provider, AnvilCraft.of("bulging/cement_cauldron"));
+            .cauldron(ModBlocks.CEMENT_CAULDRONS.get(Color.GRAY).get())
+            .requires(ModItems.LIME_POWDER, 4)
+            .requires(ModBlocks.CINERITE)
+            .fromWater(true)
+            .save(provider, AnvilCraft.of("bulging/cement_cauldron"));
+
+        BulgingRecipe.builder()
+            .cauldron(Blocks.WATER_CAULDRON)
+            .requires(Items.RED_MUSHROOM)
+            .result(Blocks.RED_MUSHROOM_BLOCK.asItem().getDefaultInstance())
+            .result(Blocks.MUSHROOM_STEM.asItem().getDefaultInstance(), 0.1f)
+            .save(provider);
+
+        BulgingRecipe.builder()
+            .cauldron(Blocks.WATER_CAULDRON)
+            .requires(Items.BROWN_MUSHROOM)
+            .result(Blocks.BROWN_MUSHROOM_BLOCK.asItem().getDefaultInstance())
+            .result(Blocks.MUSHROOM_STEM.asItem().getDefaultInstance(), 0.1f)
+            .save(provider);
     }
 
     private static void bulging(
-            RegistrateRecipeProvider provider, ItemLike input, ItemLike result, boolean consumeFluid) {
+        RegistrateRecipeProvider provider, ItemLike input, ItemLike result, boolean consumeFluid) {
         BulgingRecipe.builder()
-                .cauldron(Blocks.WATER_CAULDRON)
-                .requires(input)
-                .result(new ItemStack(result))
-                .consumeFluid(consumeFluid)
-                .save(provider);
+            .cauldron(Blocks.WATER_CAULDRON)
+            .requires(input)
+            .result(new ItemStack(result))
+            .consumeFluid(consumeFluid)
+            .save(provider);
     }
 
     private static void bulging(RegistrateRecipeProvider provider, ItemLike input, ItemLike result) {
@@ -51,13 +75,13 @@ public class BulgingRecipeLoader {
     }
 
     private static void crystallize(
-            RegistrateRecipeProvider provider, ItemLike input, ItemLike result, boolean consumeFluid) {
+        RegistrateRecipeProvider provider, ItemLike input, ItemLike result, boolean consumeFluid) {
         BulgingRecipe.builder()
-                .cauldron(Blocks.POWDER_SNOW_CAULDRON)
-                .requires(input)
-                .result(new ItemStack(result))
-                .consumeFluid(consumeFluid)
-                .save(provider);
+            .cauldron(Blocks.POWDER_SNOW_CAULDRON)
+            .requires(input)
+            .result(new ItemStack(result))
+            .consumeFluid(consumeFluid)
+            .save(provider);
     }
 
     private static void crystallize(RegistrateRecipeProvider provider, ItemLike input, ItemLike result) {

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/BulgingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/BulgingRecipeLoader.java
@@ -29,10 +29,10 @@ public class BulgingRecipeLoader {
         bulging(provider, Items.DRIED_KELP, Items.KELP);
         crystallize(provider, ModItems.SEA_HEART_SHELL_SHARD, ModItems.PRISMARINE_CLUSTER, true);
 
-        VanillaConstants.CONCRETE_POWDERS.forEach(block ->bulging(provider, block, block.concrete));
+        VanillaConstants.CONCRETE_POWDERS.forEach(block -> bulging(provider, block, block.concrete));
 
         VanillaConstants.WEATHERING_COPPERS.forEach(weatheringCopper -> {
-            if(!(weatheringCopper instanceof Block block)) return;
+            if (!(weatheringCopper instanceof Block block)) return;
             weatheringCopper.getNext(block.defaultBlockState()).ifPresent(
                 state -> bulging(provider, block, state.getBlock())
             );

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/SuperHeatingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/SuperHeatingRecipeLoader.java
@@ -34,6 +34,13 @@ public class SuperHeatingRecipeLoader {
                 .result(new ItemStack(ModItems.ROYAL_STEEL_INGOT.asItem()))
                 .save(provider);
         SuperHeatingRecipe.builder()
+            .requires(Blocks.IRON_BLOCK, 3)
+            .requires(Blocks.DIAMOND_BLOCK)
+            .requires(Blocks.AMETHYST_BLOCK, 2)
+            .requires(ModItemTags.GEM_BLOCKS)
+            .result(ModBlocks.ROYAL_STEEL_BLOCK.asStack())
+            .save(provider);
+        SuperHeatingRecipe.builder()
                 .requires(ModBlocks.QUARTZ_SAND, 8)
                 .requires(ModItems.ROYAL_STEEL_INGOT)
                 .result(new ItemStack(ModBlocks.TEMPERING_GLASS, 8))

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BulgingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BulgingCategory.java
@@ -139,7 +139,7 @@ public class BulgingCategory implements IRecipeCategory<RecipeHolder<BulgingReci
 
         JeiSlotUtil.drawInputSlots(guiGraphics, slot, recipe.mergedIngredients.size());
         if (!recipe.results.isEmpty()) {
-            JeiSlotUtil.drawOutputSlots(guiGraphics, slot, 1);
+            JeiSlotUtil.drawOutputSlots(guiGraphics, slot, recipe.results.size());
             if (recipe.isConsumeFluid()) {
                 guiGraphics.drawString(
                         Minecraft.getInstance().font,

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/BulgingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/BulgingRecipe.java
@@ -266,6 +266,11 @@ public class BulgingRecipe implements Recipe<BulgingRecipe.Input> {
             return this;
         }
 
+        public Builder result(ItemStack stack, float chance){
+            results.add(ChanceItemStack.of(stack).withChance(chance));
+            return this;
+        }
+
         @Override
         public BulgingRecipe buildRecipe() {
             return new BulgingRecipe(ingredients, cauldron, results, produceFluid, consumeFluid, fromWater);

--- a/src/main/java/dev/dubhe/anvilcraft/util/VanillaConstants.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/VanillaConstants.java
@@ -1,0 +1,66 @@
+package dev.dubhe.anvilcraft.util;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ConcretePowderBlock;
+import net.minecraft.world.level.block.WeatheringCopper;
+
+public class VanillaConstants {
+    public static final ImmutableList<ConcretePowderBlock> CONCRETE_POWDERS = ImmutableList.of(
+        (ConcretePowderBlock) Blocks.WHITE_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.ORANGE_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.MAGENTA_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.LIGHT_BLUE_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.YELLOW_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.LIME_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.PINK_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.GRAY_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.LIGHT_GRAY_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.CYAN_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.PURPLE_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.BLUE_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.BROWN_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.GREEN_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.RED_CONCRETE_POWDER,
+        (ConcretePowderBlock) Blocks.BLACK_CONCRETE_POWDER
+    );
+    
+    public static final ImmutableList<WeatheringCopper> WEATHERING_COPPERS = ImmutableList.of(
+        (WeatheringCopper) Blocks.COPPER_BLOCK,
+        (WeatheringCopper) Blocks.EXPOSED_COPPER,
+        (WeatheringCopper) Blocks.WEATHERED_COPPER,
+        (WeatheringCopper) Blocks.OXIDIZED_COPPER,
+        (WeatheringCopper) Blocks.OXIDIZED_CUT_COPPER,
+        (WeatheringCopper) Blocks.WEATHERED_CUT_COPPER,
+        (WeatheringCopper) Blocks.EXPOSED_CUT_COPPER,
+        (WeatheringCopper) Blocks.CUT_COPPER,
+        (WeatheringCopper) Blocks.OXIDIZED_CHISELED_COPPER,
+        (WeatheringCopper) Blocks.WEATHERED_CHISELED_COPPER,
+        (WeatheringCopper) Blocks.EXPOSED_CHISELED_COPPER,
+        (WeatheringCopper) Blocks.CHISELED_COPPER,
+        (WeatheringCopper) Blocks.OXIDIZED_CUT_COPPER_STAIRS,
+        (WeatheringCopper) Blocks.WEATHERED_CUT_COPPER_STAIRS,
+        (WeatheringCopper) Blocks.EXPOSED_CUT_COPPER_STAIRS,
+        (WeatheringCopper) Blocks.CUT_COPPER_STAIRS,
+        (WeatheringCopper) Blocks.OXIDIZED_CUT_COPPER_SLAB,
+        (WeatheringCopper) Blocks.WEATHERED_CUT_COPPER_SLAB,
+        (WeatheringCopper) Blocks.EXPOSED_CUT_COPPER_SLAB,
+        (WeatheringCopper) Blocks.CUT_COPPER_SLAB,
+        (WeatheringCopper) Blocks.COPPER_DOOR,
+        (WeatheringCopper) Blocks.EXPOSED_COPPER_DOOR,
+        (WeatheringCopper) Blocks.OXIDIZED_COPPER_DOOR,
+        (WeatheringCopper) Blocks.WEATHERED_COPPER_DOOR,
+        (WeatheringCopper) Blocks.COPPER_TRAPDOOR,
+        (WeatheringCopper) Blocks.EXPOSED_COPPER_TRAPDOOR,
+        (WeatheringCopper) Blocks.OXIDIZED_COPPER_TRAPDOOR,
+        (WeatheringCopper) Blocks.WEATHERED_COPPER_TRAPDOOR,
+        (WeatheringCopper) Blocks.COPPER_GRATE,
+        (WeatheringCopper) Blocks.EXPOSED_COPPER_GRATE,
+        (WeatheringCopper) Blocks.WEATHERED_COPPER_GRATE,
+        (WeatheringCopper) Blocks.OXIDIZED_COPPER_GRATE,
+        (WeatheringCopper) Blocks.COPPER_BULB,
+        (WeatheringCopper) Blocks.EXPOSED_COPPER_BULB,
+        (WeatheringCopper) Blocks.WEATHERED_COPPER_BULB,
+        (WeatheringCopper) Blocks.OXIDIZED_COPPER_BULB
+    );
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -21,6 +21,8 @@ public-f net.minecraft.world.entity.item.FallingBlockEntity cancelDrop
 public-f net.minecraft.world.phys.BlockHitResult miss
 public net.minecraft.world.item.BlockItem canPlace(Lnet/minecraft/world/item/context/BlockPlaceContext;Lnet/minecraft/world/level/block/state/BlockState;)Z # canPlace
 
+public net.minecraft.world.level.block.ConcretePowderBlock concrete
+
 public net.minecraft.data.loot.BlockLootSubProvider add(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/LootTable$Builder;)V # add
 public net.minecraft.data.loot.BlockLootSubProvider createSinglePropConditionTable(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/block/state/properties/Property;Ljava/lang/Comparable;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSinglePropConditionTable
 


### PR DESCRIPTION
- 增加了`VanillaConstants`类，用于存储原版混凝土粉末、（未涂蜡）铜质方块的列表，便于批量配方生成。
- Resolved #1343
- Fixed #1378
- Resolved #1389