### PR TITLE
Revert the modification of FallingSpectralBlockEntity to build.1138. 回退对幻灵实体的修改至build.1138

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
@@ -87,7 +87,7 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
         if (this.level().isClientSide) return;
         BlockPos current = this.blockPosition();
         BlockPos pos = this.blockPosition();
-        BlockPos below = new BlockPos(pos.getX(), (int) (pos.getY() - 0.04), pos.getZ());
+        BlockPos below = pos.below();
         BlockState blockStateDown = this.level().getBlockState(below);
         if (pos.getY() < -160) this.discard();
         if (!shouldIgnoreBlockInMovement(blockStateDown)) {


### PR DESCRIPTION
修了之后的幻灵问题比修之前还多，改回去先用着，不会写代码修不来qwq