### PR TITLE
Make crabclaws can forcefully open the shulkers 使蟹钳可强制开启潜影贝

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/item/CrabClawItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/CrabClawItem.java
@@ -5,16 +5,20 @@ import dev.dubhe.anvilcraft.api.entity.EntityHelper;
 import dev.dubhe.anvilcraft.api.entity.attribute.EntityReachAttribute;
 import dev.dubhe.anvilcraft.init.ModItems;
 
+import dev.dubhe.anvilcraft.util.EntityUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.monster.Shulker;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 
@@ -81,6 +85,19 @@ public class CrabClawItem extends Item {
                 customData.putBoolean(DUAL_CRAB_CLAW_MARKER, true);
             }
         }
+    }
+
+    @Override
+    public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity target, InteractionHand hand) {
+        if (target instanceof Shulker shulker && shulker.isAlive()) {
+            if (!player.level().isClientSide) {
+                EntityUtil.setShulkerOpen(shulker);
+            }
+
+            return InteractionResult.sidedSuccess(player.level().isClientSide);
+        }
+
+        return InteractionResult.PASS;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/util/EntityUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/EntityUtil.java
@@ -1,0 +1,17 @@
+package dev.dubhe.anvilcraft.util;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.monster.Shulker;
+
+public class EntityUtil {
+    public static void setShulkerOpen(Shulker shulker) {
+        try {
+            shulker.getAttribute(Attributes.ARMOR).removeModifier(Shulker.COVERED_ARMOR_MODIFIER_ID);
+        } catch (Exception ignored) {}
+
+        shulker.getEntityData().set(Shulker.DATA_PEEK_ID, (byte) 100);
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -91,3 +91,6 @@ public-f net.minecraft.world.level.block.AbstractCauldronBlock interactions
 public net.minecraft.world.level.block.state.properties.IntegerProperty max
 
 public net.minecraft.world.level.block.AbstractCauldronBlock useItemOn(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/phys/BlockHitResult;)Lnet/minecraft/world/ItemInteractionResult;
+
+public net.minecraft.world.entity.monster.Shulker COVERED_ARMOR_MODIFIER_ID
+public net.minecraft.world.entity.monster.Shulker DATA_PEEK_ID


### PR DESCRIPTION
- 实现了 #581 的功能
- 现在任意手持有蟹钳对潜影贝使用可以强制使其开壳，松手可解除该效果
- resolved #581 