### PR TITLE
Fixed fake item stacks in item collector poaching mode; Made inventory tick buffs server only.

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/entity/MagnetizedNodeEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/MagnetizedNodeEntity.java
@@ -67,7 +67,7 @@ public class MagnetizedNodeEntity extends Entity {
                 blockPos.getZ() + 1.01
         );
         level()
-                .getEntities(EntityType.ITEM, aabb, it -> ((AdsorbableItemEntity) it).isAdsorbable())
+                .getEntities(EntityType.ITEM, aabb, it -> ((AdsorbableItemEntity) it).anvilcraft$isAdsorbable())
                 .forEach(entity -> {
                     entity.teleportTo(position().x, position().y, position().z);
                     entity.setDeltaMovement(Vec3.ZERO);

--- a/src/main/java/dev/dubhe/anvilcraft/item/ICursed.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ICursed.java
@@ -24,6 +24,7 @@ public interface ICursed {
      */
     default void inventoryTick(ItemStack stack, Level level, Entity entity, int slotId, boolean isSelected) {
         if (!(entity instanceof Player player)) return;
+        if (level.isClientSide()) return;
         if (player.getAbilities().instabuild || player.getAbilities().invulnerable) return;
         MobEffectInstance weakness = new MobEffectInstance(MobEffects.WEAKNESS, 200, 1, false, true);
         MobEffectInstance slowness = new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 200, 1, false, true);

--- a/src/main/java/dev/dubhe/anvilcraft/item/LevitationPowderBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/LevitationPowderBlockItem.java
@@ -18,6 +18,7 @@ public class LevitationPowderBlockItem extends BlockItem implements ILevitationL
         @NotNull ItemStack stack, @NotNull Level level, @NotNull Entity entity, int slotId, boolean isSelected) {
         super.inventoryTick(stack, level, entity, slotId, isSelected);
         if (!(entity instanceof Player player)) return;
+        if (level.isClientSide()) return;
         this.addEffectToPlayer(player);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/item/LevitationPowderItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/LevitationPowderItem.java
@@ -17,6 +17,7 @@ public class LevitationPowderItem extends Item implements ILevitationLike<Levita
         @NotNull ItemStack stack, @NotNull Level level, @NotNull Entity entity, int slotId, boolean isSelected) {
         super.inventoryTick(stack, level, entity, slotId, isSelected);
         if (!(entity instanceof Player player)) return;
+        if (level.isClientSide()) return;
         this.addEffectToPlayer(player);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -393,7 +393,7 @@ abstract class ItemEntityMixin extends Entity implements MergeCooldownItemEntity
         ChunkPos chunkPos = this.chunkPosition();
         List<ItemCollectorBlockEntity> list = map.get(chunkPos);
         if (list == null || list.isEmpty()) return;
-        ItemStack itemStack = this.getItem();
+        ItemStack itemStack = this.getItem().copy();
         boolean flag = false;
         for (ItemCollectorBlockEntity collector : list) {
             if (collector.isGridWorking()
@@ -423,12 +423,12 @@ abstract class ItemEntityMixin extends Entity implements MergeCooldownItemEntity
     }
 
     @Override
-    public void setIsAdsorbable(boolean value) {
+    public void anvilcraft$setIsAdsorbable(boolean value) {
         this.anvilCraft$isAdsorbable = value;
     }
 
     @Override
-    public boolean isAdsorbable() {
+    public boolean anvilcraft$isAdsorbable() {
         return this.anvilCraft$isAdsorbable;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/AdsorbableItemEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/AdsorbableItemEntity.java
@@ -1,10 +1,10 @@
 package dev.dubhe.anvilcraft.util;
 
 public interface AdsorbableItemEntity {
-    default void setIsAdsorbable(boolean value) {
+    default void anvilcraft$setIsAdsorbable(boolean value) {
     }
 
-    default boolean isAdsorbable() {
+    default boolean anvilcraft$isAdsorbable() {
         return true;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/AnvilUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/AnvilUtil.java
@@ -121,7 +121,7 @@ public class AnvilUtil {
                 0.0d,
                 0.0d
             );
-            ((AdsorbableItemEntity) entity).setIsAdsorbable(false);
+            ((AdsorbableItemEntity) entity).anvilcraft$setIsAdsorbable(false);
             level.addFreshEntity(entity);
         }
     }


### PR DESCRIPTION
- Fixed fake item stacks in item collector poaching mode;
- 修复了#2082 的一半：不会再有假物品了。
- Made inventory tick buffs server only.
- 让物品栏给予buff的物品只在服务端给buff（从而与汇流来世的buff免疫类饰品兼容）。