### PR TITLE
Fix data component of items after reset repair cost in royal grindstone 修复皇家砂轮处理物品的物品组件问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -146,11 +146,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         goldUsed += removedRepairCost;
         goldUsable -= removedRepairCost;
         int remainRepairCost = repairCost - removedRepairCost;
-        if (remainRepairCost > 0) {
-            result.set(DataComponents.REPAIR_COST, remainRepairCost);
-        } else {
-            result.remove(DataComponents.REPAIR_COST);
-        }
+        result.set(DataComponents.REPAIR_COST, remainRepairCost);
         int removedCurseCount = 0;
         DataComponentType<ItemEnchantments> enchantmentComponent = result.is(Items.ENCHANTED_BOOK) ? DataComponents.STORED_ENCHANTMENTS : DataComponents.ENCHANTMENTS;
         ItemEnchantments enchantments = result.get(enchantmentComponent);


### PR DESCRIPTION
- 在此前的版本中，皇家砂轮将物品的附魔惩罚 （`repair_cost`）降低到0以后会在物品组件中留下字段`"!minecraft:repair_cost"`，这导致处理后的物品虽没有附魔惩罚，但`ItemStack#isSameItemSameComponents` 会将它与原始物品看作不同的物品，引起各种其他的问题。
- 将相关代码改为直接将附魔惩罚调整为0即可解决相关问题。