### PR TITLE
Fix piston behavior of Reinforced Concrete Blocks and HUD render when F1 activated 修复混凝土活塞bug与按下F1显示HUD的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
@@ -70,17 +70,17 @@ public class ReinforcedConcreteBlock extends Block {
         BlockState belowState = level.getBlockState(pos.below());
         switch (half) {
             case TOP:
-                if (!belowState.is(this)) {
-                    level.setBlock(pos, state.setValue(HALF, SINGLE), 2);
-                } else if (!this.checkHalf(belowState, BOTTOM)) {
+                if (this.checkHalf(belowState, SINGLE)) {
                     level.setBlock(pos.below(), state.setValue(HALF, BOTTOM), 2);
+                } else if (!this.checkHalf(belowState, BOTTOM)){
+                    level.setBlock(pos, state.setValue(HALF, SINGLE), 2);
                 }
                 break;
             case BOTTOM:
-                if (!aboveState.is(this)){
-                    level.setBlock(pos, state.setValue(HALF, SINGLE), 2);
-                } else if (!this.checkHalf(aboveState, TOP)){
+                if (this.checkHalf(aboveState, SINGLE)) {
                     level.setBlock(pos.above(), state.setValue(HALF, TOP), 2);
+                } else if (!this.checkHalf(aboveState, TOP)){
+                    level.setBlock(pos, state.setValue(HALF, SINGLE), 2);
                 }
                 break;
             case SINGLE:

--- a/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
@@ -1,6 +1,5 @@
 package dev.dubhe.anvilcraft.block;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.block.state.ReinforcedConcreteHalf;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
@@ -39,31 +38,6 @@ public class ReinforcedConcreteBlock extends Block {
         builder.add(HALF);
     }
 
-    //    @Override
-//    protected BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos pos, BlockPos neighborPos) {
-//        if (direction.getAxis() != Direction.Axis.Y) return state;
-//        ReinforcedConcreteHalf half = state.getValue(HALF);
-//        BlockState aboveState = level.getBlockState(pos.above());
-//        BlockState belowState = level.getBlockState(pos.below());
-//        if (half == TOP) {
-//            if (this.checkHalf(belowState, BOTTOM)) return state;
-//            return state.setValue(HALF, SINGLE);
-//        } else if (half == BOTTOM) {
-//            if (this.checkHalf(aboveState, TOP)) return state;
-//            return state.setValue(HALF, SINGLE);
-//        } else {
-//            if (this.checkHalf(aboveState, SINGLE)) {
-//                level.setBlock(pos.above(), state.setValue(HALF, TOP), 2);
-//                return state.setValue(HALF, BOTTOM);
-//            }
-//            if (this.checkHalf(belowState, SINGLE)) {
-//                level.setBlock(pos.below(), state.setValue(HALF, BOTTOM), 2);
-//                return state.setValue(HALF, TOP);
-//            }
-//        }
-//        return state;
-//    }
-//
     private boolean checkHalf(BlockState state, ReinforcedConcreteHalf half) {
         return state.is(this) && state.getValue(HALF) == half;
     }
@@ -80,7 +54,6 @@ public class ReinforcedConcreteBlock extends Block {
     private boolean shouldIgnoreUpdate(BlockPos pos, BlockPos fromPos) {
         return pos.getY() == fromPos.getY() && (pos.getX() != fromPos.getX() || pos.getZ() != fromPos.getZ());
     }
-
 
     @Override
     public void neighborChanged(

--- a/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
@@ -51,7 +51,7 @@ public class ReinforcedConcreteBlock extends Block {
      * @return If the NC update should be ignored.
      * @see PistonMovingBlockEntity#tick(Level, BlockPos, BlockState, PistonMovingBlockEntity)
      */
-    private boolean shouldIgnoreUpdate(BlockPos pos, BlockPos fromPos) {
+    private static boolean shouldIgnoreUpdate(BlockPos pos, BlockPos fromPos) {
         return pos.getY() == fromPos.getY() && (pos.getX() != fromPos.getX() || pos.getZ() != fromPos.getZ());
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ReinforcedConcreteBlock.java
@@ -46,7 +46,7 @@ public class ReinforcedConcreteBlock extends Block {
      * When piston finished a block movement, this block will receive an NC update where neighborPos is
      * same as pos. So we cannot ignore the update when <code>neighborPos.equals(pos)</code>.
      *
-     * @param pos the position where block being updated
+     * @param pos     the position where block being updated
      * @param fromPos the position where block update is spread from
      * @return If the NC update should be ignored.
      * @see PistonMovingBlockEntity#tick(Level, BlockPos, BlockState, PistonMovingBlockEntity)
@@ -72,14 +72,14 @@ public class ReinforcedConcreteBlock extends Block {
             case TOP:
                 if (this.checkHalf(belowState, SINGLE)) {
                     level.setBlock(pos.below(), state.setValue(HALF, BOTTOM), 2);
-                } else if (!this.checkHalf(belowState, BOTTOM)){
+                } else if (!this.checkHalf(belowState, BOTTOM)) {
                     level.setBlock(pos, state.setValue(HALF, SINGLE), 2);
                 }
                 break;
             case BOTTOM:
                 if (this.checkHalf(aboveState, SINGLE)) {
                     level.setBlock(pos.above(), state.setValue(HALF, TOP), 2);
-                } else if (!this.checkHalf(aboveState, TOP)){
+                } else if (!this.checkHalf(aboveState, TOP)) {
                     level.setBlock(pos, state.setValue(HALF, SINGLE), 2);
                 }
                 break;

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/GuiLayerRegistrationEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/GuiLayerRegistrationEventListener.java
@@ -32,6 +32,7 @@ public class GuiLayerRegistrationEventListener {
     public static void onRegister(RegisterGuiLayersEvent event) {
         event.registerAboveAll(AnvilCraft.of("power"), (guiGraphics, pDeltaTracker) -> {
             Minecraft minecraft = Minecraft.getInstance();
+            if (minecraft.options.hideGui) return;
             float partialTick = pDeltaTracker.getGameTimeDeltaPartialTick(
                 Minecraft.getInstance().isPaused()
             );

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/RenderEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/RenderEventListener.java
@@ -51,6 +51,7 @@ public class RenderEventListener {
     @SubscribeEvent
     public static void onRender(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_BLOCK_ENTITIES) return;
+        if (Minecraft.getInstance().options.hideGui) return;
         Entity entity = event.getCamera().getEntity();
         MultiBufferSource.BufferSource bufferSource =
             event.getLevelRenderer().renderBuffers.bufferSource();


### PR DESCRIPTION
- 重构了`ReinforcedConcreteBlock#neighborChanged`方法的实现，修复了活塞推动强化混凝土产生单独的`top`或`bottom`状态的的混凝土。
- 修复了在按下F1键隐藏GUI的状态下，电网元件、棱镜、定日镜的铁砧锤提示，电网框，输电杆之间的连线，手中的定日镜物品的绑定位置提示（高亮被选中的照射目标方块）等效果不消失的问题。
- Fixed #1400