### PR TITLE
Fix bugs about Ember Grindstone 修复余烬砂轮相关问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/inventory/EmberGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/EmberGrindstoneMenu.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.inventory;
 import com.google.common.collect.Collections2;
 import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
+import dev.dubhe.anvilcraft.util.EnchantmentUtil;
 import dev.dubhe.anvilcraft.util.ListUtil;
 import lombok.Getter;
 import net.minecraft.core.component.DataComponentType;
@@ -125,6 +126,7 @@ public class EmberGrindstoneMenu extends AbstractContainerMenu {
 
                 selectedIndex = -1;
 
+                resultBook.setItem(0, ItemStack.EMPTY);
             }
         });
         int i;
@@ -159,6 +161,7 @@ public class EmberGrindstoneMenu extends AbstractContainerMenu {
             entry -> new EnchantmentInstance(entry.getKey(), entry.getIntValue())));
         this.enchantments.removeIf(
             inst -> inst.enchantment.is(EnchantmentTags.CURSE));
+        this.enchantments.sort(EnchantmentUtil::compareEnchantmentInstance);
     }
 
     public int getCost() {

--- a/src/main/java/dev/dubhe/anvilcraft/util/EnchantmentUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/EnchantmentUtil.java
@@ -1,4 +1,21 @@
 package dev.dubhe.anvilcraft.util;
 
+import net.minecraft.core.Holder;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
+
+import java.util.Comparator;
+
 public class EnchantmentUtil {
+    public static int compareEnchantmentHolder(Holder<Enchantment> o1, Holder<Enchantment> o2) {
+        return o1.getRegisteredName().compareTo(o2.getRegisteredName());
+    }
+
+    public static int compareEnchantmentInstance(EnchantmentInstance o1, EnchantmentInstance o2) {
+        if (o1.enchantment.equals(o2.enchantment)) {
+            return Comparator.<EnchantmentInstance>comparingInt(o -> o.level).compare(o1, o2);
+        } else {
+            return compareEnchantmentHolder(o1.enchantment, o2.enchantment);
+        }
+    }
 }


### PR DESCRIPTION
- 修复了余烬砂轮在取出一次附魔书后可以无限取出附魔书的问题
- 修复了余烬砂轮在某些情况下显示的附魔顺序与实际输出的顺序不一致的问题