### PR TITLE
Fix a bug about Cogwheel Amulet 修复齿轮护符在原材料tab里出现的问题

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,10 +39,10 @@ dependencies {
     compileOnly(libs.kubejs)
 
     // Create
-    compileOnly(libs.create) { transitive = false }
-    compileOnly(libs.ponder)
-    compileOnly(libs.flywheelApi)
-    compileOnly(libs.flywheel)
+    implementation(libs.create) { transitive = false }
+    implementation(libs.ponder)
+    implementation(libs.flywheelApi)
+    implementation(libs.flywheel)
 
 //    compileOnly("org.sinytra.forgified-fabric-api:fabric-api-base:0.4.42+d1308ded19")
 //    compileOnly("org.sinytra.forgified-fabric-api:fabric-renderer-api-v1:3.4.0+acb05a3919")

--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -389,6 +389,7 @@
   "item.anvilcraft.cocoa_butter": "ɹǝʇʇnᗺ ɐoɔoƆ",
   "item.anvilcraft.cocoa_liquor": "ɹonbıꞀ ɐoɔoƆ",
   "item.anvilcraft.cocoa_powder": "ɹǝpʍoԀ ɐoɔoƆ",
+  "item.anvilcraft.cogwheel_amulet": "ʇǝןnɯⱯ ןǝǝɥʍboƆ",
   "item.anvilcraft.comrade_amulet": "ʇǝןnɯⱯ ǝpɐɹɯoƆ",
   "item.anvilcraft.comrade_amulet.tooltip": ":sɹǝʎɐןd pǝubıS",
   "item.anvilcraft.copper_nugget": "ʇǝbbnN ɹǝddoƆ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -389,6 +389,7 @@
   "item.anvilcraft.cocoa_butter": "Cocoa Butter",
   "item.anvilcraft.cocoa_liquor": "Cocoa Liquor",
   "item.anvilcraft.cocoa_powder": "Cocoa Powder",
+  "item.anvilcraft.cogwheel_amulet": "Cogwheel Amulet",
   "item.anvilcraft.comrade_amulet": "Comrade Amulet",
   "item.anvilcraft.comrade_amulet.tooltip": "Signed players:",
   "item.anvilcraft.copper_nugget": "Copper Nugget",

--- a/src/main/java/dev/dubhe/anvilcraft/integration/create/CreateIntegration.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/create/CreateIntegration.java
@@ -88,6 +88,7 @@ public class CreateIntegration {
     public static final ItemEntry<CogwheelAmuletItem> COGWHEEL_AMULET = REGISTRATE
         .item("cogwheel_amulet", CogwheelAmuletItem::new)
         .properties(properties -> properties.stacksTo(1))
+        .removeTab(ModItemGroups.ANVILCRAFT_INGREDIENTS.getKey())
         .recipe((ctx, provider) -> JewelCraftingRecipe.builder()
             .requires(ModItems.SILVER_INGOT, 1)
             .requires(AllItems.PRECISION_MECHANISM, 16)


### PR DESCRIPTION
- 现在齿轮护符不会出现在`铁砧工艺：原材料`创造物品栏中了
- 重新添加了齿轮护符的语言条目
- 将机械动力的前置类型改为implementation，以使齿轮护符不会在datagen时被移除相关条目