### PR TITLE
Fixed End/Overworld Tp Crash 修复能显示电网框时从末地/主世界往返造成崩溃的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
@@ -260,8 +260,8 @@ public class SimplePowerGrid {
                 float size = it.range() * 2 + 1;
                 input.add(Shapes.create(AABB.ofSize(center, size, size, size)));
             }
-            Future<VoxelShape> future = ShapeUtil.threadedJoin(input, BooleanOp.OR, EXECUTOR);
             try {
+                Future<VoxelShape> future = ShapeUtil.threadedJoin(input, BooleanOp.OR, EXECUTOR);
                 VoxelShape shape = future.get();
                 List<Line> lines = new ArrayList<>();
                 shape.forAllEdges((minX, minY, minZ, maxX, maxY, maxZ) -> {


### PR DESCRIPTION
Fixed End/Overworld Tp Crash 修复~~手持铁砧锤~~能显示电网框时从末地/主世界往返造成崩溃的问题
Fixed #2129 
现在手持铁砧锤从末地和主世界往返不再会崩溃