### PR TITLE
Fix position synchronization for ionocraft entity 修复与飘升机实体的位置同步相关的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
@@ -198,12 +198,6 @@ public class SimplePowerGrid {
 
     public boolean collideFast(AABB aabb) {
         for (PowerComponentInfo it : this.powerComponentInfoList) {
-//            if (new AABB(
-//                it.pos().offset(-it.range(), -it.range(), -it.range()).getCenter(),
-//                it.pos().offset(it.range(), it.range(), it.range()).getCenter()
-//            ).intersects(aabb)) {
-//                return true;
-//            }
             if (new AABB(it.pos()).inflate(it.range()).intersects(aabb)) return true;
         }
         return false;

--- a/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
@@ -198,12 +198,13 @@ public class SimplePowerGrid {
 
     public boolean collideFast(AABB aabb) {
         for (PowerComponentInfo it : this.powerComponentInfoList) {
-            if (new AABB(
-                it.pos().offset(-it.range(), -it.range(), -it.range()).getCenter(),
-                it.pos().offset(it.range(), it.range(), it.range()).getCenter()
-            ).intersects(aabb)) {
-                return true;
-            }
+//            if (new AABB(
+//                it.pos().offset(-it.range(), -it.range(), -it.range()).getCenter(),
+//                it.pos().offset(it.range(), it.range(), it.range()).getCenter()
+//            ).intersects(aabb)) {
+//                return true;
+//            }
+            if (new AABB(it.pos()).inflate(it.range()).intersects(aabb)) return true;
         }
         return false;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/IonocraftEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/IonocraftEntity.java
@@ -136,7 +136,6 @@ public class IonocraftEntity extends VehicleEntity {
     public void move(MoverType type, Vec3 motion) {
         super.move(type, motion);
         if (this.getDeltaMovement().y == 0) return;
-//        if (motion.x == 0 && motion.y == 0 && motion.z == 0) return;
         List<Entity> list = this.level().getEntities(
             this,
             this.getBoundingBox().expandTowards(0, 1F, 0),

--- a/src/main/java/dev/dubhe/anvilcraft/entity/IonocraftEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/IonocraftEntity.java
@@ -135,7 +135,8 @@ public class IonocraftEntity extends VehicleEntity {
     @Override
     public void move(MoverType type, Vec3 motion) {
         super.move(type, motion);
-        if (motion.x == 0 && motion.y == 0 && motion.z == 0) return;
+        if (this.getDeltaMovement().y == 0) return;
+//        if (motion.x == 0 && motion.y == 0 && motion.z == 0) return;
         List<Entity> list = this.level().getEntities(
             this,
             this.getBoundingBox().expandTowards(0, 1F, 0),


### PR DESCRIPTION
- 修复了 `SimplePowerGrid#collideFast` 方法执行逻辑与 `PowerGrid#collideFast` 方法不一致的问题，这修复了 #1843 中的部分问题。
- 将 `IonocraftEntity#move`方法中判断速度为0的部分改为判断碰撞后的速度，修复了玩家无法在电网外的落地的飘升机上无法起跳的问题。