### PR TITLE
Fix tags for transcendence anvil and hammer 修复超限铁砧与超限铁砧锤相关问题

### DIFF
--- a/src/generated/resources/data/c/tags/item/tools/wrench.json
+++ b/src/generated/resources/data/c/tags/item/tools/wrench.json
@@ -1,7 +1,5 @@
 {
   "values": [
-    "anvilcraft:anvil_hammer",
-    "anvilcraft:royal_anvil_hammer",
-    "anvilcraft:ember_anvil_hammer"
+    "#anvilcraft:tools/anvil_hammer"
   ]
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/MagneticChuteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/MagneticChuteBlock.java
@@ -155,8 +155,8 @@ public class MagneticChuteBlock extends BetterBaseEntityBlock implements HammerR
         if (player != null && player.isShiftKeyDown()) facing = facing.getOpposite();
         BlockState neighborState = level.getBlockState(pos.relative(facing));
         boolean cannotPlace = facing == Direction.UP
-            && (neighborState.is(ModBlocks.SIMPLE_CHUTE) || neighborState.is(ModBlocks.CHUTE)
-            && neighborState.getValue(FACING_HOPPER) == Direction.DOWN);
+            && (neighborState.is(ModBlocks.SIMPLE_CHUTE) || neighborState.is(ModBlocks.CHUTE))
+            && neighborState.getValue(FACING_HOPPER) == Direction.DOWN;
         if (cannotPlace) {
             if (player != null)
                 player.displayClientMessage(Component.translatable("message.anvilcraft.chute.cannot_place"), true);

--- a/src/main/java/dev/dubhe/anvilcraft/block/PiezoelectricCrystalBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/PiezoelectricCrystalBlock.java
@@ -38,6 +38,7 @@ public class PiezoelectricCrystalBlock extends Block implements IHammerRemovable
         ANVIL_TYPES.put(Blocks.CHIPPED_ANVIL, List.of(1, 2, 4, 8));
         ANVIL_TYPES.put(Blocks.DAMAGED_ANVIL, List.of(1, 2, 4, 8));
         ANVIL_TYPES.put(ModBlocks.EMBER_ANVIL.get(), List.of(1, 2, 5, 12));
+        ANVIL_TYPES.put(ModBlocks.TRANSCENDENCE_ANVIL.get(), List.of(2, 5, 15, 60));
     }
 
     public static VoxelShape SHAPE =

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/ItemTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/ItemTagLoader.java
@@ -120,9 +120,7 @@ public class ItemTagLoader {
             .add(findResourceKey(Items.SWEET_BERRIES))
             .add(findResourceKey(Items.GLOW_BERRIES));
         provider.addTag(ModItemTags.WRENCH)
-            .add(ModItems.ANVIL_HAMMER.getKey())
-            .add(ModItems.ROYAL_ANVIL_HAMMER.getKey())
-            .add(ModItems.EMBER_ANVIL_HAMMER.getKey());
+            .addTag(ModItemTags.ANVIL_HAMMER);
         provider.addTag(ModItemTags.FIRE_STARTER)
             .add(findResourceKey(Items.TORCH))
             .add(findResourceKey(Items.SOUL_TORCH))

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -198,10 +198,10 @@ abstract class ItemEntityMixin extends Entity implements MergeCooldownItemEntity
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void anvilcraft$neutroniumTick(CallbackInfo ci) {
-        ItemEntity thiS = Util.cast(this);
+        ItemEntity thiz = Util.cast(this);
         ItemStack item = this.getItem();
         if (!item.is(ModItems.NEUTRONIUM_INGOT)) return;
-        if (item.onEntityItemUpdate(thiS)) {
+        if (item.onEntityItemUpdate(thiz)) {
             ci.cancel();
             return;
         }
@@ -266,7 +266,7 @@ abstract class ItemEntityMixin extends Entity implements MergeCooldownItemEntity
         }
         item = this.getItem();
         if (!this.level().isClientSide && this.age >= this.lifespan) {
-            this.lifespan = Mth.clamp(this.lifespan + EventHooks.onItemExpire(thiS), 0, 32766);
+            this.lifespan = Mth.clamp(this.lifespan + EventHooks.onItemExpire(thiz), 0, 32766);
             if (this.age >= this.lifespan) {
                 this.discard();
             }

--- a/src/main/java/dev/dubhe/anvilcraft/util/SpectralAnvilConversionUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/SpectralAnvilConversionUtil.java
@@ -15,6 +15,7 @@ public class SpectralAnvilConversionUtil {
         SPECTRAL_ANVIL_CONVERSION_CHANCE.put(Blocks.ANVIL, 0.03);
         SPECTRAL_ANVIL_CONVERSION_CHANCE.put(ModBlocks.ROYAL_ANVIL.get(), 0.5);
         SPECTRAL_ANVIL_CONVERSION_CHANCE.put(ModBlocks.EMBER_ANVIL.get(), 1.0);
+        SPECTRAL_ANVIL_CONVERSION_CHANCE.put(ModBlocks.TRANSCENDENCE_ANVIL.get(), 1.0);
     }
 
     public static double chance(Block block) {


### PR DESCRIPTION
- 修复了 #2153 。
    - 现在标签`#c:tools/wrench`直接包含`#anvilcraft:tools/anvil_hammer`。
- 修复了 #2155 。
- 实现了 #2184 。
- 修复了 #2169 。
- fixed #2153
- fixed #2155
- fixed #2169 
- resolved #2184