### PR TITLE
Fixed the crafting table recipe of Empty Capacitor item, Fixed brass and bronze recipes

### DIFF
--- a/src/generated/resources/data/anvilcraft/advancement/recipe/super_heating/brass_ingot.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/super_heating/brass_ingot.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:super_heating/brass_ingot"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:super_heating/brass_ingot"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/super_heating/bronze_ingot.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/super_heating/bronze_ingot.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:super_heating/bronze_ingot"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:super_heating/bronze_ingot"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/misc/capacitor_empty.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/misc/capacitor_empty.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_copper_plates": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#c:plates/copper"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_resin": {
+      "conditions": {
+        "items": [
+          {
+            "items": "anvilcraft:resin"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:capacitor_empty"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_copper_plates",
+      "has_resin"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:capacitor_empty"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/recipe/capacitor_empty.json
+++ b/src/generated/resources/data/anvilcraft/recipe/capacitor_empty.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "A": {
+      "tag": "c:plates/copper"
+    },
+    "B": {
+      "item": "anvilcraft:resin"
+    }
+  },
+  "pattern": [
+    "A",
+    "B",
+    "A"
+  ],
+  "result": {
+    "count": 1,
+    "id": "anvilcraft:capacitor_empty"
+  }
+}

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/brass_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/brass_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:brass_ingot"
+      "tag": "c:ingots/brass"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/bronze_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/bronze_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:bronze_ingot"
+      "tag": "c:ingots/bronze"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/lead_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/lead_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:lead_ingot"
+      "tag": "c:ingots/lead"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/silver_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/silver_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:silver_ingot"
+      "tag": "c:ingots/silver"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/tin_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/tin_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:tin_ingot"
+      "tag": "c:ingots/tin"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/titanium_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/titanium_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:titanium_ingot"
+      "tag": "c:ingots/titanium"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/tungsten_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/tungsten_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:tungsten_ingot"
+      "tag": "c:ingots/tungsten"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/uranium_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/uranium_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:uranium_ingot"
+      "tag": "c:ingots/uranium"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/stamping/zinc_pressure_plate.json
+++ b/src/generated/resources/data/anvilcraft/recipe/stamping/zinc_pressure_plate.json
@@ -2,7 +2,7 @@
   "type": "anvilcraft:stamping",
   "ingredients": [
     {
-      "item": "anvilcraft:zinc_ingot"
+      "tag": "c:ingots/zinc"
     }
   ],
   "results": [

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/brass_ingot.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/brass_ingot.json
@@ -1,0 +1,23 @@
+{
+  "type": "anvilcraft:super_heating",
+  "ingredients": [
+    {
+      "item": "minecraft:copper_ingot"
+    },
+    {
+      "item": "minecraft:copper_ingot"
+    },
+    {
+      "tag": "c:ingots/zinc"
+    }
+  ],
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 3,
+        "id": "anvilcraft:brass_ingot"
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/bronze_ingot.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/bronze_ingot.json
@@ -1,0 +1,23 @@
+{
+  "type": "anvilcraft:super_heating",
+  "ingredients": [
+    {
+      "item": "minecraft:copper_ingot"
+    },
+    {
+      "item": "minecraft:copper_ingot"
+    },
+    {
+      "tag": "c:ingots/tin"
+    }
+  ],
+  "results": [
+    {
+      "amount": 1.0,
+      "stack": {
+        "count": 3,
+        "id": "anvilcraft:bronze_ingot"
+      }
+    }
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/StampingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/StampingRecipeLoader.java
@@ -6,6 +6,8 @@ import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.init.ModItemTags;
 import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.recipe.anvil.StampingRecipe;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ItemLike;
 
@@ -14,15 +16,15 @@ public class StampingRecipeLoader {
         stamping(provider, Items.IRON_INGOT, Items.HEAVY_WEIGHTED_PRESSURE_PLATE);
         stamping(provider, Items.GOLD_INGOT, Items.LIGHT_WEIGHTED_PRESSURE_PLATE);
         stamping(provider, Items.COPPER_INGOT, ModBlocks.COPPER_PRESSURE_PLATE);
-        stamping(provider, ModItems.TUNGSTEN_INGOT, ModBlocks.TUNGSTEN_PRESSURE_PLATE);
-        stamping(provider, ModItems.TITANIUM_INGOT, ModBlocks.TITANIUM_PRESSURE_PLATE);
-        stamping(provider, ModItems.ZINC_INGOT, ModBlocks.ZINC_PRESSURE_PLATE);
-        stamping(provider, ModItems.TIN_INGOT, ModBlocks.TIN_PRESSURE_PLATE);
-        stamping(provider, ModItems.LEAD_INGOT, ModBlocks.LEAD_PRESSURE_PLATE);
-        stamping(provider, ModItems.SILVER_INGOT, ModBlocks.SILVER_PRESSURE_PLATE);
-        stamping(provider, ModItems.URANIUM_INGOT, ModBlocks.URANIUM_PRESSURE_PLATE);
-        stamping(provider, ModItems.BRONZE_INGOT, ModBlocks.BRONZE_PRESSURE_PLATE);
-        stamping(provider, ModItems.BRASS_INGOT, ModBlocks.BRASS_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.TUNGSTEN_INGOTS, ModBlocks.TUNGSTEN_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.TITANIUM_INGOTS, ModBlocks.TITANIUM_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.ZINC_INGOTS, ModBlocks.ZINC_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.TIN_INGOTS, ModBlocks.TIN_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.LEAD_INGOTS, ModBlocks.LEAD_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.SILVER_INGOTS, ModBlocks.SILVER_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.URANIUM_INGOTS, ModBlocks.URANIUM_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.BRONZE_INGOTS, ModBlocks.BRONZE_PRESSURE_PLATE);
+        stamping(provider, ModItemTags.BRASS_INGOTS, ModBlocks.BRASS_PRESSURE_PLATE);
         stamping(provider, Items.SNOWBALL, Items.SNOW);
         stamping(provider, Items.CHERRY_LEAVES, Items.PINK_PETALS);
         StampingRecipe.builder()
@@ -88,5 +90,12 @@ public class StampingRecipeLoader {
 
     private static void stamping(RegistrateRecipeProvider provider, ItemLike input, ItemLike result) {
         stamping(provider, input, result, 1);
+    }
+
+    private static void stamping(RegistrateRecipeProvider provider, TagKey<Item> input, ItemLike result) {
+        StampingRecipe.builder()
+            .requires(input)
+            .result(result, 1)
+            .save(provider);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/SuperHeatingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/SuperHeatingRecipeLoader.java
@@ -48,6 +48,18 @@ public class SuperHeatingRecipeLoader {
             .requires(ModItems.EMBER_METAL_INGOT)
             .result(new ItemStack(ModBlocks.EMBER_GLASS, 8))
             .save(provider);
+
+        SuperHeatingRecipe.builder()
+            .requires(Items.COPPER_INGOT, 2)
+            .requires(ModItemTags.ZINC_INGOTS)
+            .result(ModItems.BRASS_INGOT, 3)
+            .save(provider);
+        SuperHeatingRecipe.builder()
+            .requires(Items.COPPER_INGOT, 2)
+            .requires(ModItemTags.TIN_INGOTS)
+            .result(ModItems.BRONZE_INGOT, 3)
+            .save(provider);
+
         SuperHeatingRecipe.builder()
             .requires(ModItems.WOOD_FIBER, 2)
             .result(new ItemStack(Items.CHARCOAL))

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModItems.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModItems.java
@@ -606,6 +606,16 @@ public class ModItems {
         .model((ctx, provider) -> {
         })
         .tag(ModItemTags.CAPACITOR)
+        .recipe((ctx, provider) -> ShapedRecipeBuilder.shaped(
+                RecipeCategory.MISC, ctx.get())
+            .pattern("A")
+            .pattern("B")
+            .pattern("A")
+            .define('A', ModItemTags.COPPER_PLATES)
+            .define('B', ModItems.RESIN)
+            .unlockedBy("has_copper_plates", RegistrateRecipeProvider.has(ModItemTags.COPPER_PLATES))
+            .unlockedBy("has_resin", RegistrateRecipeProvider.has(ModItems.RESIN))
+            .save(provider))
         .register();
     public static final ItemEntry<Item> CHOCOLATE = REGISTRATE
         .item("chocolate", properties -> new Item(properties.food(ModFoods.CHOCOLATE)))


### PR DESCRIPTION
Fixed the crafting table recipe of Empty Capacitor item
修复了空的电容器没有工作台配方的问题
Fixed the brass and bronze recipes
修复了青铜和黄铜没有配方的问题
Modified metal ingots -> stamping -> pressure plates recipes to accept tags
让金属锭->冲压->压力板的配方可以接受物品标签作为输入了