### PR TITLE
Refactor Ponder scene registration to use item references

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/AnvilScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/AnvilScene.java
@@ -15,9 +15,9 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 
 public class AnvilScene {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> helper) {
-        PonderSceneRegistrationHelper<Item> HELPER = helper.withKeyFunction(BuiltInRegistries.ITEM::getKey);
-        HELPER.forComponents(
+    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+        PonderSceneRegistrationHelper<Item> helper = registrationHelper.withKeyFunction(BuiltInRegistries.ITEM::getKey);
+        helper.forComponents(
                 Items.ANVIL,
                 Items.CHIPPED_ANVIL,
                 Items.DAMAGED_ANVIL

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/AnvilScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/AnvilScene.java
@@ -7,16 +7,20 @@ import net.createmod.ponder.api.scene.SceneBuilder;
 import net.createmod.ponder.api.scene.SceneBuildingUtil;
 import net.createmod.ponder.api.scene.Selection;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 
 public class AnvilScene {
     public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> helper) {
-        helper.forComponents(
-                ResourceLocation.withDefaultNamespace("anvil"),
-                ResourceLocation.withDefaultNamespace("chipped_anvil"),
-                ResourceLocation.withDefaultNamespace("damaged_anvil")
+        PonderSceneRegistrationHelper<Item> HELPER = helper.withKeyFunction(BuiltInRegistries.ITEM::getKey);
+        HELPER.forComponents(
+                Items.ANVIL,
+                Items.CHIPPED_ANVIL,
+                Items.DAMAGED_ANVIL
             )
             .addStoryBoard("anvil/01", AnvilScene::crafting);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/MagnetScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/MagnetScene.java
@@ -19,9 +19,9 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class MagnetScene {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> helper) {
-        PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> HELPER = helper.withKeyFunction(RegistryEntry::getId);
-        HELPER.forComponents(
+    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+        PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> helper = registrationHelper.withKeyFunction(RegistryEntry::getId);
+        helper.forComponents(
             ModBlocks.MAGNET_BLOCK,
             ModBlocks.HOLLOW_MAGNET_BLOCK,
             ModBlocks.FERRITE_CORE_MAGNET_BLOCK

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/MagnetScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/MagnetScene.java
@@ -1,6 +1,10 @@
 package dev.dubhe.anvilcraft.integration.ponder.scene;
 
+import com.tterrag.registrate.util.entry.ItemProviderEntry;
+import com.tterrag.registrate.util.entry.RegistryEntry;
 import dev.dubhe.anvilcraft.block.MagnetBlock;
+import dev.dubhe.anvilcraft.init.ModBlocks;
+import dev.dubhe.anvilcraft.integration.ponder.AnvilCraftPonderTags;
 import net.createmod.ponder.api.element.ElementLink;
 import net.createmod.ponder.api.element.WorldSectionElement;
 import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
@@ -16,11 +20,12 @@ import org.jetbrains.annotations.NotNull;
 
 public class MagnetScene {
     public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> helper) {
-        helper.forComponents(
-                ResourceLocation.fromNamespaceAndPath("anvilcraft", "magnet_block"),
-                ResourceLocation.fromNamespaceAndPath("anvilcraft", "hollow_magnet_block"),
-                ResourceLocation.fromNamespaceAndPath("anvilcraft", "ferrite_core_magnet_block")
-        ).addStoryBoard("magnet/01", MagnetScene::crafting);
+        PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> HELPER = helper.withKeyFunction(RegistryEntry::getId);
+        HELPER.forComponents(
+            ModBlocks.MAGNET_BLOCK,
+            ModBlocks.HOLLOW_MAGNET_BLOCK,
+            ModBlocks.FERRITE_CORE_MAGNET_BLOCK
+        ).addStoryBoard("magnet/01", MagnetScene::crafting, AnvilCraftPonderTags.ANVIL);
     }
 
     private static void crafting(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
@@ -38,10 +43,10 @@ public class MagnetScene {
         scene.idle(5);
 
         scene.overlay().showText(30)
-                .text("The anvil needs to be lifted and smashed down for processing")
-                .pointAt(util.vector().blockSurface(util.grid().at(2, 2, 2), Direction.WEST))
-                .attachKeyFrame()
-                .placeNearTarget();
+            .text("The anvil needs to be lifted and smashed down for processing")
+            .pointAt(util.vector().blockSurface(util.grid().at(2, 2, 2), Direction.WEST))
+            .attachKeyFrame()
+            .placeNearTarget();
         scene.idle(40);
 
         Selection magnet = util.select().position(2, 4, 2);
@@ -52,28 +57,28 @@ public class MagnetScene {
         scene.idle(5);
 
         scene.overlay().showText(30)
-                .text("Magnets can attract anvils")
-                .pointAt(util.vector().blockSurface(util.grid().at(2, 3, 2), Direction.WEST))
-                .attachKeyFrame()
-                .placeNearTarget();
+            .text("Magnets can attract anvils")
+            .pointAt(util.vector().blockSurface(util.grid().at(2, 3, 2), Direction.WEST))
+            .attachKeyFrame()
+            .placeNearTarget();
         scene.idle(40);
         // 放置红石块使磁铁失效
         Selection redstoneBlock = util.select().position(3, 4, 2);
         scene.world().showIndependentSection(redstoneBlock, Direction.WEST);
         scene.idle(10);
         scene.world().modifyBlock(new BlockPos(2, 4, 2),
-                bs -> bs.setValue(MagnetBlock.LIT, true),
-                false
+            bs -> bs.setValue(MagnetBlock.LIT, true),
+            false
         );
 
         scene.world().moveSection(anvilLink, new Vec3(0, -1, 0), 7);
         scene.idle(10);
 
         scene.overlay().showText(30)
-                .text("Magnet will stop working when it receives a redstone signal.")
-                .pointAt(util.vector().blockSurface(util.grid().at(2, 3, 2), Direction.WEST))
-                .attachKeyFrame()
-                .placeNearTarget();
+            .text("Magnet will stop working when it receives a redstone signal.")
+            .pointAt(util.vector().blockSurface(util.grid().at(2, 3, 2), Direction.WEST))
+            .attachKeyFrame()
+            .placeNearTarget();
         scene.idle(40);
 
         scene.markAsFinished();


### PR DESCRIPTION
Updated AnvilScene and MagnetScene to register components using item and block references instead of ResourceLocation. This improves type safety and integration with the mod's registries, and allows for easier maintenance and extension of Ponder scenes.