### PR TITLE
Fixed bugs in the chute 修复溜槽的一些bugs

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -35,6 +35,7 @@ public class ItemHandlerUtil {
     ) {
         boolean success = false;
         Item filterItem = null;
+        boolean lockFilterItem = false;
         outerLoop:
         for (int srcIndex = 0; srcIndex < source.getSlots(); srcIndex++) {
             ItemStack sourceStack = source.extractItem(srcIndex, Integer.MAX_VALUE, true);
@@ -43,7 +44,6 @@ public class ItemHandlerUtil {
                 filterItem = sourceStack.getItem();
                 maxAmount = (int) (maxAmount / 64f * sourceStack.getMaxStackSize());
             } else if (sourceStack.getItem() != filterItem) continue;
-            boolean lockFilterItem = false;
             while (true) {
                 ItemStack remainder = ItemHandlerHelper.insertItem(target, sourceStack, true);
                 int amountToInsert = sourceStack.getCount() - remainder.getCount();

--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -47,6 +47,7 @@ public class ItemHandlerUtil {
             while (true) {
                 ItemStack remainder = ItemHandlerHelper.insertItem(target, sourceStack, true);
                 int amountToInsert = sourceStack.getCount() - remainder.getCount();
+                sourceStack = remainder;
                 if (amountToInsert > 0) {
                     ItemStack stack = source.extractItem(srcIndex, Math.min(maxAmount, amountToInsert), false);
                     ItemHandlerHelper.insertItem(target, stack, false);

--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -35,28 +35,28 @@ public class ItemHandlerUtil {
     ) {
         boolean success = false;
         Item filterItem = null;
+        outerLoop:
         for (int srcIndex = 0; srcIndex < source.getSlots(); srcIndex++) {
-            while (maxAmount > 0) {
-                ItemStack sourceStack = source.extractItem(srcIndex, Integer.MAX_VALUE, true);
-                if (sourceStack.isEmpty() || !predicate.test(sourceStack)) {
-                    break;
-                }
-                if (filterItem == null) {
-                    filterItem = sourceStack.getItem();
-                    maxAmount = maxAmount / 64 * sourceStack.getMaxStackSize(); //根据最大堆叠设置maxAmount 默认情况完全等于最大堆叠
-                }
-                if (sourceStack.getItem() != filterItem) break;
-
+            ItemStack sourceStack = source.extractItem(srcIndex, Integer.MAX_VALUE, true);
+            if (sourceStack.isEmpty() || !predicate.test(sourceStack)) continue;
+            if (filterItem == null) {
+                filterItem = sourceStack.getItem();
+                maxAmount = (int) (maxAmount / 64f * sourceStack.getMaxStackSize());
+            } else if (sourceStack.getItem() != filterItem) continue;
+            boolean lockFilterItem = false;
+            while (true) {
                 ItemStack remainder = ItemHandlerHelper.insertItem(target, sourceStack, true);
                 int amountToInsert = sourceStack.getCount() - remainder.getCount();
-
                 if (amountToInsert > 0) {
-                    sourceStack = source.extractItem(srcIndex, Math.min(maxAmount, amountToInsert), false);
-                    ItemHandlerHelper.insertItem(target, sourceStack, false);
+                    ItemStack stack = source.extractItem(srcIndex, Math.min(maxAmount, amountToInsert), false);
+                    ItemHandlerHelper.insertItem(target, stack, false);
                     success = true;
+                    lockFilterItem = true;
                     maxAmount -= amountToInsert;
+                    if (maxAmount <= 0) break outerLoop;
+                    if (remainder.getCount() == 0) break;
                 } else {
-                    filterItem = null;
+                    if (!lockFilterItem) filterItem = null;
                     break;
                 }
             }

--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -49,12 +49,14 @@ public class ItemHandlerUtil {
 
                 ItemStack remainder = ItemHandlerHelper.insertItem(target, sourceStack, true);
                 int amountToInsert = sourceStack.getCount() - remainder.getCount();
+
                 if (amountToInsert > 0) {
                     sourceStack = source.extractItem(srcIndex, Math.min(maxAmount, amountToInsert), false);
                     ItemHandlerHelper.insertItem(target, sourceStack, false);
                     success = true;
                     maxAmount -= amountToInsert;
                 } else {
+                    filterItem = null;
                     break;
                 }
             }

--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -36,24 +36,27 @@ public class ItemHandlerUtil {
         boolean success = false;
         Item filterItem = null;
         for (int srcIndex = 0; srcIndex < source.getSlots(); srcIndex++) {
-            ItemStack sourceStack = source.extractItem(srcIndex, Integer.MAX_VALUE, true);
-            if (sourceStack.isEmpty() || !predicate.test(sourceStack)) {
-                continue;
-            }
-            if (filterItem == null) {
-                filterItem = sourceStack.getItem();
-                maxAmount = maxAmount / 64 * sourceStack.getMaxStackSize(); //根据最大堆叠设置maxAmount 默认情况完全等于最大堆叠
-            }
-            if (sourceStack.getItem() != filterItem) continue;
+            while (maxAmount > 0) {
+                ItemStack sourceStack = source.extractItem(srcIndex, Integer.MAX_VALUE, true);
+                if (sourceStack.isEmpty() || !predicate.test(sourceStack)) {
+                    break;
+                }
+                if (filterItem == null) {
+                    filterItem = sourceStack.getItem();
+                    maxAmount = maxAmount / 64 * sourceStack.getMaxStackSize(); //根据最大堆叠设置maxAmount 默认情况完全等于最大堆叠
+                }
+                if (sourceStack.getItem() != filterItem) break;
 
-            ItemStack remainder = ItemHandlerHelper.insertItem(target, sourceStack, true);
-            int amountToInsert = sourceStack.getCount() - remainder.getCount();
-            if (amountToInsert > 0) {
-                sourceStack = source.extractItem(srcIndex, Math.min(maxAmount, amountToInsert), false);
-                ItemHandlerHelper.insertItem(target, sourceStack, false);
-                success = true;
-                maxAmount -= amountToInsert;
-                if (maxAmount <= 0) break;
+                ItemStack remainder = ItemHandlerHelper.insertItem(target, sourceStack, true);
+                int amountToInsert = sourceStack.getCount() - remainder.getCount();
+                if (amountToInsert > 0) {
+                    sourceStack = source.extractItem(srcIndex, Math.min(maxAmount, amountToInsert), false);
+                    ItemHandlerHelper.insertItem(target, sourceStack, false);
+                    success = true;
+                    maxAmount -= amountToInsert;
+                } else {
+                    break;
+                }
             }
         }
         return success;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
@@ -135,12 +135,12 @@ public abstract class BaseChuteBlockEntity
                 );
                 if (targetList != null && !targetList.isEmpty()) {
                     for (IItemHandler target : targetList) {
+                        BlockEntity targetBE = level.getBlockEntity(targetPos);
+                        boolean setChuteCD = targetBE != null && isTargetEmpty(targetBE);
                         boolean success = ItemHandlerUtil.exportToTarget(getItemHandler(), 64, stack -> true, target);
                         if (success) {
                             //特判溜槽cd7gt
-                            BlockEntity targetBE = level.getBlockEntity(targetPos);
-                            if (targetBE != null && isTargetEmpty(targetBE))
-                                setChuteCD(targetBE);
+                            if (setChuteCD) setChuteCD(targetBE);
                             resetCD = true;
                             break;
                         }


### PR DESCRIPTION
- 修复溜槽特判溜槽cd失效的bug，现在磁性溜槽接傻溜槽可以正常8gt输出物品
- fixed #1971 
现在溜槽和堆肥桶的交互应该是符合预期的，每次尽量往里输出一组物品，而不是像之前一样每一格都输出一个物品
- 修复第一格有无法输出的物品时，后面格子无法尝试输出的bug