### PR TITLE
Fix JEI display 修复JEI显示相关问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/MobTransformWithItemCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/MobTransformWithItemCategory.java
@@ -133,7 +133,7 @@ public class MobTransformWithItemCategory implements IRecipeCategory<RecipeHolde
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.CORRUPTED_BEACON), AnvilCraftJeiPlugin.MOB_TRANSFORM);
+        registration.addRecipeCatalyst(new ItemStack(ModBlocks.CORRUPTED_BEACON), AnvilCraftJeiPlugin.MOB_TRANSFORM_WITH_ITEM);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/MultipleToOneSmithingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/MultipleToOneSmithingCategory.java
@@ -46,13 +46,13 @@ public class MultipleToOneSmithingCategory implements
     private final IDrawable disabledSlotIcon;
     private final Component title;
 
-    private static final int CENTER_INPUT_X = 79;
+    private static final int CENTER_INPUT_X = 80;
     private static final int CENTER_INPUT_Y = 23;
     private static final int OUTPUT_X = 151;
     private static final int OUTPUT_Y = 35;
-    private static final int TEMPLATE_X = 7;
+    private static final int TEMPLATE_X = 8;
     private static final int TEMPLATE_Y = 35;
-    private static final int[] INPUT_X = {79, 79, 61, 97, 61, 97, 61, 97};
+    private static final int[] INPUT_X = {80, 80, 62, 98, 62, 98, 62, 98};
     private static final int[] INPUT_Y = {5, 41, 23, 23, 5, 5, 41, 41};
 
     public MultipleToOneSmithingCategory(IGuiHelper helper) {


### PR DESCRIPTION
- 修复了多合一锻造配方的JEI显示中物品的位置。

<img width="570" height="216" alt="image" src="https://github.com/user-attachments/assets/5956a7c6-37c3-4291-9d3b-b6b22b12c0ac" />

- 修复了生物的时移转化配方中工作方块显示不正确的问题。