### PR TITLE
Fix bug 修复珠宝台的快捷移动中无法全部移动时出现的物品复制

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/inventory/JewelCraftingMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/JewelCraftingMenu.java
@@ -136,6 +136,7 @@ public class JewelCraftingMenu extends AbstractContainerMenu {
                 return ItemStack.EMPTY;
             }
 
+            sourceStack.setCount(copyOfSourceStack.getCount());
             sourceSlot.onTake(player, copyOfSourceStack);
             if (index == RESULT_SLOT) {
                 player.drop(copyOfSourceStack, false);


### PR DESCRIPTION
在珠宝台的快捷移动实现中，源物品 部分移动 到目标栏时，没有更新源物品数量 导致的物品复制bug
修改中添加了对源物品数量的更新
联系邮箱： rangeset24@outlook.com