### PR TITLE
Fix bulging behavior and cardboard blacklist tag

### DIFF
--- a/src/generated/resources/data/mekanism/tags/block/cardboard_blacklist.json
+++ b/src/generated/resources/data/mekanism/tags/block/cardboard_blacklist.json
@@ -5,10 +5,7 @@
     "anvilcraft:remote_transmission_pole",
     "anvilcraft:tesla_tower",
     "anvilcraft:overseer",
-    "anvilcraft:giant_anvil",
-    "anvilcraft:transmission_pole",
-    "anvilcraft:remote_transmission_pole",
-    "anvilcraft:tesla_tower",
-    "anvilcraft:overseer"
+    "anvilcraft:acceleration_ring",
+    "anvilcraft:deflection_ring"
   ]
 }

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -165,13 +165,9 @@ public class BlockTagLoader {
             .add(ModBlocks.TRANSMISSION_POLE.getKey())
             .add(ModBlocks.REMOTE_TRANSMISSION_POLE.getKey())
             .add(ModBlocks.TESLA_TOWER.getKey())
-            .add(ModBlocks.OVERSEER_BLOCK.getKey());
+            .add(ModBlocks.OVERSEER_BLOCK.getKey())
+            .add(ModBlocks.ACCELERATION_RING.getKey())
+            .add(ModBlocks.DEFLECTION_RING.getKey());
 
-        provider.addTag(ModBlockTags.MEKANISM_CARDBOARD_BOX_BLACKLIST)
-            .add(ModBlocks.GIANT_ANVIL.getKey())
-            .add(ModBlocks.TRANSMISSION_POLE.getKey())
-            .add(ModBlocks.REMOTE_TRANSMISSION_POLE.getKey())
-            .add(ModBlocks.TESLA_TOWER.getKey())
-            .add(ModBlocks.OVERSEER_BLOCK.getKey());
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/BulgingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/BulgingRecipe.java
@@ -110,7 +110,7 @@ public class BulgingRecipe implements Recipe<BulgingRecipe.Input> {
         if (fromWater) {
             if (input.cauldronState != FULL_WATER_CAULDRON) return false;
         } else {
-            if (consumeFluid && !CauldronUtil.compatibleForDrain(input.cauldronState, this.cauldron, 1)) {
+            if (!CauldronUtil.compatibleForDrain(input.cauldronState, this.cauldron, 1)) {
                 return false;
             }
             if (produceFluid && !CauldronUtil.compatibleForFill(input.cauldronState, this.cauldron, 1)) {


### PR DESCRIPTION
- 修复了 #1587 的问题。现在铜块的时移与膨发配方均能正常地执行了。
- 修复了`mekanism:cardboard_blacklist`方块标签文件中方块重复出现两次的问题。
- 将新加入的加速环、偏转环连体方块加入了`mekanism:cardboard_blacklist`方块标签中。
- Fixed #1587