### PR TITLE
Fixed the bug that made chargers give wrong results

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/PiezoelectricCrystalBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/PiezoelectricCrystalBlock.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @MethodsReturnNonnullByDefault
 public class PiezoelectricCrystalBlock extends Block implements IHammerRemovable {
 
-    private static final Map<Block, List<Integer>> ANVIL_TYPES = new HashMap<>();
+    public static final Map<Block, List<Integer>> ANVIL_TYPES = new HashMap<>();
 
     static {
         ANVIL_TYPES.put(ModBlocks.SPECTRAL_ANVIL.get(), List.of(1, 2, 3, 4));

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ChargerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ChargerBlockEntity.java
@@ -122,7 +122,7 @@ public class ChargerBlockEntity extends BlockEntity
         if (isCharger) {
             itemHandler.setStackInSlot(1, stack);
         } else {
-            ItemStack transformed = recipe.getResult();
+            ItemStack transformed = recipe.getResult().copy();
             itemHandler.setStackInSlot(1, transformed);
         }
         timeLeft = recipe.time + 1; //since there is a "timeLeft--" after this, here +1 to negate
@@ -139,7 +139,7 @@ public class ChargerBlockEntity extends BlockEntity
         if (isCharger) {
             ChargerChargingRecipe recipe = getItemRecipe(stack);
             if (checkRecipeItemNotValid(recipe, stack)) return;
-            ItemStack transformed = recipe.getResult();
+            ItemStack transformed = recipe.getResult().copy();
             itemHandler.setStackInSlot(2, transformed);
         } else {
             itemHandler.setStackInSlot(2, stack);


### PR DESCRIPTION
Fixed the bug that made chargers give wrong results
修复了充放电器输出错误的问题
后面的人要记得，**ItemStack是引用传递的**，从配方的结果获取ItemStack的时候要加个.copy()
。另外，把压电晶体的ANVIL_TYPES改成了public来方便访问