### PR TITLE
Refactor integration system and update integration types

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
+++ b/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.tterrag.registrate.Registrate;
+import dev.dubhe.anvilcraft.api.integration.IntegrationHook;
 import dev.dubhe.anvilcraft.api.integration.IntegrationManager;
 import dev.dubhe.anvilcraft.api.taslatower.TeslaFilter;
 import dev.dubhe.anvilcraft.api.tooltip.ItemTooltipManager;
@@ -50,6 +51,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Unit;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
@@ -79,7 +81,7 @@ public class AnvilCraft {
 
     public static final Registrate REGISTRATE = Registrate.create(MOD_ID);
 
-    public AnvilCraft(IEventBus modEventBus) {
+    public AnvilCraft(IEventBus modEventBus, ModContainer modContainer) {
         MOD_BUS = modEventBus;
         ModAttatchments.register(modEventBus);
         ModItemGroups.register(modEventBus);
@@ -110,6 +112,8 @@ public class AnvilCraft {
 
         registerEvents(modEventBus);
         StartupNotificationManager.addModMessage("[AnvilCraft] Loading Integrations");
+        IntegrationHook.setModEventBus(modEventBus);
+        IntegrationHook.setModContainer(modContainer);
         integrationManager.compileContent();
         integrationManager.loadAllIntegrations();
         StartupNotificationManager.addModMessage("[AnvilCraft] Ciallo~");

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/Integration.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/Integration.java
@@ -9,5 +9,5 @@ public @interface Integration {
 
     String version() default "*";
 
-    IntegrationType[] type() default {IntegrationType.CLIENT, IntegrationType.SERVER};
+    IntegrationType[] type() default {IntegrationType.CLIENT, IntegrationType.DEDICATED_SERVER};
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationHook.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationHook.java
@@ -2,10 +2,18 @@ package dev.dubhe.anvilcraft.api.integration;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 
 public class IntegrationHook {
     @Getter
     @Setter
     private static GatherDataEvent event = null;
+    @Getter
+    @Setter
+    private static IEventBus modEventBus = null;
+    @Getter
+    @Setter
+    private static ModContainer modContainer = null;
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationInstance.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationInstance.java
@@ -121,7 +121,7 @@ public final class IntegrationInstance {
 
     @Override
     public int hashCode() {
-        return Objects.hash(modid, instance, loader, clientLoader);
+        return Objects.hash(modid, versionRange, className, instance, loader, clientLoader, dataLoader);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationManager.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.api.integration;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import lombok.extern.slf4j.Slf4j;
+import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.LoadingModList;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.fml.loading.moddiscovery.ModInfo;
@@ -18,8 +19,6 @@ import java.util.Optional;
 @Slf4j
 public class IntegrationManager {
     private final Multimap<String, IntegrationInstance> instances = MultimapBuilder.hashKeys().hashSetValues().build();
-    private final Multimap<String, IntegrationInstance> clientInstances = MultimapBuilder.hashKeys().hashSetValues().build();
-    private final Multimap<String, IntegrationInstance> dataInstances = MultimapBuilder.hashKeys().hashSetValues().build();
 
     public static final String INTEGRATION_NAME = "L" + Integration.class.getName().replace(".", "/") + ";";
 
@@ -36,11 +35,11 @@ public class IntegrationManager {
                     //noinspection unchecked
                     List<ModAnnotation.EnumHolder> typeHolders = ((List<ModAnnotation.EnumHolder>) annotation.annotationData().get("type"));
                     if (version == null) version = "*";
-                    List<IntegrationType> type = List.of(IntegrationType.SERVER, IntegrationType.CLIENT);
+                    List<IntegrationType> type = List.of(IntegrationType.DEDICATED_SERVER, IntegrationType.CLIENT);
                     if (typeHolders != null) {
                         type = typeHolders.stream().map(
                             holder -> switch (holder.value()) {
-                                case "SERVER" -> IntegrationType.SERVER;
+                                case "DEDICATED_SERVER" -> IntegrationType.DEDICATED_SERVER;
                                 case "CLIENT" -> IntegrationType.CLIENT;
                                 case "DATA" -> IntegrationType.DATA;
                                 default -> throw new IllegalArgumentException("Unknown integration type: " + holder.value());
@@ -54,15 +53,7 @@ public class IntegrationManager {
                         annotation.memberName(),
                         type
                     );
-                    if (instance.containsType(IntegrationType.SERVER)) {
-                        this.instances.put(modid, instance);
-                    }
-                    if (instance.containsType(IntegrationType.CLIENT)) {
-                        this.clientInstances.put(modid, instance);
-                    }
-                    if (instance.containsType(IntegrationType.DATA)) {
-                        this.dataInstances.put(modid, instance);
-                    }
+                    this.instances.put(modid, instance);
                 }
             }
         }
@@ -72,6 +63,7 @@ public class IntegrationManager {
     @SuppressWarnings("DataFlowIssue")
     public void load(String modid, ModInfo info) {
         for (IntegrationInstance instance : instances.get(modid)) {
+            if (FMLLoader.getDist().isDedicatedServer() && !instance.containsType(IntegrationType.DEDICATED_SERVER)) return;
             if (!instance.is(info)) continue;
             instance.newInstance();
             log.info("Loading integration {} for {}.", instance.instance(), modid);
@@ -81,7 +73,7 @@ public class IntegrationManager {
 
     @SuppressWarnings("DataFlowIssue")
     public void loadClient(String modid, ModInfo info) {
-        for (IntegrationInstance instance : clientInstances.get(modid)) {
+        for (IntegrationInstance instance : instances.get(modid)) {
             if (!instance.is(info)) continue;
             instance.newInstance();
             log.info("Loading client integration {} for {}.", instance.instance(), modid);
@@ -91,7 +83,7 @@ public class IntegrationManager {
 
     @SuppressWarnings("DataFlowIssue")
     public void loadData(String modid, ModInfo info) {
-        for (IntegrationInstance instance : dataInstances.get(modid)) {
+        for (IntegrationInstance instance : instances.get(modid)) {
             if (!instance.is(info)) continue;
             instance.newInstance();
             log.info("Loading data integration {} for {}.", instance.instance(), modid);
@@ -100,21 +92,21 @@ public class IntegrationManager {
     }
 
     public void loadAllIntegrations() {
-        for (String key : instances.keys()) {
+        for (String key : instances.keySet()) {
             Optional<ModInfo> info = LoadingModList.get().getMods().stream().filter(it -> it.getModId().equals(key)).findFirst();
             info.ifPresent(modInfo -> load(key, modInfo));
         }
     }
 
     public void loadAllClientIntegrations() {
-        for (String key : clientInstances.keys()) {
+        for (String key : instances.keySet()) {
             Optional<ModInfo> info = LoadingModList.get().getMods().stream().filter(it -> it.getModId().equals(key)).findFirst();
             info.ifPresent(modInfo -> loadClient(key, modInfo));
         }
     }
 
     public void loadAllDataIntegrations() {
-        for (String key : dataInstances.keys()) {
+        for (String key : instances.keySet()) {
             Optional<ModInfo> info = LoadingModList.get().getMods().stream().filter(it -> it.getModId().equals(key)).findFirst();
             info.ifPresent(modInfo -> loadData(key, modInfo));
         }

--- a/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/integration/IntegrationType.java
@@ -2,6 +2,6 @@ package dev.dubhe.anvilcraft.api.integration;
 
 public enum IntegrationType {
     CLIENT,
-    SERVER,
+    DEDICATED_SERVER,
     DATA
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/AnvilCraftClient.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/AnvilCraftClient.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.client;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.integration.IntegrationHook;
 import dev.dubhe.anvilcraft.client.event.GuiLayerRegistrationEventListener;
 import dev.dubhe.anvilcraft.client.init.ModKeyMappings;
 import dev.dubhe.anvilcraft.client.init.ModModelLayers;
@@ -29,13 +30,18 @@ import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @Mod(value = AnvilCraft.MOD_ID, dist = Dist.CLIENT)
 public class AnvilCraftClient {
+    public static IEventBus modEventBus = null;
+    public static ModContainer modContainer = null;
 
-    public AnvilCraftClient(IEventBus modBus, ModContainer container) {
+    public AnvilCraftClient(@NotNull IEventBus modBus, @NotNull ModContainer container) {
+        modEventBus = modBus;
+        modContainer = container;
         modBus.addListener(GuiLayerRegistrationEventListener::onRegister);
         container.registerExtensionPoint(
             IConfigScreenFactory.class,
@@ -54,6 +60,8 @@ public class AnvilCraftClient {
     }
 
     public static void clientSetup(FMLClientSetupEvent event) {
+        IntegrationHook.setModEventBus(modEventBus);
+        IntegrationHook.setModContainer(modContainer);
         AnvilCraft.getIntegrationManager().loadAllClientIntegrations();
     }
 
@@ -62,11 +70,11 @@ public class AnvilCraftClient {
         e.registerItem(new ItemExtensionImpl(), ModItems.IONOCRAFT_BACKPACK);
     }
 
-    public static void registerCustomItemDecorations(RegisterItemDecorationsEvent e) {
+    public static void registerCustomItemDecorations(@NotNull RegisterItemDecorationsEvent e) {
         e.register(ModItems.IONOCRAFT_BACKPACK, new IonoCraftBackpackDecoration());
     }
 
-    public static void registerParticleProviders(RegisterParticleProvidersEvent e) {
+    public static void registerParticleProviders(@NotNull RegisterParticleProvidersEvent e) {
         e.registerSpriteSet(ModParticles.PLASMA_JETS.get(), PlasmaJetsParticle.Provider::new);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderPlugin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderPlugin.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.integration.ponder;
 import com.tterrag.registrate.providers.ProviderType;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.integration.Integration;
+import dev.dubhe.anvilcraft.api.integration.IntegrationType;
 import dev.dubhe.anvilcraft.integration.ponder.data.PonderLangHandler;
 import net.createmod.ponder.api.registration.PonderPlugin;
 import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
@@ -13,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import static dev.dubhe.anvilcraft.AnvilCraft.REGISTRATE;
 
-@Integration("ponder")
+@Integration(value = "ponder", type = {IntegrationType.CLIENT, IntegrationType.DATA})
 public class AnvilCraftPonderPlugin implements PonderPlugin {
 
     /**


### PR DESCRIPTION
Replaces 'SERVER' with 'DEDICATED_SERVER' in IntegrationType and related code. Refactors IntegrationManager to use a single instances map and adjusts loading logic accordingly. Adds mod event bus and mod container references to IntegrationHook, and ensures they are set in AnvilCraft and AnvilCraftClient. Updates integration annotation usage in AnvilCraftPonderPlugin.