### PR TITLE
Optimize network and fix Sliding Rail Syncing 优化网络包，修复滑轨同步

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/ItemDetectorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ItemDetectorBlock.java
@@ -98,7 +98,7 @@ public class ItemDetectorBlock extends BetterBaseEntityBlock implements EntityBl
     protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
         if (level.isClientSide ||
             (oldState.is(this) && state.getValue(FACING) == oldState.getValue(FACING))) return;
-        if (oldState.is(this) && level.getBlockEntity(pos) instanceof ItemDetectorBlockEntity blockEntity) {
+        if (level.getBlockEntity(pos) instanceof ItemDetectorBlockEntity blockEntity) {
             blockEntity.recalcDetectionRange();
         }
         if (state.getValue(POWERED)) this.updateNeighborsInFront(level, pos, state);

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemDetectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemDetectorBlockEntity.java
@@ -21,7 +21,6 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -60,6 +59,7 @@ public class ItemDetectorBlockEntity extends BlockEntity implements MenuProvider
     private Mode filterMode;
     @Getter
     private int range = 0;
+    private boolean rangeChanged = true;
     private AABB detectionRange;
     @Getter
     private final ContainerData dataAccess = new ContainerData() {
@@ -137,8 +137,10 @@ public class ItemDetectorBlockEntity extends BlockEntity implements MenuProvider
 
     @Override
     public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
+        if (!this.rangeChanged) return new CompoundTag();
         CompoundTag tag = super.getUpdateTag(registries);
         tag.putInt("Range", this.range);
+        this.rangeChanged = false;
         return tag;
     }
 
@@ -220,8 +222,13 @@ public class ItemDetectorBlockEntity extends BlockEntity implements MenuProvider
         range = Mth.clamp(range, MIN_RANGE, MAX_RANGE);
         if (this.range == range) return;
         this.range = range;
-        this.setChanged();
         this.recalcDetectionRange();
+    }
+
+    @Override
+    public void setChanged() {
+        this.rangeChanged = true;
+        super.setChanged();
     }
 
     @Override


### PR DESCRIPTION
- 优化了物品探测器的`getUpdateTag`方法，现在物品探测器不会在每次改变信号状态时向客户端发送同步探测范围的网络包了。
- 利用`Level#blockEvent`机制为修复了滑轨的同步问题，现在滑轨在推动方块时不会出现闪烁状态了。
    - 此前版本中，滑轨推动方块时不会将`MovingPistonBlock`及其方块实体的创建同步至客户端，这导致客户端无法正常渲染被滑轨推动的方块。