### PR TITLE
Fix bugs about sliding rail 使玩家可以放置四向普通滑轨，修复其它滑轨不可互相粘连的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.block.sliding;
 
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.block.entity.ActivatorSlidingRailBlockEntity;
+import dev.dubhe.anvilcraft.block.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
 import dev.dubhe.anvilcraft.init.ModBlockEntities;
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -15,7 +16,6 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class ActivatorSlidingRailBlock extends BaseSlidingRailBlock implements IHammerChangeable, EntityBlock {
+public class ActivatorSlidingRailBlock extends BaseSlidingRailBlock implements IHammerChangeable, IMoveableEntityBlock {
     public static final List<Direction> SIGNAL_SOURCE_SIDES = List.of(
         Direction.DOWN, Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST);
     public static final VoxelShape AABB_X = Stream.of(
@@ -218,11 +218,6 @@ public class ActivatorSlidingRailBlock extends BaseSlidingRailBlock implements I
     public boolean change(Player player, BlockPos blockPos, @NotNull Level level, ItemStack anvilHammer) {
         BlockState bs = level.getBlockState(blockPos);
         level.setBlockAndUpdate(blockPos, bs.cycle(FACING));
-        return true;
-    }
-
-    @Override
-    public boolean isStickyBlock(BlockState state) {
         return true;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/BaseSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/BaseSlidingRailBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.pathfinder.PathComputationType;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -64,7 +65,9 @@ public abstract class BaseSlidingRailBlock extends Block implements ISlidingRail
     @Override
     public boolean canStickTo(BlockPos pos, BlockState state, BlockPos otherPos, BlockState other) {
         if (otherPos.equals(pos.above())) return false;
-        if (!AnvilCraft.config.slidingRailStickToEachOther) return other.isStickyBlock();
+        if (!AnvilCraft.config.slidingRailStickToEachOther) {
+            return other.isStickyBlock() && !(other.getBlock() instanceof BaseSlidingRailBlock);
+        }
         if (!other.is(ModBlockTags.STICKABLE_WITH_SLIDING_RAILS)) return other.isStickyBlock();
         Direction.Axis axis = state.getOptionalValue(BlockStateProperties.AXIS)
             .or(() -> state.getOptionalValue(BlockStateProperties.FACING).map(Direction::getAxis))
@@ -72,15 +75,24 @@ public abstract class BaseSlidingRailBlock extends Block implements ISlidingRail
         Direction.Axis otherAxis = other.getOptionalValue(BlockStateProperties.AXIS)
             .or(() -> state.getOptionalValue(BlockStateProperties.FACING).map(Direction::getAxis))
             .orElse(null);
-        if (!Objects.equals(otherAxis, axis)) return false;
-        if (axis == null) {
-            return pos.relative(Direction.Axis.X, -1).equals(otherPos)
-                   || pos.relative(Direction.Axis.X, 1).equals(otherPos)
-                   || pos.relative(Direction.Axis.Y, -1).equals(otherPos)
-                   || pos.relative(Direction.Axis.Y, 1).equals(otherPos)
-                   || pos.relative(Direction.Axis.Z, -1).equals(otherPos)
-                   || pos.relative(Direction.Axis.Z, 1).equals(otherPos);
+        return this.canStickTo(pos, axis, otherPos, otherAxis);
+    }
+
+    private boolean canStickTo(
+        BlockPos pos, @Nullable Direction.Axis axis,
+        BlockPos otherPos, @Nullable Direction.Axis otherAxis
+    ) {
+        if (axis == Direction.Axis.Y || otherAxis == Direction.Axis.Y) return true;
+        boolean axisIsNotNull = axis != null;
+        if (Objects.equals(otherAxis, axis) && axisIsNotNull) {
+            return pos.relative(axis, -1).equals(otherPos) || pos.relative(axis, 1).equals(otherPos);
         }
-        return pos.relative(axis, -1).equals(otherPos) || pos.relative(axis, 1).equals(otherPos);
+        if (axisIsNotNull && otherAxis != null) return false;
+        return pos.relative(Direction.Axis.X, -1).equals(otherPos)
+               || pos.relative(Direction.Axis.X, 1).equals(otherPos)
+               || pos.relative(Direction.Axis.Y, -1).equals(otherPos)
+               || pos.relative(Direction.Axis.Y, 1).equals(otherPos)
+               || pos.relative(Direction.Axis.Z, -1).equals(otherPos)
+               || pos.relative(Direction.Axis.Z, 1).equals(otherPos);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/BaseSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/BaseSlidingRailBlock.java
@@ -57,6 +57,11 @@ public abstract class BaseSlidingRailBlock extends Block implements ISlidingRail
     }
 
     @Override
+    public boolean isStickyBlock(BlockState state) {
+        return true;
+    }
+
+    @Override
     public boolean canStickTo(BlockPos pos, BlockState state, BlockPos otherPos, BlockState other) {
         if (otherPos.equals(pos.above())) return false;
         if (!AnvilCraft.config.slidingRailStickToEachOther) return other.isStickyBlock();

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
@@ -144,11 +144,6 @@ public class DetectorSlidingRailBlock extends BaseSlidingRailBlock implements IH
     }
 
     @Override
-    public boolean isStickyBlock(BlockState state) {
-        return true;
-    }
-
-    @Override
     public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
         return FACING;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailBlock.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.block.sliding;
 
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction.Axis;
@@ -134,8 +135,19 @@ public class SlidingRailBlock extends BaseSlidingRailBlock implements IHammerCha
 
     private TriState isOtherRailInAxis(Level level, BlockPos pos, Axis axis, int relative) {
         BlockState other = level.getBlockState(pos.relative(axis, relative));
-        if (!(other.getBlock() instanceof SlidingRailBlock)) return TriState.DEFAULT;
-        return axis.equals(other.getValue(AXIS)) ? TriState.TRUE : TriState.FALSE;
+        Axis otherAxis;
+        if (other.getBlock() instanceof SlidingRailBlock) {
+            otherAxis = other.getValue(AXIS);
+        } else if (other.getBlock() instanceof PoweredSlidingRailBlock) {
+            otherAxis = other.getValue(PoweredSlidingRailBlock.FACING).getAxis();
+        } else if (other.getBlock() instanceof ActivatorSlidingRailBlock) {
+            otherAxis = other.getValue(ActivatorSlidingRailBlock.FACING).getAxis();
+        } else if (other.getBlock() instanceof DetectorSlidingRailBlock) {
+            otherAxis = other.getValue(DetectorSlidingRailBlock.FACING).getAxis();
+        } else {
+            return TriState.DEFAULT;
+        }
+        return axis == otherAxis || otherAxis == Axis.Y ? TriState.TRUE : TriState.FALSE;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.neoforge.common.util.TriState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -60,8 +61,15 @@ public class SlidingRailBlock extends BaseSlidingRailBlock implements IHammerCha
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        return this.defaultBlockState()
-            .setValue(AXIS, context.getHorizontalDirection().getOpposite().getAxis());
+        Axis axis = context.getHorizontalDirection().getOpposite().getAxis();
+        Level level = context.getLevel();
+        BlockPos pos = context.getClickedPos();
+        if ((isOtherRailInAxis(level, pos, Axis.X, -1) == TriState.TRUE
+             || isOtherRailInAxis(level, pos, Axis.X, 1) == TriState.TRUE)
+            && (isOtherRailInAxis(level, pos, Axis.Z, -1) == TriState.TRUE
+                || isOtherRailInAxis(level, pos, Axis.Z, 1) == TriState.TRUE)
+        ) axis = Axis.Y;
+        return this.defaultBlockState().setValue(AXIS, axis);
     }
 
     @Override
@@ -88,20 +96,52 @@ public class SlidingRailBlock extends BaseSlidingRailBlock implements IHammerCha
     ) {
         return switch (blockState.getValue(AXIS)) {
             case X -> AABB_X;
-            case Z -> AABB_Z;
             case Y -> AABB_Y;
+            case Z -> AABB_Z;
         };
+    }
+
+    @Override
+    protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos fromPos, boolean isMoving) {
+        if (isOtherRailInAxis(level, pos, Axis.X, -1) == TriState.TRUE
+            || isOtherRailInAxis(level, pos, Axis.X, 1) == TriState.TRUE
+        ) {
+            if (state.getValue(AXIS) != Axis.Y
+                && (isOtherRailInAxis(level, pos, Axis.Z, -1) == TriState.TRUE
+                    || isOtherRailInAxis(level, pos, Axis.Z, 1) == TriState.TRUE)
+            ) {
+                level.setBlockAndUpdate(pos, state.setValue(AXIS, Axis.Y));
+            }
+            if (state.getValue(AXIS) == Axis.Y
+                && isOtherRailInAxis(level, pos, Axis.Z, -1) != TriState.TRUE
+                && isOtherRailInAxis(level, pos, Axis.Z, 1) != TriState.TRUE
+            ) {
+                level.setBlockAndUpdate(pos, state.setValue(AXIS, Axis.X));
+            }
+        } else if (
+            isOtherRailInAxis(level, pos, Axis.Z, -1) == TriState.TRUE
+            || isOtherRailInAxis(level, pos, Axis.Z, 1) == TriState.TRUE
+        ) {
+            if (state.getValue(AXIS) == Axis.Y
+                && isOtherRailInAxis(level, pos, Axis.X, -1) != TriState.TRUE
+                && isOtherRailInAxis(level, pos, Axis.X, 1) != TriState.TRUE
+            ) {
+                level.setBlockAndUpdate(pos, state.setValue(AXIS, Axis.Z));
+            }
+        }
+        super.neighborChanged(state, level, pos, block, fromPos, isMoving);
+    }
+
+    private TriState isOtherRailInAxis(Level level, BlockPos pos, Axis axis, int relative) {
+        BlockState other = level.getBlockState(pos.relative(axis, relative));
+        if (!(other.getBlock() instanceof SlidingRailBlock)) return TriState.DEFAULT;
+        return axis.equals(other.getValue(AXIS)) ? TriState.TRUE : TriState.FALSE;
     }
 
     @Override
     public boolean change(Player player, BlockPos blockPos, @NotNull Level level, ItemStack anvilHammer) {
         BlockState bs = level.getBlockState(blockPos);
         level.setBlockAndUpdate(blockPos, bs.cycle(AXIS));
-        return true;
-    }
-
-    @Override
-    public boolean isStickyBlock(BlockState state) {
         return true;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModBlocks.java
@@ -1521,11 +1521,7 @@ public class ModBlocks {
     public static BlockEntry<SlidingRailStopBlock> SLIDING_RAIL_STOP = REGISTRATE
         .block("sliding_rail_stop", SlidingRailStopBlock::new)
         .initialProperties(() -> Blocks.IRON_BLOCK)
-        .properties(it -> it
-            .mapColor(MapColor.COLOR_GRAY)
-            .friction(0.8241758242f)
-            .pushReaction(PushReaction.PUSH_ONLY)
-        )
+        .properties(it -> it.mapColor(MapColor.COLOR_GRAY))
         .tag(BlockTags.MINEABLE_WITH_PICKAXE)
         .blockstate((ctx, provider) -> {
             provider.simpleBlock(ctx.get(), DangerUtil.genModModelFile("block/sliding_rail_stop").get());


### PR DESCRIPTION
- fixed #2282 
  - 现在可以按预期正常放置出四向滑轨了
  - 四向滑轨的放置条件为：
    - 在x轴上相邻的两个方块任意一个是滑轨且轴为x
    - 在z轴上相邻的两个方块任意一个是滑轨且轴为z
  - 当四向滑轨从满足所有条件变为只满足其一时会变为这其一检查的轴
    （也就是说完全不满足条件时更新它不会改变它的轴）
- 现在其它滑轨可以与普通滑轨正常粘连了
- 现在关闭滑轨互相粘连设置后滑轨不会互相粘连了