### PR TITLE
Fix bug about entity blocks 修复实体方块对蜘蛛网等没有碰撞的方块的错误判断

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
 import org.jetbrains.annotations.NotNull;
 
 public class LevitatingBlockEntity extends FallingBlockEntity {
@@ -73,13 +74,13 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
                 this.discard();
             } else if (
                 this.level().getBlockState(blockPos.above()).isAir()
-                    || (this.level().getBlockState(blockPos).getBlock() instanceof Fallable
+                || this.level().getBlockState(blockPos.above()).getCollisionShape(this.level(), blockPos.above()).equals(Shapes.empty())
+                || (this.level().getBlockState(blockPos).getBlock() instanceof Fallable
                     || this.level().getBlockState(blockPos.above()).getBlock() instanceof Fallable
                     || !this.level().getEntitiesOfClass(
                     FallingBlockEntity.class,
                     new AABB(this.position(), this.position()).expandTowards(-0.2, 0, -0.2).expandTowards(0.2, 1.7, 0.2),
-                    entity -> !entity.equals(this) && entity.getBlockState().getBlock() instanceof Fallable).isEmpty()
-                )
+                    entity -> !entity.equals(this) && entity.getBlockState().getBlock() instanceof Fallable).isEmpty())
             ) {
                 this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
             } else {

--- a/src/main/java/dev/dubhe/anvilcraft/entity/StandableFallingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/StandableFallingBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -77,9 +78,7 @@ public class StandableFallingBlockEntity extends FallingBlockEntity {
 
             if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
                 this.discard();
-            } else if (FallingBlock.isFree(
-                this.level().getBlockState(new BlockPos(this.getBlockX(), (int) (this.getY() - 0.01), this.getBlockZ()))
-            )) {
+            } else if (isFree(this.level(), new BlockPos(this.getBlockX(), (int) (this.getY() - 0.01), this.getBlockZ()))) {
                 this.setDeltaMovement(this.getDeltaMovement().add(0.0, -0.04, 0.0));
             } else {
                 if (!this.level().isClientSide) {
@@ -136,7 +135,7 @@ public class StandableFallingBlockEntity extends FallingBlockEntity {
         if (motion.x == 0 && motion.y == 0 && motion.z == 0) return;
         List<Entity> list = this.level().getEntities(
             this,
-            this.getBoundingBox().expandTowards(0, 1F, 0),
+            this.getBoundingBox().move(0, 0.99F, 0),
             EntitySelector.pushableBy(this)
         );
         if (!list.isEmpty()) {
@@ -159,5 +158,10 @@ public class StandableFallingBlockEntity extends FallingBlockEntity {
     @Override
     public @NotNull EntityDimensions getDimensions(@NotNull Pose pose) {
         return EntityDimensions.scalable(0.98f, 0.98f);
+    }
+
+    static boolean isFree(Level level, BlockPos pos) {
+        return FallingBlock.isFree(level.getBlockState(pos))
+               || level.getBlockState(pos).getCollisionShape(level, pos).equals(Shapes.empty());
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/StandableLevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/StandableLevitatingBlockEntity.java
@@ -17,7 +17,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Fallable;
-import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
@@ -72,7 +71,7 @@ public class StandableLevitatingBlockEntity extends LevitatingBlockEntity {
 
             if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
                 this.discard();
-            } else if (FallingBlock.isFree(this.level().getBlockState(blockPos.above()))) {
+            } else if (StandableFallingBlockEntity.isFree(this.level(), blockPos.above())) {
                 this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
             } else {
                 if (!this.level().isClientSide) {


### PR DESCRIPTION
- fixed #1879
  - 现在漂浮粉块和可控沙不会在遇到蜘蛛网等没有碰撞的方块时尝试方块化了