### PR TITLE
Fix recipe bug with KubeJS 修复与KubeJS的配方问题

### DIFF
--- a/src/generated/resources/data/anvilcraft/recipe/jewel_crafting/cogwheel_amulet.json
+++ b/src/generated/resources/data/anvilcraft/recipe/jewel_crafting/cogwheel_amulet.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "create"
+    }
+  ],
   "type": "anvilcraft:jewel_crafting",
   "ingredients": [
     {

--- a/src/main/java/dev/dubhe/anvilcraft/integration/create/CreateIntegration.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/create/CreateIntegration.java
@@ -16,7 +16,6 @@ import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.init.ModDamageTypeTags;
 import dev.dubhe.anvilcraft.init.ModEntityTypeTags;
 import dev.dubhe.anvilcraft.init.ModItemGroups;
-import dev.dubhe.anvilcraft.init.ModItemTags;
 import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.init.ModRegistries;
 import dev.dubhe.anvilcraft.item.amulet.AmuletItem;
@@ -29,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.conditions.ModLoadedCondition;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -103,6 +103,7 @@ public class CreateIntegration {
         .properties(properties -> properties.stacksTo(1))
         .removeTab(ModItemGroups.ANVILCRAFT_INGREDIENTS.getKey())
         .recipe((ctx, provider) -> JewelCraftingRecipe.builder()
+            .withCondition(new ModLoadedCondition("create"))
             .requires(ModItems.SILVER_INGOT, 1)
             .requires(AllItems.PRECISION_MECHANISM, 16)
             .result(new ItemStack(ctx.get()))

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/JewelCraftingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/JewelCraftingRecipe.java
@@ -27,22 +27,27 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.conditions.ICondition;
 import org.jetbrains.annotations.Contract;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
 public class JewelCraftingRecipe implements Recipe<JewelCraftingRecipe.Input> {
+    public final List<ICondition> conditions;
     public final NonNullList<Ingredient> ingredients;
     public final ItemStack result;
     public final List<Object2IntMap.Entry<Ingredient>> mergedIngredients;
     public Input cache;
     public int cacheTimes;
 
-    public JewelCraftingRecipe(NonNullList<Ingredient> ingredients, ItemStack result) {
+    public JewelCraftingRecipe(List<ICondition> conditions, NonNullList<Ingredient> ingredients, ItemStack result) {
+        this.conditions = conditions;
         this.ingredients = ingredients;
         this.result = result;
         this.mergedIngredients = RecipeUtil.mergeIngredient(ingredients);
@@ -113,6 +118,7 @@ public class JewelCraftingRecipe implements Recipe<JewelCraftingRecipe.Input> {
     public static class Serializer implements RecipeSerializer<JewelCraftingRecipe> {
 
         private static final MapCodec<JewelCraftingRecipe> CODEC = RecordCodecBuilder.mapCodec(ins -> ins.group(
+            ICondition.LIST_CODEC.optionalFieldOf("neoforge:conditions", new ArrayList<>()).forGetter(JewelCraftingRecipe::getConditions),
             CodecUtil.createIngredientListCodec("ingredients", 256, "jewel_crafting").forGetter(JewelCraftingRecipe::getIngredients),
             ItemStack.CODEC.fieldOf("result").forGetter(JewelCraftingRecipe::getResult)
         ).apply(ins, JewelCraftingRecipe::new));
@@ -144,15 +150,21 @@ public class JewelCraftingRecipe implements Recipe<JewelCraftingRecipe.Input> {
             NonNullList<Ingredient> ingredients = NonNullList.withSize(size, Ingredient.EMPTY);
             ingredients.replaceAll(i -> Ingredient.CONTENTS_STREAM_CODEC.decode(buf));
             ItemStack result = ItemStack.STREAM_CODEC.decode(buf);
-            return new JewelCraftingRecipe(ingredients, result);
+            return new JewelCraftingRecipe(new ArrayList<>(), ingredients, result);
         }
     }
 
     @Setter
     @Accessors(fluent = true, chain = true)
     public static class Builder extends AbstractRecipeBuilder<JewelCraftingRecipe> {
+        private List<ICondition> conditions = new ArrayList<>();
         private NonNullList<Ingredient> ingredients = NonNullList.create();
         private ItemStack result = ItemStack.EMPTY;
+
+        public Builder withCondition(ICondition condition) {
+            this.conditions.add(condition);
+            return this;
+        }
 
         public Builder requires(Ingredient ingredient, int count) {
             for (int i = 0; i < count; i++) {
@@ -183,7 +195,7 @@ public class JewelCraftingRecipe implements Recipe<JewelCraftingRecipe.Input> {
 
         @Override
         public JewelCraftingRecipe buildRecipe() {
-            return new JewelCraftingRecipe(ingredients, result);
+            return new JewelCraftingRecipe(conditions, ingredients, result);
         }
 
         @Override


### PR DESCRIPTION
Fixed issue #1941 : Registering the ServerEvents.recipes callback in KubeJS would cause an error when the Create mod was not installed.

The cause of the issue was that the data file `data/anvilcraft/recipe/jewel_crafting/cogwheel_amulet.json` did not declare that it should only be active when Create is loaded. As a result, when Create was not installed, KubeJS still considered the recipe valid (even though it was actually invalid) and attempted to load it, triggering an error.

Since this data file was generated using datagen, this commit modifies two files related to amulet datagen.
It adds support for specifying the `neoforge:conditions` attribute for item recipes when registering amulet items.
By adding a `neoforge:mod_loaded` condition to the cogwheel amulet, this resolves issue #1941.

修复了在未安装联动模组机械动力的情况下，使用 Kubejs 注册 ServerEvents.recipes 事件回调将导致 Kubejs 报错的问题。（#1941）

导致该问题的原因是，数据文件 data/anvilcraft/recipe/jewel_crafting/cogwheel_amulet.json 未声明需要在机械动力加载时生效。因此在未安装机械动力时，Kubejs 仍认为该配方是有效的（实际上无效），故而尝试读取，引发报错。

由于该数据文件使用 datagen 生成，此次提交修改了有关护符 datagen 的两个文件。
使在注册护符物品时，可以声明该物品配方的 neoforge:conditions 属性。
通过给齿轮护符添加 neoforge:mod_loaded condition，即可解决 issue #1941

 Changes to be committed:
	modified:   src/generated/resources/data/anvilcraft/recipe/jewel_crafting/cogwheel_amulet.json
	modified:   src/main/java/dev/dubhe/anvilcraft/integration/create/CreateIntegration.java
	modified:   src/main/java/dev/dubhe/anvilcraft/recipe/JewelCraftingRecipe.java

fixed #1941 