### PR TITLE
Add ghost item handling function for filter screen 添加过滤器屏幕的幽灵物品处理功能

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/FilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/FilterScreen.java
@@ -18,9 +18,10 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
+import java.util.Collection;
 import java.util.Objects;
 
-public class FilterScreen extends AbstractContainerScreen<FilterMenu> {
+public class FilterScreen extends AbstractContainerScreen<FilterMenu> implements IGhostIngredientScreen {
     private static final ResourceLocation BACKGROUND_LOCATION = AnvilCraft.of("textures/gui/container/filter/background.png");
 
     private static final WidgetSprites INCLUDE_COMPONENTS = new WidgetSprites(
@@ -101,6 +102,18 @@ public class FilterScreen extends AbstractContainerScreen<FilterMenu> {
     }
 
     private void sync(Button button) {
+        this.getMenu().sync();
+    }
+
+    @Override
+    public Collection<Integer> getGhostSlots() {
+        return IGhostIngredientScreen.range(36, 54, 1);
+    }
+
+    @Override
+    public void acceptGhost(Slot slot, ItemStack filterStack) {
+        if (!(slot instanceof FilterSlot filterSlot)) return;
+        filterSlot.set(filterStack.copyWithCount(1));
         this.getMenu().sync();
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IFilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IFilterScreen.java
@@ -6,6 +6,8 @@ import dev.dubhe.anvilcraft.api.itemhandler.SlotItemHandlerWithFilter;
 import dev.dubhe.anvilcraft.client.gui.component.EnableFilterButton;
 import dev.dubhe.anvilcraft.inventory.IFilterMenu;
 import dev.dubhe.anvilcraft.network.MachineEnableFilterPacket;
+import dev.dubhe.anvilcraft.network.SlotDisableChangePacket;
+import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import dev.dubhe.anvilcraft.util.RenderHelper;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
@@ -15,12 +17,14 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.function.BiFunction;
 
 /**
  * 有过滤的 GUI
  */
-public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> {
+public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> extends IGhostIngredientScreen {
     ResourceLocation DISABLED_SLOT = AnvilCraft.of("textures/gui/container/machine/disabled_slot.png");
 
     T getFilterMenu();
@@ -157,5 +161,20 @@ public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> {
 
     default int getOffsetX() {
         return 0;
+    }
+
+    @Override
+    default Collection<Integer> getGhostSlots() {
+        if (!this.getFilterMenu().isFilterEnabled()) return List.of();
+        return IGhostIngredientScreen.range(36, 45, 1);
+    }
+
+    @Override
+    default void acceptGhost(Slot slot, ItemStack ingredient) {
+        if (!this.getFilterMenu().isFilterEnabled()) return;
+        int slotIndex = slot.getSlotIndex();
+        PacketDistributor.sendToServer(new SlotDisableChangePacket(slotIndex, false));
+        PacketDistributor.sendToServer(new SlotFilterChangePacket(slotIndex, ingredient.copyWithCount(1)));
+        this.getFilterMenu().setFilter(slotIndex, ingredient.copyWithCount(1));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IGhostIngredientScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IGhostIngredientScreen.java
@@ -1,0 +1,33 @@
+package dev.dubhe.anvilcraft.client.gui.screen;
+
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+@SuppressWarnings("unused")
+public interface IGhostIngredientScreen {
+    default Collection<Integer> getGhostSlots() {
+        return List.of();
+    }
+
+    default Vec2i getSlotSize(int slot) {
+        return new Vec2i(16, 16);
+    }
+
+    default void acceptGhost(Slot slot, ItemStack ingredient) {
+    }
+
+    record Vec2i(int x, int y) {
+    }
+
+    static Collection<Integer> range(int start, int end, int step) {
+        List<Integer> list = new LinkedList<>();
+        for (int i = start; i < end; i += step) {
+            list.add(i);
+        }
+        return list;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/AnvilCraftJeiPlugin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/AnvilCraftJeiPlugin.java
@@ -1,6 +1,11 @@
 package dev.dubhe.anvilcraft.integration.jei;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.client.gui.screen.BaseChuteScreen;
+import dev.dubhe.anvilcraft.client.gui.screen.BatchCrafterScreen;
+import dev.dubhe.anvilcraft.client.gui.screen.FilterScreen;
+import dev.dubhe.anvilcraft.client.gui.screen.ItemCollectorScreen;
+import dev.dubhe.anvilcraft.client.gui.screen.ItemDetectorScreen;
 import dev.dubhe.anvilcraft.client.gui.screen.JewelCraftingScreen;
 import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.init.ModItems;
@@ -33,6 +38,7 @@ import dev.dubhe.anvilcraft.integration.jei.category.anvil.UnpackCategory;
 import dev.dubhe.anvilcraft.integration.jei.category.extension.CanningFoodExtension;
 import dev.dubhe.anvilcraft.integration.jei.category.multiblock.MultiBlockConversionCategory;
 import dev.dubhe.anvilcraft.integration.jei.category.multiblock.MultiBlockCraftingCategory;
+import dev.dubhe.anvilcraft.integration.jei.handlers.GhostIngredientHandler;
 import dev.dubhe.anvilcraft.integration.jei.recipe.BeaconConversionRecipe;
 import dev.dubhe.anvilcraft.integration.jei.recipe.CementStainingRecipe;
 import dev.dubhe.anvilcraft.integration.jei.recipe.ColoredConcreteRecipe;
@@ -287,6 +293,27 @@ public class AnvilCraftJeiPlugin implements IModPlugin {
             30,
             13,
             JEWEL_CRAFTING
+        );
+
+        registration.addGhostIngredientHandler(
+            FilterScreen.class,
+            new GhostIngredientHandler<>()
+        );
+        registration.addGhostIngredientHandler(
+            BaseChuteScreen.class,
+            new GhostIngredientHandler<>()
+        );
+        registration.addGhostIngredientHandler(
+            BatchCrafterScreen.class,
+            new GhostIngredientHandler<>()
+        );
+        registration.addGhostIngredientHandler(
+            ItemDetectorScreen.class,
+            new GhostIngredientHandler<>()
+        );
+        registration.addGhostIngredientHandler(
+            ItemCollectorScreen.class,
+            new GhostIngredientHandler<>()
         );
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/handlers/GhostIngredientHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/handlers/GhostIngredientHandler.java
@@ -1,0 +1,68 @@
+package dev.dubhe.anvilcraft.integration.jei.handlers;
+
+import dev.dubhe.anvilcraft.client.gui.screen.IGhostIngredientScreen;
+import lombok.Getter;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class GhostIngredientHandler<
+    M extends AbstractContainerMenu,
+    T extends AbstractContainerScreen<M> & IGhostIngredientScreen
+    > implements IGhostIngredientHandler<T> {
+    @Override
+    public <X> @NotNull List<Target<X>> getTargetsTyped(
+        @NotNull T screen,
+        @NotNull ITypedIngredient<X> ingredient,
+        boolean doStart
+    ) {
+        List<Target<X>> targets = new LinkedList<>();
+
+        if (ingredient.getType() == VanillaTypes.ITEM_STACK) {
+            for (int slot : screen.getGhostSlots()) {
+                if (!screen.getMenu().slots.get(slot).isActive()) continue;
+                targets.add(new GhostTarget<>(screen, slot, screen.getSlotSize(slot)));
+            }
+        }
+
+        return targets;
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    public static class GhostTarget<
+        I,
+        M extends AbstractContainerMenu,
+        T extends AbstractContainerScreen<M> & IGhostIngredientScreen
+        > implements Target<I> {
+        @Getter
+        private final Rect2i area;
+        private final T screen;
+        private final int slotIndex;
+
+        public GhostTarget(@NotNull T screen, int slotIndex, IGhostIngredientScreen.@NotNull Vec2i size) {
+            this.screen = screen;
+            this.slotIndex = slotIndex;
+            Slot slot = screen.getMenu().slots.get(slotIndex);
+            this.area = new Rect2i(screen.getGuiLeft() + slot.x, screen.getGuiTop() + slot.y, size.x(), size.y());
+        }
+
+        @Override
+        public void accept(@NotNull I ingredient) {
+            if (!(ingredient instanceof ItemStack stack)) return;
+            screen.acceptGhost(screen.getMenu().getSlot(slotIndex), stack);
+        }
+    }
+}


### PR DESCRIPTION
- 在 AnvilCraftJeiPlugin 中添加了对过滤器屏幕的幽灵物品处理器注册
- 添加 IGhostIngredientScreen 接口定义幽灵物品相关方法
- 在 FilterScreen 和 IFilterScreen 实现了 IGhostIngredientScreen 接口以支持幽灵物品功能
- 新增 GhostIngredientHandler 类用于处理幽灵物品的交互逻辑