### PR TITLE
Optimized display 优化使用飘升机飞行时的电网功耗显示

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/item/IonoCraftBackpackItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/IonoCraftBackpackItem.java
@@ -168,7 +168,7 @@ public class IonoCraftBackpackItem extends ArmorItem implements IInventoryCarrie
                 instance.removeModifier(CREATIVE_FLIGHT);
             }
             return;
-        } else if (getFlightTime(equipped) >= AnvilCraft.config.ionoCraftBackpackMaxFlightTime) {
+        } else if (getFlightTime(equipped) >= AnvilCraft.config.ionoCraftBackpackMaxFlightTime && !player.getAbilities().flying) {
             powerComponent.getPowerConsumptions().remove(CONSUMPTION);
             return;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ServerPlayerMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ServerPlayerMixin.java
@@ -56,7 +56,7 @@ public abstract class ServerPlayerMixin extends Player implements IDynamicPowerC
     @Override
     public void anvilCraft$gridTick() {
         ItemStack stack = IonoCraftBackpackItem.getByPlayer(this);
-        if (IonoCraftBackpackItem.canModify(stack, this.anvilCraft$component)) {
+        if (IonoCraftBackpackItem.canModify(stack, this.anvilCraft$component) && IonoCraftBackpackItem.getFlightTime(stack) < AnvilCraft.config.ionoCraftBackpackMaxFlightTime) {
             IonoCraftBackpackItem.addFlightTime(stack, AnvilCraft.config.ionoCraftBackpackMaxFlightTime / 120);
         }
     }


### PR DESCRIPTION
原有飘升机在飞行状态时 电网的64供电时有时没 此次修改将原有移除 ` CONSUMPTION ` 的条件由 满电 改为 不在飞行状态且满电（ ` ServerPlayerMixin ` 的增加飞行时长中添加了判断是否满电的逻辑） 
稳定了电网功率显示 提升游戏体验