### PR TITLE
Fixed bug between vault and jewel crafting 修复宝库与珠宝台合成之间的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/mixin/VaultBlockEntityServerMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/VaultBlockEntityServerMixin.java
@@ -1,0 +1,24 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.vault.VaultBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(VaultBlockEntity.Server.class)
+public abstract class VaultBlockEntityServerMixin {
+    @WrapOperation(
+        method = "isValidToInsert",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/item/ItemStack;"
+                     + "isSameItemSameComponents("
+                     + "Lnet/minecraft/world/item/ItemStack;"
+                     + "Lnet/minecraft/world/item/ItemStack;)Z"))
+    private static boolean validKeyItemOnly(ItemStack stack, ItemStack other, Operation<Boolean> original) {
+        if (other.getComponentsPatch().isEmpty()) return stack.is(other.getItem());
+        return original.call(stack, other);
+    }
+}

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -37,6 +37,7 @@
     "ServerLevelMixin",
     "ServerPlayerMixin",
     "SkeletonMixin",
+    "VaultBlockEntityServerMixin",
     "VaultServerDataAccessor",
     "VibrationSystemUserMixin",
     "VillagerMixin",


### PR DESCRIPTION
- fixed #1841 
  - 现在宝库在钥匙为普通物品时不会检查components了