### PR TITLE
Fix bugs about laser and amulet 修复激光与护符的相关问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/amulet/AmuletManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/amulet/AmuletManager.java
@@ -105,7 +105,7 @@ public class AmuletManager {
 
         if (raffleProbability > random.nextIntBetweenInclusive(0, 100)) {
             Optional<AmuletType> type = this.getTypeMatchedDamage(player, source, player.registryAccess()).map(Holder::value);
-            type.ifPresent(amuletType -> player.getInventory().placeItemBackInInventory(amuletType.amulet()));
+            type.ifPresent(amuletType -> player.getInventory().placeItemBackInInventory(amuletType.amulet().copy()));
 
             this.setRaffleProbability(player, source, value -> 20);
         } else {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
@@ -277,6 +277,7 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
         super.setRemoved();
         if (level == null) return;
         if (irradiateBlockPos == null) return;
+        if (!level.isLoaded(irradiateBlockPos)) return;
         if (!(level.getBlockEntity(irradiateBlockPos) instanceof BaseLaserBlockEntity irradiateBlockEntity)) return;
         irradiateBlockEntity.onCancelingIrradiation(this);
         if (level.isClientSide()) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/multipart/AbstractMultiPartBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/multipart/AbstractMultiPartBlock.java
@@ -115,8 +115,9 @@ public abstract class AbstractMultiPartBlock<P extends Enum<P>> extends Block im
     }
 
     public void removePartsAndUpdate(Level level, BlockPos pos) {
+        BlockState baseState = level.getBlockState(pos);
         for (P part : getParts()) {
-            BlockPos bp = pos.offset(this.offsetFrom(level.getBlockState(pos), part));
+            BlockPos bp = pos.offset(this.offsetFrom(baseState, part));
             BlockState blockState = level.getBlockState(bp);
             level.setBlock(bp, blockState.getFluidState().createLegacyBlock(), 3, 0);
         }

--- a/src/main/java/dev/dubhe/anvilcraft/util/predicate/DamageSourcePredicate.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/predicate/DamageSourcePredicate.java
@@ -78,7 +78,7 @@ public record DamageSourcePredicate(List<DamageSourceSubPredicate> subPredicates
                 && this.victimPredicate.get().matches(level, entity.position(), entity) == this.isOr
             ) {
                 return this.isOr == !this.isInverted;
-            } else if (this.murderPredicate.isPresent()
+            } else if (this.murderPredicate.isPresent() && source.getEntity() != null
                        && this.murderPredicate.get().matches(level, source.getEntity().position(), source.getEntity()) == this.isOr
             ) {
                 return this.isOr == !this.isInverted;

--- a/src/main/java/dev/dubhe/anvilcraft/util/predicate/DamageSourcePredicate.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/predicate/DamageSourcePredicate.java
@@ -3,22 +3,18 @@ package dev.dubhe.anvilcraft.util.predicate;
 import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import dev.dubhe.anvilcraft.init.ModItemTags;
 import net.minecraft.advancements.critereon.EntityTypePredicate;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.level.ItemLike;
-import net.minecraft.world.phys.Vec3;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,12 +27,12 @@ public record DamageSourcePredicate(List<DamageSourceSubPredicate> subPredicates
     ).apply(ins, DamageSourcePredicate::new));
 
     public boolean matches(ServerPlayer player, DamageSource source) {
-        return this.matches(player.serverLevel(), player.position(), source);
+        return this.matches(player.serverLevel(), player, source);
     }
 
-    public boolean matches(ServerLevel level, Vec3 position, DamageSource source) {
+    public boolean matches(ServerLevel level, Entity victim, DamageSource source) {
         for (DamageSourceSubPredicate subPredicate : this.subPredicates) {
-            if (subPredicate.matches(level, position, source) == this.isOr) {
+            if (subPredicate.matches(level, victim, source) == this.isOr) {
                 return this.isOr;
             }
         }
@@ -61,16 +57,16 @@ public record DamageSourcePredicate(List<DamageSourceSubPredicate> subPredicates
         ).apply(ins, DamageSourceSubPredicate::new));
 
         public boolean matches(ServerPlayer player, DamageSource source) {
-            return this.matches(player.serverLevel(), player.position(), source);
+            return this.matches(player.serverLevel(), player, source);
         }
 
-        public boolean matches(ServerLevel level, Vec3 position, DamageSource source) {
+        public boolean matches(ServerLevel level, Entity entity, DamageSource source) {
             if (this.typePredicate.isPresent() && this.typePredicate.get().test(source.typeHolder()) == this.isOr) {
                 return this.isOr == !this.isInverted;
             }
 
             if (this.isSameTeam.isPresent() && this.murderPredicate.isPresent() && this.victimPredicate.isPresent()
-                && source.getEntity() instanceof Player murder && source.getDirectEntity() instanceof Player victim
+                && source.getEntity() instanceof Player murder && entity instanceof Player victim
             ) {
                 boolean isSameTeam = Optional.ofNullable(victim.getTeam())
                     .map(team -> team.getPlayers().contains(murder.getScoreboardName()))
@@ -79,11 +75,11 @@ public record DamageSourcePredicate(List<DamageSourceSubPredicate> subPredicates
                     return this.isOr == !this.isInverted;
                 }
             } else if (this.victimPredicate.isPresent()
-                && this.victimPredicate.get().matches(level, position, source.getDirectEntity()) == this.isOr
+                && this.victimPredicate.get().matches(level, entity.position(), entity) == this.isOr
             ) {
                 return this.isOr == !this.isInverted;
             } else if (this.murderPredicate.isPresent()
-                       && this.murderPredicate.get().matches(level, position, source.getEntity()) == this.isOr
+                       && this.murderPredicate.get().matches(level, source.getEntity().position(), source.getEntity()) == this.isOr
             ) {
                 return this.isOr == !this.isInverted;
             } else if (this.weaponPredicate.isPresent()


### PR DESCRIPTION
- 修复了 #1972。
- fixed #1972
- 修复了护符在获取一次后，在游戏重启前无法再次获得的问题。
- 修复了护符获取的条件检查中，`victimPredicate`检查的并不是受伤实体的问题。
- 修复了 #1988。
- fixed #1988