### PR TITLE
Modify features about Chute 溜槽相关修改

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/ChuteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ChuteBlock.java
@@ -75,24 +75,28 @@ public class ChuteBlock extends BetterBaseEntityBlock implements HammerRotateBeh
     public static final VoxelShape AABB_W = Stream.of(
             Block.box(2, 8, 2, 14, 12, 14),
             Block.box(0, 4, 4, 12, 12, 12),
+            Block.box(-4, 4, 4, 12, 12, 12),
             Block.box(0, 12, 0, 16, 16, 16)
         ).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR))
         .get();
     public static final VoxelShape AABB_E = Stream.of(
             Block.box(2, 8, 2, 14, 12, 14),
             Block.box(4, 4, 4, 16, 12, 12),
+            Block.box(4, 4, 4, 20, 12, 12),
             Block.box(0, 12, 0, 16, 16, 16)
         ).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR))
         .get();
     public static final VoxelShape AABB_S = Stream.of(
             Block.box(2, 8, 2, 14, 12, 14),
             Block.box(4, 4, 4, 12, 12, 16),
+            Block.box(4, 4, 4, 12, 12, 20),
             Block.box(0, 12, 0, 16, 16, 16)
         ).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR))
         .get();
     public static final VoxelShape AABB_N = Stream.of(
             Block.box(2, 8, 2, 14, 12, 14),
             Block.box(4, 4, 0, 12, 12, 12),
+            Block.box(4, 4, -4, 12, 12, 12),
             Block.box(0, 12, 0, 16, 16, 16)
         ).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR))
         .get();
@@ -150,6 +154,7 @@ public class ChuteBlock extends BetterBaseEntityBlock implements HammerRotateBeh
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         Direction dir = context.getClickedFace().getOpposite();
+        if (context.getPlayer() != null && context.getPlayer().isShiftKeyDown()) dir = dir.getOpposite();
         Direction facing = dir.getAxis() == Direction.Axis.Y ? Direction.DOWN : dir;
         BlockState result = getState(context.getLevel(), context.getClickedPos(), facing);
         Player player = context.getPlayer();
@@ -225,18 +230,19 @@ public class ChuteBlock extends BetterBaseEntityBlock implements HammerRotateBeh
     }
 
     @Override
-    public VoxelShape getShape(
-        BlockState blockState,
-        BlockGetter blockGetter,
-        BlockPos blockPos,
-        CollisionContext collisionContext) {
-        return switch (blockState.getValue(FACING)) {
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext collisionContext) {
+        return switch (state.getValue(FACING)) {
             case NORTH -> AABB_N;
             case SOUTH -> AABB_S;
             case WEST -> AABB_W;
             case EAST -> AABB_E;
             default -> AABB;
         };
+    }
+
+    @Override
+    protected VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return this.getShape(state, level, pos, context);
     }
 
     @SuppressWarnings({"DuplicatedCode", "UnreachableCode"})

--- a/src/main/java/dev/dubhe/anvilcraft/block/MagneticChuteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/MagneticChuteBlock.java
@@ -61,17 +61,17 @@ public class MagneticChuteBlock extends BetterBaseEntityBlock implements HammerR
     public static final BooleanProperty ENABLED = BlockStateProperties.ENABLED;
 
     public static final VoxelShape SHAPE_UP =
-        Shapes.join(Block.box(4, 8, 4, 12, 16, 12), Block.box(0, 0, 0, 16, 8, 16), BooleanOp.OR);
+        Shapes.join(Block.box(4, 8, 4, 12, 20, 12), Block.box(0, 0, 0, 16, 8, 16), BooleanOp.OR);
     public static final VoxelShape SHAPE_DOWN =
-        Shapes.join(Block.box(4, 0, 4, 12, 8, 12), Block.box(0, 8, 0, 16, 16, 16), BooleanOp.OR);
+        Shapes.join(Block.box(4, -4, 4, 12, 8, 12), Block.box(0, 8, 0, 16, 16, 16), BooleanOp.OR);
     public static final VoxelShape SHAPE_W =
-        Shapes.join(Block.box(0, 4, 4, 8, 12, 12), Block.box(8, 0, 0, 16, 16, 16), BooleanOp.OR);
+        Shapes.join(Block.box(-4, 4, 4, 8, 12, 12), Block.box(8, 0, 0, 16, 16, 16), BooleanOp.OR);
     public static final VoxelShape SHAPE_E =
-        Shapes.join(Block.box(8, 4, 4, 16, 12, 12), Block.box(0, 0, 0, 8, 16, 16), BooleanOp.OR);
+        Shapes.join(Block.box(8, 4, 4, 20, 12, 12), Block.box(0, 0, 0, 8, 16, 16), BooleanOp.OR);
     public static final VoxelShape SHAPE_S =
-        Shapes.join(Block.box(4, 4, 8, 12, 12, 16), Block.box(0, 0, 0, 16, 16, 8), BooleanOp.OR);
+        Shapes.join(Block.box(4, 4, 8, 12, 12, 20), Block.box(0, 0, 0, 16, 16, 8), BooleanOp.OR);
     public static final VoxelShape SHAPE_N =
-        Shapes.join(Block.box(4, 4, 0, 12, 12, 8), Block.box(0, 0, 8, 16, 16, 16), BooleanOp.OR);
+        Shapes.join(Block.box(4, 4, -4, 12, 12, 8), Block.box(0, 0, 8, 16, 16, 16), BooleanOp.OR);
 
     /**
      * 溜槽方块
@@ -90,13 +90,8 @@ public class MagneticChuteBlock extends BetterBaseEntityBlock implements HammerR
     }
 
     @Override
-    public VoxelShape getShape(
-        BlockState blockState,
-        BlockGetter blockGetter,
-        BlockPos blockPos,
-        CollisionContext collisionContext
-    ) {
-        return switch (blockState.getValue(FACING)) {
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext collisionContext) {
+        return switch (state.getValue(FACING)) {
             case NORTH -> SHAPE_N;
             case SOUTH -> SHAPE_S;
             case WEST -> SHAPE_W;
@@ -104,6 +99,11 @@ public class MagneticChuteBlock extends BetterBaseEntityBlock implements HammerR
             case DOWN -> SHAPE_DOWN;
             case UP -> SHAPE_UP;
         };
+    }
+
+    @Override
+    protected VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return this.getShape(state, level, pos, context);
     }
 
     @Override
@@ -156,8 +156,8 @@ public class MagneticChuteBlock extends BetterBaseEntityBlock implements HammerR
         Level level = context.getLevel();
         BlockPos pos = context.getClickedPos();
         Player player = context.getPlayer();
-        Direction facing = context.getNearestLookingDirection();
-        if (context.getPlayer() != null && context.getPlayer().isShiftKeyDown()) {
+        Direction facing = context.getClickedFace().getOpposite();
+        if (player != null && player.isShiftKeyDown()) {
             facing = facing.getOpposite();
         }
         BlockState result = this.defaultBlockState()

--- a/src/main/java/dev/dubhe/anvilcraft/block/SimpleChuteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SimpleChuteBlock.java
@@ -66,18 +66,15 @@ public class SimpleChuteBlock
 
     public static final VoxelShape AABB = Block.box(2, 0, 2, 14, 12, 14);
     public static final VoxelShape AABB_TALL = Block.box(2, 0, 2, 14, 16, 14);
-    public static final VoxelShape AABB_N = Block.box(4, 4, 0, 12, 12, 12);
-    public static final VoxelShape AABB_TALL_N =
-        Shapes.join(Block.box(4, 4, 0, 12, 12, 12), Block.box(2, 8, 2, 14, 16, 14), BooleanOp.OR);
-    public static final VoxelShape AABB_E = Block.box(4, 4, 4, 16, 12, 12);
-    public static final VoxelShape AABB_TALL_E =
-        Shapes.join(Block.box(4, 4, 4, 16, 12, 12), Block.box(2, 8, 2, 14, 16, 14), BooleanOp.OR);
-    public static final VoxelShape AABB_S = Block.box(4, 4, 4, 12, 12, 16);
-    public static final VoxelShape AABB_TALL_S =
-        Shapes.join(Block.box(4, 4, 4, 12, 12, 16), Block.box(2, 8, 2, 14, 16, 14), BooleanOp.OR);
-    public static final VoxelShape AABB_W = Block.box(0, 4, 4, 12, 12, 12);
-    public static final VoxelShape AABB_TALL_W =
-        Shapes.join(Block.box(0, 4, 4, 12, 12, 12), Block.box(2, 8, 2, 14, 16, 14), BooleanOp.OR);
+    public static final VoxelShape AABB_TALL_BASE = Block.box(2, 8, 2, 14, 16, 14);
+    public static final VoxelShape AABB_N = Block.box(4, 4, -4, 12, 12, 12);
+    public static final VoxelShape AABB_TALL_N = Shapes.join(AABB_N, AABB_TALL_BASE, BooleanOp.OR);
+    public static final VoxelShape AABB_E = Block.box(4, 4, 4, 20, 12, 12);
+    public static final VoxelShape AABB_TALL_E = Shapes.join(AABB_E, AABB_TALL_BASE, BooleanOp.OR);
+    public static final VoxelShape AABB_S = Block.box(4, 4, 4, 12, 12, 20);
+    public static final VoxelShape AABB_TALL_S = Shapes.join(AABB_S, AABB_TALL_BASE, BooleanOp.OR);
+    public static final VoxelShape AABB_W = Block.box(-4, 4, 4, 12, 12, 12);
+    public static final VoxelShape AABB_TALL_W = Shapes.join(AABB_W, AABB_TALL_BASE, BooleanOp.OR);
 
     /**
      * @param properties 方块属性
@@ -198,13 +195,10 @@ public class SimpleChuteBlock
 
 
     @Override
-    public VoxelShape getShape(
-        BlockState blockState,
-        BlockGetter blockGetter,
-        BlockPos blockPos,
-        CollisionContext collisionContext) {
-        if (!blockState.getValue(TALL)) {
-            return switch (blockState.getValue(FACING)) {
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        Direction facing = state.getValue(FACING);
+        if (!state.getValue(TALL)) {
+            return switch (facing) {
                 case NORTH -> AABB_N;
                 case EAST -> AABB_E;
                 case SOUTH -> AABB_S;
@@ -212,7 +206,7 @@ public class SimpleChuteBlock
                 default -> AABB;
             };
         } else {
-            return switch (blockState.getValue(FACING)) {
+            return switch (facing) {
                 case NORTH -> AABB_TALL_N;
                 case EAST -> AABB_TALL_E;
                 case SOUTH -> AABB_TALL_S;
@@ -220,6 +214,11 @@ public class SimpleChuteBlock
                 default -> AABB_TALL;
             };
         }
+    }
+
+    @Override
+    protected VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return this.getShape(state, level, pos, context);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModBlocks.java
@@ -124,6 +124,7 @@ import dev.dubhe.anvilcraft.block.state.DirectionCube3x3PartHalf;
 import dev.dubhe.anvilcraft.block.state.Vertical3PartHalf;
 import dev.dubhe.anvilcraft.block.state.Vertical4PartHalf;
 import dev.dubhe.anvilcraft.data.AnvilCraftDatagen;
+import dev.dubhe.anvilcraft.item.ChuteBlockItem;
 import dev.dubhe.anvilcraft.item.CursedBlockItem;
 import dev.dubhe.anvilcraft.item.EndDustBlockItem;
 import dev.dubhe.anvilcraft.item.FlexibleMultiPartBlockItem;
@@ -1322,7 +1323,7 @@ public class ModBlocks {
         .initialProperties(() -> Blocks.IRON_BLOCK)
         .properties(BlockBehaviour.Properties::noOcclusion)
         .blockstate(BlockStatProviderUtil::none)
-        .item(BlockItem::new)
+        .item(ChuteBlockItem::new)
         .onRegister(blockItem -> Item.BY_BLOCK.put(ModBlocks.SIMPLE_CHUTE.get(), blockItem))
         .build()
         .tag(BlockTags.MINEABLE_WITH_PICKAXE)
@@ -1343,7 +1344,7 @@ public class ModBlocks {
         .initialProperties(ModBlocks.CHUTE)
         .properties(BlockBehaviour.Properties::noOcclusion)
         .blockstate(BlockStatProviderUtil::none)
-        .item(BlockItem::new)
+        .item(ChuteBlockItem::new)
         .build()
         .tag(BlockTags.MINEABLE_WITH_PICKAXE)
         .recipe((ctx, provider) -> {

--- a/src/main/java/dev/dubhe/anvilcraft/item/ChuteBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ChuteBlockItem.java
@@ -1,0 +1,33 @@
+package dev.dubhe.anvilcraft.item;
+
+import dev.dubhe.anvilcraft.api.itemhandler.IItemHandlerHolder;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.capabilities.Capabilities;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class ChuteBlockItem extends BlockItem {
+    public ChuteBlockItem(Block block, Properties properties) {
+        super(block, properties);
+    }
+
+    @Override
+    public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
+        Level level = context.getLevel();
+        BlockPos pos = context.getClickedPos();
+        return level.getBlockEntity(pos) instanceof IItemHandlerHolder || level.getCapability(
+            Capabilities.ItemHandler.BLOCK, context.getClickedPos(), context.getClickedFace()
+        ) != null ? this.useOn(context) : super.onItemUseFirst(stack, context);
+    }
+}


### PR DESCRIPTION
- resolved #1683 
  - 现在尝试对着有方块实体的方块放置溜槽类方块时可以优先放置了
  - 现在按住shift放置溜槽时会反向放置了
  - 现在放置磁性溜槽时会对着点击面放置了（按住shift可反向放置）
- 修改了溜槽的形状，使其与模型同步（准心仍无法命中另一格内的部分）