### PR TITLE
Add content to Pachuli's manual 为帕秋莉手册增加内容

### DIFF
--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/basic_minerals.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/basic_minerals.json
@@ -1,0 +1,9 @@
+{
+  "name": "Basic Minerals",
+  "category": "anvilcraft:basic_gameplay",
+  "icon": "anvilcraft:void_stone",
+  "sortnum": 1001,
+  "pages": [
+    "No English now"
+    ]
+}

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/basic_minerals.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/basic_minerals.json
@@ -2,7 +2,7 @@
   "name": "Basic Minerals",
   "category": "anvilcraft:basic_gameplay",
   "icon": "anvilcraft:void_stone",
-  "sortnum": 1001,
+  "sortnum": 1006,
   "pages": [
     "No English now"
     ]

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/power_advanced_void_energy_collection.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/power_advanced_void_energy_collection.json
@@ -1,0 +1,9 @@
+{
+  "name": "Advanced Power Generation - Void Energy Collection",
+  "category": "anvilcraft:power_system",
+  "icon": "anvilcraft:void_energy_collector",
+  "sortnum": 2004,
+  "pages": [
+    "No English now"
+  ]
+}

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_item_processing.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_item_processing.json
@@ -78,7 +78,7 @@
     },
     {
       "type": "patchouli:multiblock",
-      "anchor": "item_sifting",
+      "anchor": "mesh",
       "name": "物品过筛",
       "multiblock": {
         "mapping": {

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_item_processing.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_item_processing.json
@@ -78,6 +78,7 @@
     },
     {
       "type": "patchouli:multiblock",
+      "anchor": "item_sifting",
       "name": "物品过筛",
       "multiblock": {
         "mapping": {

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_minerals.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_minerals.json
@@ -1,50 +1,44 @@
 {
   "name": "基本矿石",
   "category": "anvilcraft:basic_gameplay",
-  "icon": "anvilcraft:void_stone",
-  "sortnum": 1001,
+  "icon": "anvilcraft:earth_core_shard_ore",
+  "sortnum": 1006,
   "pages": [
-    "不同于大多数mod，正常情况下本模组的矿石不会自然生成，只能通过矿物泉涌得到。$(br)为了在前期获得本模组的金属，你需要使用类似于“无中生有”的方式——“$(l:basic_item_processing#item_sifting)物品过筛$()”。$(br)以此法获得的金属粒及其来源在后文列出。",
+    "不同于大多数mod，正常情况下本模组的矿石不会自然生成，只能通过矿物涌泉得到。$(br)为了在前期获得本模组的金属，你需要使用类似于“无中生有”的方式——“$(l:basic_item_processing#item_sifting)物品过筛$()”。$(br)以此法获得的金属粒及其来源在后文列出。",
     {
       "type": "patchouli:spotlight",
-      "anchor": "lead_nugget",
       "item": "anvilcraft:lead_nugget",
       "text": "$(item)铅粒$()通过筛选$(item)火山灰$()概率获得。"
     },
     {
       "type": "patchouli:spotlight",
-      "anchor": "tin_nugget",
       "item": "anvilcraft:tin_nugget",
       "text": "$(item)锡粒$()通过筛选$(item)火山灰$()概率获得。"
     },
     {
       "type": "patchouli:spotlight",
-      "anchor": "zinc_nugget",
       "item": "anvilcraft:zinc_nugget",
       "text": "$(item)锌粒$()通过筛选$(item)火山灰$()概率获得。"
     },
     {
       "type": "patchouli:spotlight",
-      "anchor": "silver_nugget",
       "item": "anvilcraft:silver_nugget",
       "text": "$(item)银粒$()通过筛选$(item)火山灰$()概率获得。"
     },
     {
       "type": "patchouli:spotlight",
-      "anchor": "tungsten_nugget",
       "item": "anvilcraft:tungsten_nugget",
       "text": "$(item)钨粒$()通过筛选$(item)下界尘$()概率获得。"
     },
     {
       "type": "patchouli:spotlight",
-      "anchor": "titanium_nugget",
       "item": "anvilcraft:titanium_nugget",
       "text": "$(item)钛粒$()通过筛选$(item)末地尘$()概率获得。"
     },
-    "在获得一定量的金属后，你可以通过$(#ffa500)时移$()将金属块转化为粗矿，并用粗矿块配合$(item)矿脉涌泉$()再生矿物。",
+    "在获得一定量的金属后，你可以通过$(l:smithing_corrupted_beacon#time_warp)时移$()将金属块转化为粗矿，并用粗矿块配合$(item)矿脉涌泉$()再生矿物。这要求你现阶段有能力制造$(item)腐化信标$()和$(item)冲击桩$()",
     {
       "type": "patchouli:multiblock",
-      "name": "矿物涌泉结构",
+      "name": "矿物涌泉产矿",
       "multiblock": {
         "mapping": {
           "A": "minecraft:deepslate",
@@ -61,6 +55,75 @@
       },
       "text": "这种结构下的$(item)矿物涌泉$()可以生成矿石"
     },
-    "$(item)矿物涌泉$()每秒检测四个面相邻方块，如果它们都是某一种粗矿块，则将$(item)深板岩$()转化为对应的深层矿。$(br)在主世界生成时，有1%概率生成$(item)地核碎片矿石$()，有1%的概率生成$(item)虚空石$()。$(br)在下界生成时，有20%概率生成$(item)地核碎片矿石$()。$(br)在末地生成时，有20%的概率生成$(item)虚空石$()。$(br)$(#aa2222)注意$()：宝石不能以这种方式再生，仅接受粗矿块。"
+    "$(item)矿物涌泉$()每秒检测四个面相邻方块，如果它们都是某一种粗矿块，则将$(item)深板岩$()转化为对应的深层矿。$(br)在主世界生成时，有1%概率生成$(item)地核碎片矿石$()，有1%概率生成$(item)虚空石$()。$(br)在下界生成时，有20%概率生成$(item)地核碎片矿石$()。$(br)在末地生成时，有20%概率生成$(item)虚空石$()。$(br)$(#aa2222)注意$()：宝石不能以这种方式再生，仅接受粗矿块。$(br)$(#aa2222)注意$()：矿物涌泉仅在y=-54及以下位置工作",
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "earth_core_shard_ore",
+      "item": "anvilcraft:earth_core_shard_ore",
+      "text": "$(item)地核碎片矿石$()只能通过$(thing)矿物涌泉产矿$()伴生$(br)受到$(thing)时运$()与$(thing)精准采集$()影响$(br)需要钻石镐及以上等级镐挖掘$(br)挖掘获得$(item)地核碎片$()"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "earth_core_shard",
+      "item": "anvilcraft:earth_core_shard",
+      "text": "$(item)地核碎片$()及其块状物、矿石防火，不受$(item)熔岩$()和$(item)火焰$()损害$(br)可参与$(l:smithing_tier_2_materials#ember_metal)余烬金属锭$()的制作"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "void_stone",
+      "item": "anvilcraft:void_stone",
+      "text": "$(item)虚空石$()只能通过$(thing)矿物涌泉产矿$()伴生$(br)受到$(thing)时运$()与$(thing)精准采集$()影响$(br)需要钻石镐及以上等级镐挖掘$(br)挖掘获得$(item)虚空物质$()"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "void_matter",
+      "item": "anvilcraft:void_matter",
+      "text": "$(item)虚空物质$()及其块状物、矿石防虚空，在$(thing)虚空$()中会上升"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "void_matter_block",
+      "item": "anvilcraft:void_matter_block",
+      "text": "$(item)虚空物质块$()防虚空<br>可用于制作$(l:power_advanced_void_energy_collection#void_energy_collector)虚空能收集器$()<br>自身具有$(thing)虚空衰变$()的特性"
+    },
+    {
+      "type": "patchouli:text",
+      "anchor": "void_decay",
+      "title": "虚空衰变",
+      "text": "$(item)虚空物质块$()周围6个面有至少5个面接触到$(item)虚空物质块$()时可以发生$(thing)虚空衰变$()：接收到$(thing)随机刻$()时，自身随机转化为以下方块：<br>石头、深板岩、安山岩、花岗岩、闪长岩、下界岩、黑石、末地石、冰、粗铁块、氧化的铜块、铁矿石、深层铁矿石、铜矿石、深层铜矿石、金矿石、深层金矿石、虚空石、末地尘、$(l:smithing_tier_1_materials#cursed_gold_block)诅咒金块$()、深层锡矿石、深层锌矿石、深层铅矿石、深层铀矿石"
+    },
+    "人工挖掘矿物并替换深板岩低效且劳累$(br)使用$(thing)激光采矿系统$()可以自动采集。",
+    {
+      "type": "patchouli:multiblock",
+      "name": "激光采矿系统",
+      "multiblock": {
+        "mapping": {
+          "A": "anvilcraft:deepslate_silver_ore",
+          "T": "anvilcraft:raw_silver_block",
+          "O": "anvilcraft:mineral_fountain",
+          "M": "anvilcraft:arrow",
+          "F": "anvilcraft:ruby_prism",
+          "W": "anvilcraft:ruby_laser[facing=west]",
+          "E": "anvilcraft:ruby_laser[facing=east]",
+          "N": "anvilcraft:ruby_laser[facing=north]",
+          "S": "anvilcraft:ruby_laser[facing=south]",
+          "C": "minecraft:barrel"
+        },
+        "pattern": [
+          ["   ", " C ", "   "],
+          [" E ", "SFN", " W "],
+          ["   ", "   ", "   "],
+          ["   ", "   ", "   "],
+          ["   ", " 0 ", "   "],
+          ["   ", "   ", "   "],
+          ["   ", " A ", "   "],
+          [" T ", "TMT", " T "]
+        ]
+      },
+      "text": "这种结构可以自动提取粗矿并存放至上方容器内,更多结构可以参考$(thing)5.5激光采矿机$()"
+    },
+    "$(item)棱镜$()和$(thing)矿石$()的高度差不能超过128$(br)提取到的物品会从$(item)棱镜$()上方弹出，或存入$(item)棱镜$()上方相邻的$(thing)容器$()$(br)提取效率=$(thing)激光等级$()/4(向下取整),$(thing)提取效率$()与$(thing)提取时间$()的关系如下：$(br)效率=1：24s/次$(br)效率=2：6s/次$(br)效率=3：2s/次$(br)效率=4：1s/次"
   ]
 }
+
+

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_minerals.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_minerals.json
@@ -1,0 +1,66 @@
+{
+  "name": "基本矿石",
+  "category": "anvilcraft:basic_gameplay",
+  "icon": "anvilcraft:void_stone",
+  "sortnum": 1001,
+  "pages": [
+    "不同于大多数mod，正常情况下本模组的矿石不会自然生成，只能通过矿物泉涌得到。$(br)为了在前期获得本模组的金属，你需要使用类似于“无中生有”的方式——“$(l:basic_item_processing#item_sifting)物品过筛$()”。$(br)以此法获得的金属粒及其来源在后文列出。",
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "lead_nugget",
+      "item": "anvilcraft:lead_nugget",
+      "text": "$(item)铅粒$()通过筛选$(item)火山灰$()概率获得。"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "tin_nugget",
+      "item": "anvilcraft:tin_nugget",
+      "text": "$(item)锡粒$()通过筛选$(item)火山灰$()概率获得。"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "zinc_nugget",
+      "item": "anvilcraft:zinc_nugget",
+      "text": "$(item)锌粒$()通过筛选$(item)火山灰$()概率获得。"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "silver_nugget",
+      "item": "anvilcraft:silver_nugget",
+      "text": "$(item)银粒$()通过筛选$(item)火山灰$()概率获得。"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "tungsten_nugget",
+      "item": "anvilcraft:tungsten_nugget",
+      "text": "$(item)钨粒$()通过筛选$(item)下界尘$()概率获得。"
+    },
+    {
+      "type": "patchouli:spotlight",
+      "anchor": "titanium_nugget",
+      "item": "anvilcraft:titanium_nugget",
+      "text": "$(item)钛粒$()通过筛选$(item)末地尘$()概率获得。"
+    },
+    "在获得一定量的金属后，你可以通过$(#ffa500)时移$()将金属块转化为粗矿，并用粗矿块配合$(item)矿脉涌泉$()再生矿物。",
+    {
+      "type": "patchouli:multiblock",
+      "name": "矿物涌泉结构",
+      "multiblock": {
+        "mapping": {
+          "A": "minecraft:deepslate",
+          "B": "anvilcraft:deepslate_silver_ore",
+          "T": "anvilcraft:raw_silver_block",
+          "O": "anvilcraft:mineral_fountain",
+          "0": "anvilcraft:arrow"
+        },
+        "pattern": [
+          ["       ", "       ", "       "],
+          ["       ", " B   A ", "       "],
+          [" T   T ", "TOT0TOT", " T   T "]
+        ]
+      },
+      "text": "这种结构下的$(item)矿物涌泉$()可以生成矿石"
+    },
+    "$(item)矿物涌泉$()每秒检测四个面相邻方块，如果它们都是某一种粗矿块，则将$(item)深板岩$()转化为对应的深层矿。$(br)在主世界生成时，有1%概率生成$(item)地核碎片矿石$()，有1%的概率生成$(item)虚空石$()。$(br)在下界生成时，有20%概率生成$(item)地核碎片矿石$()。$(br)在末地生成时，有20%的概率生成$(item)虚空石$()。$(br)$(#aa2222)注意$()：宝石不能以这种方式再生，仅接受粗矿块。"
+  ]
+}

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_minerals.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic_minerals.json
@@ -4,7 +4,7 @@
   "icon": "anvilcraft:earth_core_shard_ore",
   "sortnum": 1006,
   "pages": [
-    "不同于大多数mod，正常情况下本模组的矿石不会自然生成，只能通过矿物涌泉得到。$(br)为了在前期获得本模组的金属，你需要使用类似于“无中生有”的方式——“$(l:basic_item_processing#item_sifting)物品过筛$()”。$(br)以此法获得的金属粒及其来源在后文列出。",
+    "不同于大多数mod，正常情况下本模组的矿石不会自然生成，只能通过矿物涌泉得到。$(br)为了在前期获得本模组的金属，你需要使用类似于“无中生有”的方式——“$(l:basic_item_processing#mesh)物品过筛$()”。$(br)以此法获得的金属粒及其来源在后文列出。",
     {
       "type": "patchouli:spotlight",
       "item": "anvilcraft:lead_nugget",
@@ -81,9 +81,9 @@
       "text": "$(item)虚空物质$()及其块状物、矿石防虚空，在$(thing)虚空$()中会上升"
     },
     {
-      "type": "patchouli:spotlight",
+      "type": "patchouli:crafting",
       "anchor": "void_matter_block",
-      "item": "anvilcraft:void_matter_block",
+      "recipe": "anvilcraft:void_matter_block",
       "text": "$(item)虚空物质块$()防虚空<br>可用于制作$(l:power_advanced_void_energy_collection#void_energy_collector)虚空能收集器$()<br>自身具有$(thing)虚空衰变$()的特性"
     },
     {
@@ -100,8 +100,7 @@
         "mapping": {
           "A": "anvilcraft:deepslate_silver_ore",
           "T": "anvilcraft:raw_silver_block",
-          "O": "anvilcraft:mineral_fountain",
-          "M": "anvilcraft:arrow",
+          "M": "anvilcraft:mineral_fountain",
           "F": "anvilcraft:ruby_prism",
           "W": "anvilcraft:ruby_laser[facing=west]",
           "E": "anvilcraft:ruby_laser[facing=east]",

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/power_advanced_void_energy_collection.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/power_advanced_void_energy_collection.json
@@ -1,0 +1,48 @@
+{
+  "name": "高级发电-虚空能量收集",
+  "category": "anvilcraft:power_system",
+  "icon": "anvilcraft:void_energy_collector",
+  "sortnum": 2004,
+  "pages": [
+    "使用$(item)虚空能收集器$()来收集$(thing)非物质方块$()的虚空能。$(thing)非物质方块$()包括$(item)空气方块$()、$(item)虚空$()、$(l:basic_minerals#void_matter_block)虚空物质块$()、$(item)虚空能收集器$()和$(item)负物质块$()",
+    {
+      "type": "patchouli:crafting",
+      "anchor": "void_energy_collector",
+      "recipe": "anvilcraft:void_energy_collector",
+      "text": "$(item)虚空能收集器$()的默认发电功率为512KW。检测范围是以自己为中心5x5x5，范围内的$(thing)物质数$()决定了它的发电功率。周期默认为1秒。"
+    },
+    "$(item)虚空能收集器$()的检测范围不可重叠。其$(thing)发电量$()由$(thing)物质数$()决定。$(thing)物质数$()由检测范围内每一个$(thing)方块$()决定:<br>$(thing)物质方块$()使$(thing)物质数$()+1<br>$(item)负物质块$()使$(thing)物质数$()-1",
+    {
+      "type": "patchouli:text",
+      "title": "发电量-物质数关系",
+      "text": "$(thing)发电量$()和$(thing)物质数n$()关系如下:$(br)n≥21：0kW$(br)20≥n≥11：128kW$(br)10≥n≥3：256kW$(br)2≥n≥-10：512kW$(br)-11≥n≥-20：1024kW$(br)-21≥n≥-40：2048kW$(br)n<-40：4096kW"
+    },
+    {
+      "type": "patchouli:text",
+      "title": "产生物质方块",
+      "text": "每隔一段时间，$(item)虚空能收集器$()将检测范围内的一个$(item)空气方块$()转化为$(thing)物质方块$()，可能出现的方块与$(thing)虚空衰变$()一致。这些$(thing)物质方块$()会影响$(item)虚空能收集器$()发电。$(br)可以采取以下手段：<br>1.及时清理$(thing)物质方块$()<br>2.使用其他$(thing)非物质方块$()取代$(item)空气方块$()，需要注意$(l:basic_minerals#void_matter_block)虚空物质块$()的$(l:basic_minerals#void_decay)虚空衰变$()特性"
+    },
+    {
+      "type": "patchouli:multiblock",
+      "name": "产生物质方块",
+      "multiblock": {
+        "mapping": {
+          "A": "minecraft:andesite",
+          "B": "anvilcraft:cursed_gold_block",
+          "C": "anvilcraft:end_dust",
+          "O": "anvilcraft:void_matter_block",
+          "P": "anvilcraft:negative_matter_block",
+          "0": "anvilcraft:void_energy_collector"
+        },
+        "pattern": [
+          ["     ", "A    ", "     ", "     ", "C    "],
+          ["     ", "     ", " OOO ", "     ", "     "],
+          ["  C  ", "     ", " O0O ", "    B", "     "],
+          ["     ", "     ", " PPP ", "     ", "     "],
+          ["     ", "     ", "     ", "     ", "     "]
+        ]
+      },
+      "text": "如图：通过$(thing)非物质方块$()避免$(thing)物质方块$()生成在内圈，用任意自动挖掘手段破坏外圈的$(thing)物质方块$()，维护$(item)虚空能收集器$()的运行。"
+    }
+  ]
+}

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/smithing_corrupted_beacon.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/smithing_corrupted_beacon.json
@@ -11,6 +11,7 @@
     "生物转化：$(br)$(thing)猪$()→$(thing)疣猪兽$()$(br)$(thing)牛$()→$(thing)劫掠兽$()$(br)$(thing)守卫者$()→$(thing)远古守卫者$()$(br)$(thing)猪灵$()→$(thing)猪灵蛮兵$()$(br)$(thing)村民$()→30%$(thing)掠夺者$()、60%$(thing)卫道士$()、10%$(thing)唤魔者$()$(br)$(thing)悦灵$()→$(thing)恼鬼$()$(br)$(thing)蝙蝠$()→$(thing)幻翼$()$(br)$(thing)马$()→10%$(thing)僵尸马$()、90%$(thing)骷髅马$()$(br)$(thing)蠹虫$()→$(thing)末影螨$()",
     {
       "type": "patchouli:multiblock",
+      "anchor": "time_warp",
       "name": "时移",
       "multiblock": {
         "mapping": {

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/smithing_tier_1_materials.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/smithing_tier_1_materials.json
@@ -67,6 +67,7 @@
     },
     {
       "type": "patchouli:crafting",
+      "anchor": "cursed_gold_block",
       "recipe": "anvilcraft:cursed_gold_block",
       "recipe2": "anvilcraft:cursed_gold_nugget"
     },


### PR DESCRIPTION
为手册添加了两个新的章节：
    虚空发电机
    基础矿物：筛矿获得金属粒，矿物涌泉，激光提取矿物
在其他已存在章节设立锚点以供跳转。