### PR TITLE
Refactoring the rendering logic of items 重构物品渲染逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/AbstractItemInHandRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/AbstractItemInHandRenderer.java
@@ -1,0 +1,51 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import lombok.Setter;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Setter
+public abstract class AbstractItemInHandRenderer {
+    protected ItemStack offHandItem;
+    protected ItemStack mainHandItem;
+    protected final ItemRenderer itemRenderer;
+    private final IItemRenderer iItemRenderer;
+
+    protected AbstractItemInHandRenderer(ItemRenderer itemRenderer, IItemRenderer iItemRenderer) {
+        this.itemRenderer = itemRenderer;
+        this.iItemRenderer = iItemRenderer;
+    }
+
+    public void renderItem(
+        LivingEntity entity,
+        ItemStack itemStack,
+        ItemDisplayContext displayContext,
+        boolean leftHand,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int seed
+    ) {
+        this.iItemRenderer.renderItem(entity, itemStack, displayContext, leftHand, poseStack, buffer, seed);
+    }
+
+    public abstract void render(
+        AbstractClientPlayer player,
+        float partialTicks,
+        float pitch,
+        InteractionHand hand,
+        float swingProgress,
+        ItemStack stack,
+        float equippedProgress,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int combinedLight,
+        CallbackInfo ci
+    );
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/CrabClawItemInHandRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/CrabClawItemInHandRenderer.java
@@ -1,0 +1,117 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.FishingRodItem;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.MaceItem;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+public class CrabClawItemInHandRenderer extends AbstractItemInHandRenderer {
+
+    @Unique
+    private static final ModelResourceLocation anvilCraft$HOLDING_ITEM =
+        ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_item"));
+
+    @Unique
+    private static final ModelResourceLocation anvilCraft$HOLDING_BLOCK =
+        ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_block"));
+
+    protected CrabClawItemInHandRenderer(ItemRenderer itemRenderer, IItemRenderer iItemRenderer) {
+        super(itemRenderer, iItemRenderer);
+    }
+
+    @Override
+    public void render(
+        AbstractClientPlayer player,
+        float partialTicks,
+        float pitch,
+        InteractionHand hand,
+        float swingProgress,
+        ItemStack stack,
+        float equippedProgress,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int combinedLight,
+        CallbackInfo ci
+    ) {
+        if (hand == InteractionHand.OFF_HAND) {
+            poseStack.popPose();
+            ci.cancel();
+            return;
+        }
+        boolean flag = hand == InteractionHand.MAIN_HAND;
+        HumanoidArm humanoidarm = flag ? player.getMainArm() : player.getMainArm().getOpposite();
+        boolean flag2 = humanoidarm == HumanoidArm.LEFT;
+        int i = flag2 ? -1 : 1;
+        if (this.mainHandItem.isEmpty()) {
+            this.renderItem(
+                player,
+                this.offHandItem,
+                ItemDisplayContext.FIRST_PERSON_RIGHT_HAND,
+                flag2,
+                poseStack,
+                buffer,
+                combinedLight
+            );
+            return;
+        }
+        boolean isBlockItem = this.itemRenderer.getModel(this.mainHandItem, player.level(), player, combinedLight).isGui3d()
+            && this.mainHandItem.getItem() instanceof BlockItem;
+        switch (stack.getUseAnimation()) {
+            case EAT:
+            case DRINK:
+                if (
+                    player.isUsingItem()
+                        && player.getUseItemRemainingTicks() > 0
+                        && player.getUsedItemHand() == hand
+                ) {
+                    poseStack.translate(0, -0.25f, 0.05f);
+                }
+                break;
+            case NONE:
+                break;
+            default:
+                return;
+        }
+        if (stack.getItem() instanceof FishingRodItem) return;
+        this.itemRenderer.render(
+            this.offHandItem,
+            ItemDisplayContext.FIRST_PERSON_RIGHT_HAND,
+            flag2,
+            poseStack,
+            buffer,
+            combinedLight,
+            OverlayTexture.NO_OVERLAY,
+            this.itemRenderer
+                .getItemModelShaper()
+                .getModelManager()
+                .getModel(isBlockItem ? anvilCraft$HOLDING_BLOCK : anvilCraft$HOLDING_ITEM)
+        );
+        if (isBlockItem) {
+            poseStack.mulPose(Axis.YP.rotationDegrees(60f * i));
+            poseStack.mulPose(Axis.XP.rotationDegrees(25f));
+            poseStack.scale(0.5f, 0.5f, 0.5f);
+            poseStack.translate(0.25f * i, 0.4f, -0.1f);
+        } else {
+            poseStack.mulPose(Axis.ZP.rotationDegrees(5f * i));
+            poseStack.scale(0.75f, 0.75f, 0.75f);
+            poseStack.translate(0, 0.45f, 0.02f);
+            if (stack.getItem() instanceof MaceItem) {
+                poseStack.mulPose(Axis.YP.rotationDegrees(-10f * i));
+                poseStack.translate(0.08f * i, -0.1f, 0);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/IExtraItemDisplayRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/IExtraItemDisplayRenderer.java
@@ -1,0 +1,88 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.dubhe.anvilcraft.api.item.IExtraItemDisplay;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Consumer;
+
+public class IExtraItemDisplayRenderer extends AbstractItemInHandRenderer {
+    protected IExtraItemDisplayRenderer(ItemRenderer itemRenderer, IItemRenderer iItemRenderer) {
+        super(itemRenderer, iItemRenderer);
+    }
+
+    public static void renderGuiExtra(
+        PoseStack pose,
+        IGuiItemRenderer itemRenderer,
+        LivingEntity entity,
+        Level level,
+        ItemStack stack,
+        int x,
+        int y,
+        int seed,
+        int guiOffset,
+        int recursion,
+        int maxRecursion,
+        Consumer<Integer> recursionSetter
+    ) {
+        if (recursion >= maxRecursion) return;
+        if (!(stack.getItem() instanceof IExtraItemDisplay item)) return;
+        ItemStack innerStack = item.getDisplayedItem(stack);
+        if (innerStack.isEmpty()) return;
+        recursionSetter.accept(recursion + 1);
+        pose.pushPose();
+        pose.translate(x + item.xOffset(stack), y + item.yOffset(stack), 0);
+        float scale = item.scale(stack);
+        pose.scale(scale, scale, 1.0f);
+        itemRenderer.renderItem(entity, level, innerStack, 0, 0, seed, guiOffset + 10);
+        recursionSetter.accept(recursion - 1);
+        pose.popPose();
+    }
+
+    @Override
+    public void render(
+        AbstractClientPlayer player,
+        float partialTicks,
+        float pitch,
+        InteractionHand hand,
+        float swingProgress,
+        @NotNull ItemStack stack,
+        float equippedProgress,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int combinedLight,
+        CallbackInfo ci
+    ) {
+        if (!(stack.getItem() instanceof IExtraItemDisplay display)) return;
+        HumanoidArm humanoidarm = hand == InteractionHand.MAIN_HAND ? player.getMainArm() : player.getMainArm().getOpposite();
+        boolean flag = humanoidarm == HumanoidArm.LEFT;
+        int i = flag ? -1 : 1;
+        ItemStack displayedItem = display.getDisplayedItem(stack);
+        float scale = display.scale(stack);
+        int xOffset = display.xOffset(stack);
+        int yOffset = display.yOffset(stack);
+        poseStack.pushPose();
+        poseStack.translate(i * 0.024, 0.015 * i + 0.10 + yOffset * 0.03, 0.0225 * i - 0.1425 + xOffset * 0.03);
+        poseStack.scale(scale, scale, scale);
+        this.renderItem(
+            player,
+            displayedItem,
+            ItemDisplayContext.FIRST_PERSON_RIGHT_HAND,
+            flag,
+            poseStack,
+            buffer,
+            combinedLight
+        );
+        poseStack.popPose();
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/IGuiItemRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/IGuiItemRenderer.java
@@ -1,0 +1,19 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nullable;
+
+public interface IGuiItemRenderer {
+    void renderItem(
+        @Nullable LivingEntity entity,
+        @Nullable Level level,
+        ItemStack stack,
+        int x,
+        int y,
+        int seed,
+        int guiOffset
+    );
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/IItemRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/IItemRenderer.java
@@ -1,0 +1,19 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+
+public interface IItemRenderer {
+    void renderItem(
+        LivingEntity entity,
+        ItemStack itemStack,
+        ItemDisplayContext displayContext,
+        boolean leftHand,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int seed
+    );
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/ItemInHandRendererManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/ItemInHandRendererManager.java
@@ -1,0 +1,88 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.dubhe.anvilcraft.api.item.IExtraItemDisplay;
+import dev.dubhe.anvilcraft.init.ModItems;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ItemInHandRendererManager extends AbstractItemInHandRenderer {
+    private final Set<AbstractItemInHandRenderer> renderers = new HashSet<>();
+    public final CrabClawItemInHandRenderer crabClawItemRenderer;
+    public final IExtraItemDisplayRenderer extraItemRenderer;
+
+    public ItemInHandRendererManager(ItemRenderer itemRenderer, IItemRenderer iItemRenderer) {
+        super(itemRenderer, iItemRenderer);
+        this.crabClawItemRenderer = new CrabClawItemInHandRenderer(itemRenderer, iItemRenderer);
+        this.renderers.add(this.crabClawItemRenderer);
+        this.extraItemRenderer = new IExtraItemDisplayRenderer(itemRenderer, iItemRenderer);
+        this.renderers.add(this.extraItemRenderer);
+    }
+
+    @Override
+    public void setMainHandItem(ItemStack mainHandItem) {
+        this.renderers.forEach(renderer -> renderer.setMainHandItem(mainHandItem));
+        super.setMainHandItem(mainHandItem);
+    }
+
+    @Override
+    public void setOffHandItem(ItemStack offHandItem) {
+        this.renderers.forEach(renderer -> renderer.setOffHandItem(offHandItem));
+        super.setOffHandItem(offHandItem);
+    }
+
+    public void render(
+        AbstractClientPlayer player,
+        float partialTicks,
+        float pitch,
+        InteractionHand hand,
+        float swingProgress,
+        ItemStack stack,
+        float equippedProgress,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int combinedLight,
+        CallbackInfo ci
+    ) {
+        if (
+            this.offHandItem.is(ModItems.CRAB_CLAW.get())
+                && !this.mainHandItem.is(ModItems.CRAB_CLAW.get())
+        ) {
+            this.crabClawItemRenderer.render(
+                player,
+                partialTicks,
+                pitch,
+                hand,
+                swingProgress,
+                stack,
+                equippedProgress,
+                poseStack,
+                buffer,
+                combinedLight,
+                ci
+            );
+        }
+        if (stack.getItem() instanceof IExtraItemDisplay) {
+            this.extraItemRenderer.render(
+                player,
+                partialTicks,
+                pitch,
+                hand,
+                swingProgress,
+                stack,
+                equippedProgress,
+                poseStack,
+                buffer,
+                combinedLight,
+                ci
+            );
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/item/CannedFoodItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/CannedFoodItem.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.item;
 
 import dev.dubhe.anvilcraft.api.item.IExtraItemDisplay;
 import dev.dubhe.anvilcraft.init.ModComponents;
+import dev.dubhe.anvilcraft.init.ModItems;
 import lombok.Getter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Holder;
@@ -21,6 +22,14 @@ public class CannedFoodItem extends Item implements IExtraItemDisplay {
     public CannedFoodItem(Properties properties, Holder<Item> canItem) {
         super(properties);
         this.canItem = canItem;
+    }
+
+    @Override
+    public void verifyComponentsAfterLoad(ItemStack stack) {
+        if (!stack.has(ModComponents.DISPLAY_ITEM)) {
+            this.setFood(stack, ModItems.BEEF_MUSHROOM_STEW.asStack());
+        }
+        super.verifyComponentsAfterLoad(stack);
     }
 
     @Override
@@ -50,12 +59,12 @@ public class CannedFoodItem extends Item implements IExtraItemDisplay {
 
     @Override
     public int xOffset(ItemStack stack) {
-        return 4;
+        return 5;
     }
 
     @Override
     public int yOffset(ItemStack stack) {
-        return 6;
+        return 2;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/HasMobBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/HasMobBlockItem.java
@@ -3,16 +3,19 @@ package dev.dubhe.anvilcraft.item;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.dubhe.anvilcraft.block.entity.HasMobBlockEntity;
+import dev.dubhe.anvilcraft.init.ModBlocks;
 import dev.dubhe.anvilcraft.init.ModComponents;
 import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
@@ -33,7 +36,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -46,6 +48,28 @@ import java.util.Optional;
 public class HasMobBlockItem extends BlockItem {
     public HasMobBlockItem(Block block, Properties properties) {
         super(block, properties);
+    }
+
+    @Override
+    public void verifyComponentsAfterLoad(ItemStack stack) {
+        super.verifyComponentsAfterLoad(stack);
+        if (stack.has(ModComponents.SAVED_ENTITY)) return;
+        if (
+            !stack.is(ModBlocks.MOB_AMBER_BLOCK.asItem())
+                && !stack.is(ModBlocks.RESENTFUL_AMBER_BLOCK.asItem())
+        ) return;
+        ResourceLocation id;
+        boolean isMonster = false;
+        if (stack.is(ModBlocks.RESENTFUL_AMBER_BLOCK.asItem())) {
+            isMonster = true;
+            id = BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE);
+        } else {
+            id = BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.PIG);
+        }
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id", id.toString());
+        SavedEntity savedEntity = new SavedEntity(tag, isMonster);
+        stack.set(ModComponents.SAVED_ENTITY, savedEntity);
     }
 
     @Override
@@ -74,7 +98,7 @@ public class HasMobBlockItem extends BlockItem {
         return super.updateCustomBlockEntityTag(pos, level, player, stack, state);
     }
 
-    public static boolean hasMob(@NotNull ItemStack stack) {
+    public static boolean hasMob(ItemStack stack) {
         return stack.has(ModComponents.SAVED_ENTITY);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/item/HasMobBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/HasMobBlockItem.java
@@ -64,7 +64,7 @@ public class HasMobBlockItem extends BlockItem {
             isMonster = true;
             id = BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.ZOMBIE);
         } else {
-            id = BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.PIG);
+            id = BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.MOOSHROOM);
         }
         CompoundTag tag = new CompoundTag();
         tag.putString("id", id.toString());

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/GuiGraphicsMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/GuiGraphicsMixin.java
@@ -1,7 +1,7 @@
 package dev.dubhe.anvilcraft.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import dev.dubhe.anvilcraft.api.item.IExtraItemDisplay;
+import dev.dubhe.anvilcraft.client.renderer.item.IExtraItemDisplayRenderer;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -18,7 +18,6 @@ import javax.annotation.Nullable;
 
 @Mixin(GuiGraphics.class)
 public abstract class GuiGraphicsMixin {
-
     @Unique
     private static int ANVILCRAFT$RECURSION = 0;
     @Unique
@@ -40,17 +39,19 @@ public abstract class GuiGraphicsMixin {
         )
     )
     private void renderExtra(LivingEntity entity, Level level, ItemStack stack, int x, int y, int seed, int guiOffset, CallbackInfo ci) {
-        if (ANVILCRAFT$RECURSION >= ANVILCRAFT$MAX_RECURSION) return;
-        if (!(stack.getItem() instanceof IExtraItemDisplay item)) return;
-        ItemStack innerStack = item.getDisplayedItem(stack);
-        if (innerStack.isEmpty()) return;
-        ANVILCRAFT$RECURSION++;
-        pose.pushPose();
-        pose.translate(x + item.xOffset(stack), y + item.yOffset(stack), 0);
-        float scale = item.scale(stack);
-        pose.scale(scale, scale, 1.0f);
-        this.renderItem(entity, level, innerStack, 0, 0, seed, guiOffset + 10);
-        ANVILCRAFT$RECURSION--;
-        pose.popPose();
+        IExtraItemDisplayRenderer.renderGuiExtra(
+            this.pose,
+            this::renderItem,
+            entity,
+            level,
+            stack,
+            x,
+            y,
+            seed,
+            guiOffset,
+            ANVILCRAFT$RECURSION,
+            ANVILCRAFT$MAX_RECURSION,
+            i -> ANVILCRAFT$RECURSION = i
+        );
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemInHandRendererMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemInHandRendererMixin.java
@@ -1,24 +1,18 @@
 package dev.dubhe.anvilcraft.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.math.Axis;
-import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.client.renderer.item.ItemInHandRendererManager;
 import dev.dubhe.anvilcraft.init.ModItems;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.ItemInHandRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.ItemRenderer;
-import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.FishingRodItem;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.MaceItem;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -29,24 +23,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemInHandRenderer.class)
 abstract class ItemInHandRendererMixin {
-
-    @Unique
-    private static final ModelResourceLocation anvilCraft$HOLDING_ITEM =
-        ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_item"));
-
-    @Unique
-    private static final ModelResourceLocation anvilCraft$HOLDING_BLOCK =
-        ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_block"));
-
     @Shadow
     private ItemStack offHandItem;
 
     @Shadow
     private ItemStack mainHandItem;
-
-    @Shadow
-    @Final
-    private ItemRenderer itemRenderer;
 
     @Shadow
     public abstract void renderItem(
@@ -56,11 +37,25 @@ abstract class ItemInHandRendererMixin {
         boolean leftHand,
         PoseStack poseStack,
         MultiBufferSource buffer,
-        int seed);
+        int seed
+    );
+
+    @Unique
+    private ItemInHandRendererManager anvilcraft$manager = null;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void init(Minecraft minecraft, EntityRenderDispatcher entityRenderDispatcher, ItemRenderer itemRenderer, CallbackInfo ci) {
+        anvilcraft$manager = new ItemInHandRendererManager(itemRenderer, this::renderItem);
+    }
 
     @Redirect(
         method = "renderArmWithItem",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;isEmpty()Z", ordinal = 0))
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/item/ItemStack;isEmpty()Z",
+            ordinal = 0
+        )
+    )
     private boolean isEmpty(ItemStack instance) {
         if (this.offHandItem.is(ModItems.CRAB_CLAW.get())) return false;
         return instance.isEmpty();
@@ -76,9 +71,11 @@ abstract class ItemInHandRendererMixin {
                 + "renderItem(Lnet/minecraft/world/entity/LivingEntity;"
                 + "Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemDisplayContext;"
                 + "ZLcom/mojang/blaze3d/vertex/PoseStack;"
-                + "Lnet/minecraft/client/renderer/MultiBufferSource;I)V"),
-        cancellable = true)
-    private void renderOffHandCrabClaw(
+                + "Lnet/minecraft/client/renderer/MultiBufferSource;I)V"
+        ),
+        cancellable = true
+    )
+    private void renderArmWithItem(
         AbstractClientPlayer player,
         float partialTicks,
         float pitch,
@@ -89,73 +86,23 @@ abstract class ItemInHandRendererMixin {
         PoseStack poseStack,
         MultiBufferSource buffer,
         int combinedLight,
-        CallbackInfo ci) {
-        if (this.offHandItem.is(ModItems.CRAB_CLAW.get()) && !this.mainHandItem.is(ModItems.CRAB_CLAW.get())) {
-            if (hand == InteractionHand.OFF_HAND) {
-                poseStack.popPose();
-                ci.cancel();
-                return;
-            }
-            boolean flag = hand == InteractionHand.MAIN_HAND;
-            HumanoidArm humanoidarm = flag ? player.getMainArm() : player.getMainArm().getOpposite();
-            boolean flag2 = humanoidarm == HumanoidArm.LEFT;
-            int i = flag2 ? -1 : 1;
-            if (this.mainHandItem.isEmpty()) {
-                this.renderItem(
-                    player,
-                    this.offHandItem,
-                    ItemDisplayContext.FIRST_PERSON_RIGHT_HAND,
-                    flag2,
-                    poseStack,
-                    buffer,
-                    combinedLight);
-                return;
-            }
-            boolean isBlockItem = this.itemRenderer
-                .getModel(this.mainHandItem, player.level(), player, combinedLight)
-                .isGui3d()
-                && this.mainHandItem.getItem() instanceof BlockItem;
-            switch (stack.getUseAnimation()) {
-                case EAT:
-                case DRINK:
-                    if (player.isUsingItem()
-                        && player.getUseItemRemainingTicks() > 0
-                        && player.getUsedItemHand() == hand) {
-                        poseStack.translate(0, -0.25f, 0.05f);
-                    }
-                    break;
-                case NONE:
-                    break;
-                default:
-                    return;
-            }
-            if (stack.getItem() instanceof FishingRodItem) return;
-            this.itemRenderer.render(
-                this.offHandItem,
-                ItemDisplayContext.FIRST_PERSON_RIGHT_HAND,
-                flag2,
-                poseStack,
-                buffer,
-                combinedLight,
-                OverlayTexture.NO_OVERLAY,
-                this.itemRenderer
-                    .getItemModelShaper()
-                    .getModelManager()
-                    .getModel(isBlockItem ? anvilCraft$HOLDING_BLOCK : anvilCraft$HOLDING_ITEM));
-            if (isBlockItem) {
-                poseStack.mulPose(Axis.YP.rotationDegrees(60f * i));
-                poseStack.mulPose(Axis.XP.rotationDegrees(25f));
-                poseStack.scale(0.5f, 0.5f, 0.5f);
-                poseStack.translate(0.25f * i, 0.4f, -0.1f);
-            } else {
-                poseStack.mulPose(Axis.ZP.rotationDegrees(5f * i));
-                poseStack.scale(0.75f, 0.75f, 0.75f);
-                poseStack.translate(0, 0.45f, 0.02f);
-                if (stack.getItem() instanceof MaceItem) {
-                    poseStack.mulPose(Axis.YP.rotationDegrees(-10f * i));
-                    poseStack.translate(0.08f * i, -0.1f, 0);
-                }
-            }
-        }
+        CallbackInfo ci
+    ) {
+        if (this.anvilcraft$manager == null) return;
+        this.anvilcraft$manager.setMainHandItem(this.mainHandItem);
+        this.anvilcraft$manager.setOffHandItem(this.offHandItem);
+        this.anvilcraft$manager.render(
+            player,
+            partialTicks,
+            pitch,
+            hand,
+            swingProgress,
+            stack,
+            equippedProgress,
+            poseStack,
+            buffer,
+            combinedLight,
+            ci
+        );
     }
 }


### PR DESCRIPTION
- 新增 AbstractItemInHandRenderer、IExtraItemDisplayRenderer 等接口和抽象类
- 实现 CrabClawItemInHandRenderer 和 IExtraItemDisplayRenderer
- 创建 ItemInHandRendererManager 来管理不同的渲染器
- 重构 ItemInHandRendererMixin，使用新的渲染器管理逻辑
- 调整 CannedFoodItem 和 HasMobBlockItem 的物品显示逻辑