### PR TITLE
Modified the behavior of the gunpowder block and flint block 修改了火药块和燧石块的行为

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/FlintBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/FlintBlock.java
@@ -19,15 +19,23 @@ public class FlintBlock extends Block {
         super(properties);
     }
 
-    public static void ignite(LevelAccessor level, BlockPos pos) {
-        boolean relativeIsIronBlock = false;
+    public static void ignite(LevelAccessor level, BlockPos pos, boolean isFlint) {
+        boolean flag = false;
         for (Direction direction : Direction.values()) {
-            if (level.getBlockState(pos.relative(direction)).is(Blocks.IRON_BLOCK)) {
-                relativeIsIronBlock = true;
-                break;
+            BlockState blockState = level.getBlockState(pos.relative(direction));
+            if (isFlint) {
+                if (blockState.is(Blocks.IRON_BLOCK) || blockState.is(ModBlocks.HEAVY_IRON_BLOCK)) {
+                    flag = true;
+                    break;
+                }
+            } else {
+                if (blockState.is(ModBlocks.FLINT_BLOCK)) {
+                    flag = true;
+                    break;
+                }
             }
         }
-        if (relativeIsIronBlock) {
+        if (flag) {
             List<BlockPos> blocks = new ArrayList<>();
             for (int x = -1; x < 2; x++) {
                 for (int y = -1; y < 2; y++) {
@@ -64,7 +72,7 @@ public class FlintBlock extends Block {
     @Override
     protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
         if (movedByPiston) {
-            ignite(level, pos);
+            ignite(level, pos, true);
         }
     }
 
@@ -72,7 +80,7 @@ public class FlintBlock extends Block {
     protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
         super.onRemove(state, level, pos, newState, movedByPiston);
         if (movedByPiston) {
-            ignite(level, pos);
+            ignite(level, pos, true);
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/GunpowderBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/GunpowderBlock.java
@@ -1,14 +1,16 @@
 package dev.dubhe.anvilcraft.block;
 
+import dev.dubhe.anvilcraft.block.heatable.HeatableBlock;
+import dev.dubhe.anvilcraft.block.heatable.NormalBlock;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.sounds.SoundEvents;
+import net.minecraft.core.Direction;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -16,11 +18,14 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.ExplosionDamageCalculator;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.BaseFireBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -29,34 +34,10 @@ public class GunpowderBlock extends Block {
         super(properties);
     }
 
-    /**
-     * 不要把这个方法修改的和 {@link dev.dubhe.anvilcraft.block.GunpowderBlock#explosion(Level, BlockPos)} 方法一样，不然不会正常工作
-     */
-    public void onHit(Level level, BlockPos pos) {
-        level.setBlock(pos, Blocks.AIR.defaultBlockState(), 11);
-        level.explode(null,
-            null,
-            new ExplosionDamageCalculator() {
-                @Override
-                public Optional<Float> getBlockExplosionResistance(Explosion explosion, BlockGetter reader, BlockPos pos, BlockState state, FluidState fluid) {
-                    return Optional.of(Float.MAX_VALUE);
-                }
-
-                @Override
-                public boolean shouldDamageEntity(Explosion explosion, Entity entity) {
-                    return false;
-                }
-            },
-            pos.getX(),
-            pos.getY(),
-            pos.getZ(),
-            4.0F,
-            false,
-            Level.ExplosionInteraction.BLOCK
-        );
-    }
-
     public void explosion(Level level, BlockPos pos) {
+        if (level.isClientSide) {
+            return;
+        }
         level.setBlock(pos, Blocks.AIR.defaultBlockState(), 11);
         level.explode(null,
             null,
@@ -76,11 +57,7 @@ public class GunpowderBlock extends Block {
             pos.getZ(),
             4.0f,
             false,
-            Level.ExplosionInteraction.BLOCK,
-            true,
-            ParticleTypes.EXPLOSION,
-            ParticleTypes.EXPLOSION_EMITTER,
-            SoundEvents.GENERIC_EXPLODE);
+            Level.ExplosionInteraction.BLOCK);
     }
 
     @Override
@@ -97,5 +74,61 @@ public class GunpowderBlock extends Block {
             return ItemInteractionResult.sidedSuccess(level.isClientSide);
         }
         return super.useItemOn(stack, state, level, pos, player, hand, hitResult);
+    }
+
+    @Override
+    protected BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos pos, BlockPos neighborPos) {
+        if (!level.isClientSide()) {
+            BlockState block = level.getBlockState(pos.relative(direction));
+            if (block.getBlock() instanceof BaseFireBlock
+                || block.is(Blocks.LAVA)
+                || ((block.getBlock() instanceof HeatableBlock) && !(block.getBlock() instanceof NormalBlock))) {
+                explosion((Level) level, pos);
+            }
+        }
+        return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
+    }
+
+    @Override
+    protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
+        if (!level.isClientSide()) {
+            for (Direction direction : Direction.values()) {
+                BlockState block = level.getBlockState(pos.relative(direction));
+                if (block.getBlock() instanceof BaseFireBlock
+                    || block.is(Blocks.LAVA)
+                    || ((block.getBlock() instanceof HeatableBlock) && !(block.getBlock() instanceof NormalBlock))) {
+                    explosion(level, pos);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onCaughtFire(BlockState state, Level level, BlockPos pos, @Nullable Direction direction, @Nullable LivingEntity igniter) {
+        explosion(level, pos);
+    }
+
+    @Override
+    protected void onProjectileHit(Level level, BlockState state, BlockHitResult hit, Projectile projectile) {
+        if (level.isClientSide) {
+            return;
+        }
+        BlockPos pos = hit.getBlockPos();
+        if (projectile.isOnFire() && projectile.mayInteract(level, pos)) {
+            explosion(level, pos);
+        }
+    }
+
+    @Override
+    public void wasExploded(Level level, BlockPos pos, Explosion explosion) {
+        if (level.isClientSide) {
+            return;
+        }
+        explosion(level, pos);
+    }
+
+    @Override
+    public boolean canDropFromExplosion(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        return false;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitGunpowderBlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitGunpowderBlockEventListener.java
@@ -2,8 +2,10 @@ package dev.dubhe.anvilcraft.event.anvil;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.event.anvil.AnvilEvent;
+import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
 import dev.dubhe.anvilcraft.block.GunpowderBlock;
 import dev.dubhe.anvilcraft.entity.AnimateAscendingBlockEntity;
+import dev.dubhe.anvilcraft.init.ModBlocks;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -26,6 +28,33 @@ public class AnvilHitGunpowderBlockEventListener {
         final BlockPos hitPos = pos.below();
         final BlockState hitState = level.getBlockState(hitPos);
         if (hitState.getBlock() instanceof GunpowderBlock gunpowderBlock) {
+            gunpowderBlock.explosion(level, hitPos);
+            int distance = (int) Math.ceil(event.getFallDistance()) + 1;
+            BlockPos above = pos;
+            for (int i = 1; i < distance + 1; i++) {
+                above = above.above();
+                if (!level.getBlockState(above).isAir()) {
+                    break;
+                }
+            }
+            above = above.below();
+            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+            AnimateAscendingBlockEntity.animate(level, pos, blockState, above);
+            level.setBlockAndUpdate(above, blockState);
+        }
+    }
+
+    @SubscribeEvent
+    public static void anvilHammerHit(AnvilFallOnLandEvent event) {
+        Level level = event.getLevel();
+        final BlockPos pos = event.getPos();
+        final BlockState blockState = level.getBlockState(pos);
+        final BlockPos hitPos = pos.below();
+        final BlockState hitState = level.getBlockState(hitPos);
+        if (hitState.getBlock() instanceof GunpowderBlock gunpowderBlock) {
+            if (blockState.is(ModBlocks.GIANT_ANVIL)) {
+                return;
+            }
             gunpowderBlock.explosion(level, hitPos);
             int distance = (int) Math.ceil(event.getFallDistance()) + 1;
             BlockPos above = pos;

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitGunpowderBlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitGunpowderBlockEventListener.java
@@ -2,7 +2,6 @@ package dev.dubhe.anvilcraft.event.anvil;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.event.anvil.AnvilEvent;
-import dev.dubhe.anvilcraft.api.event.anvil.GiantAnvilFallOnLandEvent;
 import dev.dubhe.anvilcraft.block.GunpowderBlock;
 import dev.dubhe.anvilcraft.entity.AnimateAscendingBlockEntity;
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -21,30 +20,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class AnvilHitGunpowderBlockEventListener {
     @SubscribeEvent
     public static void onLand(AnvilEvent.OnLand event) {
-        Level level = event.getLevel();
-        final BlockPos pos = event.getPos();
-        final BlockState blockState = level.getBlockState(pos);
-        final BlockPos hitPos = pos.below();
-        final BlockState hitState = level.getBlockState(hitPos);
-        if (hitState.getBlock() instanceof GunpowderBlock gunpowderBlock) {
-            gunpowderBlock.explosion(level, hitPos);
-            int distance = (int) Math.ceil(event.getFallDistance()) + 1;
-            BlockPos above = pos;
-            for (int i = 1; i < distance + 1; i++) {
-                above = above.above();
-                if (!level.getBlockState(above).isAir()) {
-                    break;
-                }
-            }
-            above = above.below();
-            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
-            AnimateAscendingBlockEntity.animate(level, pos, blockState, above);
-            level.setBlockAndUpdate(above, blockState);
-        }
-    }
-
-    @SubscribeEvent
-    public static void giantAnvilOnLand(GiantAnvilFallOnLandEvent event) {
         Level level = event.getLevel();
         final BlockPos pos = event.getPos();
         final BlockState blockState = level.getBlockState(pos);

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitGunpowderBlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitGunpowderBlockEventListener.java
@@ -27,9 +27,8 @@ public class AnvilHitGunpowderBlockEventListener {
         final BlockPos hitPos = pos.below();
         final BlockState hitState = level.getBlockState(hitPos);
         if (hitState.getBlock() instanceof GunpowderBlock gunpowderBlock) {
-            gunpowderBlock.onHit(level, hitPos);
-            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
-            int distance = Math.round(event.getFallDistance());
+            gunpowderBlock.explosion(level, hitPos);
+            int distance = (int) Math.ceil(event.getFallDistance()) + 1;
             BlockPos above = pos;
             for (int i = 1; i < distance + 1; i++) {
                 above = above.above();
@@ -38,6 +37,7 @@ public class AnvilHitGunpowderBlockEventListener {
                 }
             }
             above = above.below();
+            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
             AnimateAscendingBlockEntity.animate(level, pos, blockState, above);
             level.setBlockAndUpdate(above, blockState);
         }
@@ -51,9 +51,8 @@ public class AnvilHitGunpowderBlockEventListener {
         final BlockPos hitPos = pos.below();
         final BlockState hitState = level.getBlockState(hitPos);
         if (hitState.getBlock() instanceof GunpowderBlock gunpowderBlock) {
-            gunpowderBlock.onHit(level, hitPos);
-            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
-            int distance = Math.round(event.getFallDistance());
+            gunpowderBlock.explosion(level, hitPos);
+            int distance = (int) Math.ceil(event.getFallDistance()) + 1;
             BlockPos above = pos;
             for (int i = 1; i < distance + 1; i++) {
                 above = above.above();
@@ -62,6 +61,7 @@ public class AnvilHitGunpowderBlockEventListener {
                 }
             }
             above = above.below();
+            level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
             AnimateAscendingBlockEntity.animate(level, pos, blockState, above);
             level.setBlockAndUpdate(above, blockState);
         }

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitSugarBlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilHitSugarBlockEventListener.java
@@ -2,7 +2,6 @@ package dev.dubhe.anvilcraft.event.anvil;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
-import dev.dubhe.anvilcraft.api.event.anvil.GiantAnvilFallOnLandEvent;
 import dev.dubhe.anvilcraft.block.SugarBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -14,17 +13,6 @@ import net.neoforged.fml.common.EventBusSubscriber;
 public class AnvilHitSugarBlockEventListener {
     @SubscribeEvent
     public static void onLand(AnvilFallOnLandEvent event) {
-        Level level = event.getLevel();
-        BlockPos pos = event.getPos();
-        BlockPos hitPos = pos.below();
-        BlockState hitState = level.getBlockState(hitPos);
-        if (hitState.getBlock() instanceof SugarBlock sugarBlock) {
-            sugarBlock.onHit(level, hitPos);
-        }
-    }
-
-    @SubscribeEvent
-    public static void giantAnvilOnLand(GiantAnvilFallOnLandEvent event) {
         Level level = event.getLevel();
         BlockPos pos = event.getPos();
         BlockPos hitPos = pos.below();

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/BlockBehaviourMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/BlockBehaviourMixin.java
@@ -1,0 +1,40 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import dev.dubhe.anvilcraft.block.FlintBlock;
+import dev.dubhe.anvilcraft.init.ModBlocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BlockBehaviour.class)
+abstract class BlockBehaviourMixin {
+    @Inject(
+        method = "onPlace",
+        at = @At("HEAD")
+    )
+    private void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston, CallbackInfo ci) {
+        if (state.is(Blocks.IRON_BLOCK) || state.is(ModBlocks.HEAVY_IRON_BLOCK)) {
+            if (movedByPiston) {
+                FlintBlock.ignite(level, pos, false);
+            }
+        }
+    }
+
+    @Inject(
+        method = "onRemove",
+        at = @At("RETURN")
+    )
+    private void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston, CallbackInfo ci) {
+        if (state.is(Blocks.IRON_BLOCK) || state.is(ModBlocks.HEAVY_IRON_BLOCK)) {
+            if (movedByPiston) {
+                FlintBlock.ignite(level, pos, false);
+            }
+        }
+    }
+}

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -8,6 +8,7 @@
     "AnvilMenuMixin",
     "AvoidEntityGoalMixin",
     "BeaconMenuMixin",
+    "BlockBehaviourMixin",
     "BlockMixin",
     "BlockStateMixin",
     "ComparatorBlockEntityMixin",


### PR DESCRIPTION
- 火药块的引爆条件
   - 被打火石右键时
   - 被烈焰弹右键时
   - 被着火的弹射物击中时
   - 被爆炸破坏时
   - 着火时
   - 周围有火、岩浆、高温方块
   - 被铁砧砸
   - 被铁砧锤砸
- 火药块被大铁砧砸时不处理（因为大铁砧的事件处理有点问题）
- 燧石块
   - 现在燧石块被活塞推动时旁边有铁块或重质铁块会尝试点火
   - 现在铁块或重质铁块被活塞推动时旁边有燧石块会尝试点火

- Fixed #2308 