### PR TITLE
Added support for modifying tag in root path (Entity data) in TagModification

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/recipe/transform/TagModification.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/transform/TagModification.java
@@ -73,7 +73,7 @@ public class TagModification implements Consumer<Tag> {
     @Override
     public void accept(Tag input) {
         String path = this.path;
-        if (op == ModifyOperation.SET) {
+        if (op == ModifyOperation.SET || op == ModifyOperation.ROOT_SET) {
             try {
                 int index = path.lastIndexOf('.');
                 path = this.path.substring(0, index == -1 ? path.length() : index);
@@ -155,6 +155,20 @@ public class TagModification implements Consumer<Tag> {
                     listTag.add(0, tag);
                 } else {
                     throw new RuntimeException("Expected list, got " + inputSrc.getAsString());
+                }
+            }
+        },
+        ROOT_SET {
+            @Override
+            public void accept(Tag inputSrc, Tag tag, int index, String key) {
+                if (inputSrc instanceof CompoundTag src && tag instanceof CompoundTag target) {
+                    src.merge(target);
+                } else {
+                    throw new RuntimeException("Expected Compound Tag, got "
+                        + inputSrc.getAsString()
+                        + " and "
+                        + tag.getAsString()
+                    );
                 }
             }
         };


### PR DESCRIPTION
Added support for modifying tag in root path (Entity data) in TagModification
让TagModification可以直接修改根目录（其实是Entity data）了。
样例 Sample：
给雪傀儡去掉南瓜头 Remove Pumpkin from a Snow Golem：
```java
.tagModification( b -> {
    CompoundTag tag = new CompoundTag();
    tag.putBoolean("Pumpkin", false);
    b.path("")
        .operation(TagModification.ModifyOperation.ROOT_SET)
        .value(tag);
})
```