### PR TITLE
Hide IonoCraft Backpack HUD when F1 is pressed 使飘升机背包的能量显示UI能在F1下被隐藏

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/hud/IonoCraftBackpackHUD.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/hud/IonoCraftBackpackHUD.java
@@ -22,6 +22,7 @@ public class IonoCraftBackpackHUD {
             return;
         }
         Minecraft mc = Minecraft.getInstance();
+        if (mc.options.hideGui) return;
         LocalPlayer player = mc.player;
         if (player == null) {
             return;


### PR DESCRIPTION
让飘升机背包的能量显示能在F1下被隐藏

今天寻思开个播玩玩来着， 打算F1截个封面， 然后发现飘升机背包的那个能量显示明晃晃的
于是加了一行检测 提了个Pr（