### PR TITLE
Refactor integration system and add data integration support 重构集成系统并添加数据集成支持

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/Integration.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/Integration.java
@@ -6,4 +6,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface Integration {
     String value();
+
+    String version() default "*";
+
+    IntegrationType[] type() default {IntegrationType.CLIENT, IntegrationType.SERVER};
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationHook.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationHook.java
@@ -1,0 +1,11 @@
+package dev.dubhe.anvilcraft.api.integration;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+
+public class IntegrationHook {
+    @Getter
+    @Setter
+    private static GatherDataEvent event = null;
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationInstance.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationInstance.java
@@ -2,29 +2,39 @@ package dev.dubhe.anvilcraft.api.integration;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import net.neoforged.fml.loading.moddiscovery.ModInfo;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.List;
 import java.util.Objects;
 
 @Slf4j
 public final class IntegrationInstance {
     private final String modid;
+    private final ModVersionRange versionRange;
     private final String className;
+    private final List<IntegrationType> type;
     private Class<?> clazz;
     private Object instance;
     private MethodHandle constructor;
     private MethodHandle loader;
     private MethodHandle clientLoader;
+    private MethodHandle dataLoader;
 
     @SneakyThrows
     public IntegrationInstance(
         String modid,
-        String className
+        ModVersionRange versionRange,
+        String className,
+        List<IntegrationType> type
     ) {
         this.modid = modid;
+        this.versionRange = versionRange;
         this.className = className;
+        this.type = type;
     }
 
     @SneakyThrows
@@ -46,7 +56,13 @@ public final class IntegrationInstance {
                 loader = null;
             }
             this.clientLoader = loader;
-            if (this.loader == null && this.clientLoader == null) {
+            try {
+                loader = lookup.findVirtual(clazz, "applyData", MethodType.methodType(void.class));
+            } catch (Throwable e) {
+                loader = null;
+            }
+            this.dataLoader = loader;
+            if (this.loader == null && this.clientLoader == null && this.dataLoader == null) {
                 log.warn("Integration {} does not declare any loader method.", className);
             }
         }
@@ -67,6 +83,21 @@ public final class IntegrationInstance {
         if (clientLoader != null) {
             clientLoader.invoke(instance);
         }
+    }
+
+    @SneakyThrows
+    public void invokeData() {
+        if (dataLoader != null) {
+            dataLoader.invoke(instance);
+        }
+    }
+
+    public boolean containsType(IntegrationType type) {
+        return this.type.contains(type);
+    }
+
+    public boolean is(@NotNull ModInfo modInfo) {
+        return modid.equals(modInfo.getModId()) && versionRange.containsVersion(modInfo.getVersion());
     }
 
     public String modid() {

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationManager.java
@@ -5,19 +5,25 @@ import com.google.common.collect.MultimapBuilder;
 import lombok.extern.slf4j.Slf4j;
 import net.neoforged.fml.loading.LoadingModList;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
+import net.neoforged.fml.loading.moddiscovery.ModInfo;
+import net.neoforged.fml.loading.modscan.ModAnnotation;
 import net.neoforged.fml.loading.progress.ProgressMeter;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
 import net.neoforged.neoforgespi.language.ModFileScanData;
 
 import java.lang.annotation.ElementType;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 public class IntegrationManager {
-
     private final Multimap<String, IntegrationInstance> instances = MultimapBuilder.hashKeys().hashSetValues().build();
+    private final Multimap<String, IntegrationInstance> clientInstances = MultimapBuilder.hashKeys().hashSetValues().build();
+    private final Multimap<String, IntegrationInstance> dataInstances = MultimapBuilder.hashKeys().hashSetValues().build();
 
     public static final String INTEGRATION_NAME = "L" + Integration.class.getName().replace(".", "/") + ";";
 
+    @SuppressWarnings("UnstableApiUsage")
     public void compileContent() {
         ProgressMeter meter = StartupNotificationManager.addProgressBar("Load Integrations", LoadingModList.get().getModFiles().size());
         for (ModFileInfo modFile : LoadingModList.get().getModFiles()) {
@@ -26,47 +32,91 @@ public class IntegrationManager {
             for (ModFileScanData.AnnotationData annotation : scanData.getAnnotations()) {
                 if (annotation.annotationType().getDescriptor().equals(INTEGRATION_NAME) && annotation.targetType() == ElementType.TYPE) {
                     String modid = (String) annotation.annotationData().get("value");
-                    log.info("Considering integration {} for {}", annotation.memberName(), modid);
+                    String version = (String) annotation.annotationData().get("version");
+                    //noinspection unchecked
+                    List<ModAnnotation.EnumHolder> typeHolders = ((List<ModAnnotation.EnumHolder>) annotation.annotationData().get("type"));
+                    if (version == null) version = "*";
+                    List<IntegrationType> type = List.of(IntegrationType.SERVER, IntegrationType.CLIENT);
+                    if (typeHolders != null) {
+                        type = typeHolders.stream().map(
+                            holder -> switch (holder.value()) {
+                                case "SERVER" -> IntegrationType.SERVER;
+                                case "CLIENT" -> IntegrationType.CLIENT;
+                                case "DATA" -> IntegrationType.DATA;
+                                default -> throw new IllegalArgumentException("Unknown integration type: " + holder.value());
+                            }
+                        ).toList();
+                    }
+                    log.info("Considering integration {} for {id:{}, version:{}}", annotation.memberName(), modid, version);
                     IntegrationInstance instance = new IntegrationInstance(
                         modid,
-                        annotation.memberName()
+                        ModVersionRange.of(version),
+                        annotation.memberName(),
+                        type
                     );
-                    this.instances.put(modid, instance);
+                    if (instance.containsType(IntegrationType.SERVER)) {
+                        this.instances.put(modid, instance);
+                    }
+                    if (instance.containsType(IntegrationType.CLIENT)) {
+                        this.clientInstances.put(modid, instance);
+                    }
+                    if (instance.containsType(IntegrationType.DATA)) {
+                        this.dataInstances.put(modid, instance);
+                    }
                 }
             }
         }
         StartupNotificationManager.popBar(meter);
     }
 
-    public void load(String modid) {
+    @SuppressWarnings("DataFlowIssue")
+    public void load(String modid, ModInfo info) {
         for (IntegrationInstance instance : instances.get(modid)) {
+            if (!instance.is(info)) continue;
             instance.newInstance();
             log.info("Loading integration {} for {}.", instance.instance(), modid);
             instance.invoke();
         }
     }
 
-    public void loadClient(String modid) {
-        for (IntegrationInstance instance : instances.get(modid)) {
+    @SuppressWarnings("DataFlowIssue")
+    public void loadClient(String modid, ModInfo info) {
+        for (IntegrationInstance instance : clientInstances.get(modid)) {
+            if (!instance.is(info)) continue;
             instance.newInstance();
             log.info("Loading client integration {} for {}.", instance.instance(), modid);
             instance.invokeClient();
         }
     }
 
+    @SuppressWarnings("DataFlowIssue")
+    public void loadData(String modid, ModInfo info) {
+        for (IntegrationInstance instance : dataInstances.get(modid)) {
+            if (!instance.is(info)) continue;
+            instance.newInstance();
+            log.info("Loading data integration {} for {}.", instance.instance(), modid);
+            instance.invokeData();
+        }
+    }
+
     public void loadAllIntegrations() {
         for (String key : instances.keys()) {
-            if (LoadingModList.get().getMods().stream().anyMatch(it -> it.getModId().equals(key))) {
-                load(key);
-            }
+            Optional<ModInfo> info = LoadingModList.get().getMods().stream().filter(it -> it.getModId().equals(key)).findFirst();
+            info.ifPresent(modInfo -> load(key, modInfo));
         }
     }
 
     public void loadAllClientIntegrations() {
-        for (String key : instances.keys()) {
-            if (LoadingModList.get().getMods().stream().anyMatch(it -> it.getModId().equals(key))) {
-                loadClient(key);
-            }
+        for (String key : clientInstances.keys()) {
+            Optional<ModInfo> info = LoadingModList.get().getMods().stream().filter(it -> it.getModId().equals(key)).findFirst();
+            info.ifPresent(modInfo -> loadClient(key, modInfo));
+        }
+    }
+
+    public void loadAllDataIntegrations() {
+        for (String key : dataInstances.keys()) {
+            Optional<ModInfo> info = LoadingModList.get().getMods().stream().filter(it -> it.getModId().equals(key)).findFirst();
+            info.ifPresent(modInfo -> loadData(key, modInfo));
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationType.java
@@ -1,0 +1,7 @@
+package dev.dubhe.anvilcraft.api.integration;
+
+public enum IntegrationType {
+    CLIENT,
+    SERVER,
+    DATA
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/ModVersionRange.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/ModVersionRange.java
@@ -1,0 +1,49 @@
+package dev.dubhe.anvilcraft.api.integration;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+@Getter
+public class ModVersionRange {
+    public static final ModVersionRange ANY = new ModVersionRange(null) {
+        @Override
+        public boolean containsVersion(ArtifactVersion version) {
+            return true;
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return "*";
+        }
+    };
+    private final VersionRange range;
+
+    protected ModVersionRange(VersionRange range) {
+        this.range = range;
+    }
+
+    public static @NotNull ModVersionRange of(String spec) {
+        try {
+            if ("*".equals(spec)) return ModVersionRange.ANY;
+            return new ModVersionRange(VersionRange.createFromVersionSpec(spec));
+        } catch (InvalidVersionSpecificationException e) {
+            log.error("Invalid version specification: {}", spec);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    boolean containsVersion(ArtifactVersion version) {
+        return range == null || range.containsVersion(version);
+    }
+
+    @Override
+    public String toString() {
+        return range.toString();
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/data/AnvilCraftDatagen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/AnvilCraftDatagen.java
@@ -3,9 +3,9 @@ package dev.dubhe.anvilcraft.data;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateRecipeProvider;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.integration.IntegrationHook;
 import dev.dubhe.anvilcraft.data.advancement.AdvancementHandler;
 import dev.dubhe.anvilcraft.data.lang.LangHandler;
-import dev.dubhe.anvilcraft.data.provider.ModCuriosProvider;
 import dev.dubhe.anvilcraft.data.provider.ModDamageTypeProvider;
 import dev.dubhe.anvilcraft.data.provider.ModDamageTypeTagProvider;
 import dev.dubhe.anvilcraft.data.provider.ModFurnaceFuelProvider;
@@ -51,9 +51,11 @@ public class AnvilCraftDatagen {
         generator.addProvider(event.includeServer(), new ModFurnaceFuelProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new ModDamageTypeProvider(packOutput, lookupProvider));
         generator.addProvider(event.includeServer(), new ModDamageTypeTagProvider(packOutput, lookupProvider, existingFileHelper));
-        generator.addProvider(event.includeServer(), new ModCuriosProvider(packOutput, existingFileHelper, lookupProvider));
         generator.addProvider(event.includeServer(), new ModLootModifierProvider(packOutput, lookupProvider, AnvilCraft.MOD_ID));
         generator.addProvider(event.includeClient(), new ModParticleDescriptionProvider(packOutput, existingFileHelper));
+
+        IntegrationHook.setEvent(event);
+        AnvilCraft.getIntegrationManager().loadAllDataIntegrations();
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/integration/curios/data/CuriosData.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/curios/data/CuriosData.java
@@ -1,0 +1,25 @@
+package dev.dubhe.anvilcraft.integration.curios.data;
+
+import dev.dubhe.anvilcraft.api.integration.Integration;
+import dev.dubhe.anvilcraft.api.integration.IntegrationHook;
+import dev.dubhe.anvilcraft.api.integration.IntegrationType;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+
+import java.util.concurrent.CompletableFuture;
+
+@Integration(value = "curios", type = IntegrationType.DATA)
+public class CuriosData {
+    public void applyData() {
+        GatherDataEvent event = IntegrationHook.getEvent();
+        DataGenerator generator = event.getGenerator();
+        CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+        ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
+        PackOutput packOutput = generator.getPackOutput();
+
+        generator.addProvider(event.includeServer(), new ModCuriosProvider(packOutput, existingFileHelper, lookupProvider));
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/curios/data/ModCuriosProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/curios/data/ModCuriosProvider.java
@@ -1,4 +1,4 @@
-package dev.dubhe.anvilcraft.data.provider;
+package dev.dubhe.anvilcraft.integration.curios.data;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import net.minecraft.core.HolderLookup;


### PR DESCRIPTION
Introduces `IntegrationType` and `ModVersionRange` for more flexible integration handling, including support for `CLIENT`, `SERVER`, and `DATA` types. Refactors integration loading logic to support version ranges and data integrations, moving `Curios Data Provider` to a dedicated integration class, favor of dynamic data generation via the new integration system.

引入了 `IntegrationType` 和 `ModVersionRange` 以实现更灵活的集成处理，包括对 `CLIENT`、`SERVER` 和 `DATA` 类型的支持。重构了集成加载逻辑以支持版本范围和数据集成，将 `Curios Data Provider` 移至专门的集成类中，改为通过新的集成系统动态生成数据。