### PR TITLE
Move the filter configuration logic to the FilterContainer 将过滤器配置逻辑移至 FilterContainer

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/FilteredItemStackHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/FilteredItemStackHandler.java
@@ -145,8 +145,7 @@ public class FilteredItemStackHandler extends ItemStackHandler {
      * @return 指定槽位是否允许放入指定物品堆叠
      */
     public boolean isFiltered(int slot, ItemStack stack) {
-        ItemStack filter = this.filteredItems.get(slot);
-        return filter.isEmpty() || ItemStack.isSameItem(filter, stack) || FilterItem.filter(filter, stack);
+        return FilterItem.filter(this.filteredItems.get(slot), stack);
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/component/SwitchableImageButton.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/component/SwitchableImageButton.java
@@ -53,7 +53,7 @@ public class SwitchableImageButton extends ImageButton {
         Consumer<Boolean> changeStatus,
         OnPress onPress
     ) {
-        this(x, y, 18, 18, sprites, status, changeStatus, onPress);
+        this(x, y, 16, 16, sprites, status, changeStatus, onPress);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BaseChuteScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BaseChuteScreen.java
@@ -4,7 +4,9 @@ import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.itemhandler.SlotItemHandlerWithFilter;
 import dev.dubhe.anvilcraft.block.entity.BaseChuteBlockEntity;
 import dev.dubhe.anvilcraft.client.gui.component.EnableFilterButton;
+import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.inventory.BaseChuteMenu;
+import dev.dubhe.anvilcraft.item.FilterItem;
 import dev.dubhe.anvilcraft.network.SlotDisableChangePacket;
 import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import lombok.Getter;
@@ -17,20 +19,17 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BiFunction;
 
 /**
  * 溜槽屏幕基类
  */
-public abstract class BaseChuteScreen<T extends BaseChuteBlockEntity, M extends BaseChuteMenu<T>>
-    extends BaseMachineScreen<M> implements IFilterScreen<M> {
-    private static final ResourceLocation CONTAINER_LOCATION =
-        AnvilCraft.of("textures/gui/container/machine/background/chute.png");
+public abstract class BaseChuteScreen<T extends BaseChuteBlockEntity, M extends BaseChuteMenu<T>> extends BaseMachineScreen<M>
+    implements IFilterScreen<M> {
+    private static final ResourceLocation CONTAINER_LOCATION = AnvilCraft.of("textures/gui/container/machine/background/chute.png");
 
-    BiFunction<Integer, Integer, EnableFilterButton> enableFilterButtonSupplier =
-        this.getEnableFilterButtonSupplier(134, 36);
+    BiFunction<Integer, Integer, EnableFilterButton> enableFilterButtonSupplier = this.getEnableFilterButtonSupplier(134, 36);
 
     @Getter
     private EnableFilterButton enableFilterButton = null;
@@ -57,25 +56,25 @@ public abstract class BaseChuteScreen<T extends BaseChuteBlockEntity, M extends 
     abstract boolean shouldSkipDirection(Direction direction);
 
     @Override
-    protected void renderBg(@NotNull GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
+    protected void renderBg(GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
         int i = (this.width - this.imageWidth) / 2;
         int j = (this.height - this.imageHeight) / 2;
         guiGraphics.blit(CONTAINER_LOCATION, i, j, 0, 0, this.imageWidth, this.imageHeight);
     }
 
     @Override
-    public void renderSlot(@NotNull GuiGraphics guiGraphics, @NotNull Slot slot) {
+    public void renderSlot(GuiGraphics guiGraphics, Slot slot) {
         super.renderSlot(guiGraphics, slot);
         IFilterScreen.super.renderSlot(guiGraphics, slot);
     }
 
     @Override
-    protected void renderTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderTooltip(GuiGraphics guiGraphics, int x, int y) {
         super.renderTooltip(guiGraphics, x, y);
         this.renderSlotTooltip(guiGraphics, x, y);
     }
 
-    protected void renderSlotTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderSlotTooltip(GuiGraphics guiGraphics, int x, int y) {
         if (this.hoveredSlot == null) return;
         if (!(this.hoveredSlot instanceof SlotItemHandlerWithFilter)) return;
         if (!((SlotItemHandlerWithFilter) this.hoveredSlot).isFilter()) return;
@@ -95,25 +94,27 @@ public abstract class BaseChuteScreen<T extends BaseChuteBlockEntity, M extends 
     }
 
     @Override
-    protected void slotClicked(@NotNull Slot slot, int slotId, int mouseButton, @NotNull ClickType type) {
-            if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
-                ItemStack carriedItem = this.menu.getCarried();
-                int realSlotId = slot.getContainerSlot();
-                if (this.menu.isFilterEnabled()) {
+    protected void slotClicked(Slot slot, int slotId, int mouseButton, ClickType type) {
+        if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
+            ItemStack carriedItem = this.menu.getCarried().copy();
+            int realSlotId = slot.getContainerSlot();
+            if (this.menu.isFilterEnabled()) {
+                ItemStack filter = this.menu.getFilter(realSlotId);
+                if (this.menu.isSlotDisabled(realSlotId)) {
                     PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
-                    PacketDistributor.sendToServer(new SlotFilterChangePacket(realSlotId, carriedItem.copy()));
-                    menu.setSlotDisabled(realSlotId, false);
-                    menu.setFilter(realSlotId, carriedItem.copy());
-                    slot.set(carriedItem);
-                } else {
-                    if (carriedItem.isEmpty()) {
-                        PacketDistributor.sendToServer(
-                            new SlotDisableChangePacket(realSlotId, !this.menu.isSlotDisabled(realSlotId)));
-                    } else {
-                        PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
-                    }
+                    this.menu.setSlotDisabled(realSlotId, false);
                 }
+                PacketDistributor.sendToServer(new SlotFilterChangePacket(realSlotId, carriedItem));
+                this.menu.setFilter(realSlotId, carriedItem);
+                if (carriedItem.is(ModItems.FILTER) && (filter.isEmpty() || !FilterItem.filter(filter, carriedItem))) return;
+                slot.set(carriedItem);
+            } else {
+                PacketDistributor.sendToServer(new SlotDisableChangePacket(
+                    realSlotId,
+                    carriedItem.isEmpty() && !this.menu.isSlotDisabled(realSlotId)
+                ));
             }
+        }
         super.slotClicked(slot, slotId, mouseButton, type);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BaseChuteScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BaseChuteScreen.java
@@ -11,6 +11,7 @@ import dev.dubhe.anvilcraft.network.SlotDisableChangePacket;
 import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import lombok.Getter;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -98,7 +99,7 @@ public abstract class BaseChuteScreen<T extends BaseChuteBlockEntity, M extends 
         if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
             ItemStack carriedItem = this.menu.getCarried().copy();
             int realSlotId = slot.getContainerSlot();
-            if (this.menu.isFilterEnabled()) {
+            if (!carriedItem.isEmpty() && this.menu.isFilterEnabled()) {
                 ItemStack filter = this.menu.getFilter(realSlotId);
                 if (this.menu.isSlotDisabled(realSlotId)) {
                     PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
@@ -108,7 +109,7 @@ public abstract class BaseChuteScreen<T extends BaseChuteBlockEntity, M extends 
                 this.menu.setFilter(realSlotId, carriedItem);
                 if (carriedItem.is(ModItems.FILTER) && (filter.isEmpty() || !FilterItem.filter(filter, carriedItem))) return;
                 slot.set(carriedItem);
-            } else {
+            } else if (Screen.hasShiftDown()) {
                 PacketDistributor.sendToServer(new SlotDisableChangePacket(
                     realSlotId,
                     carriedItem.isEmpty() && !this.menu.isSlotDisabled(realSlotId)

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BatchCrafterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BatchCrafterScreen.java
@@ -10,6 +10,7 @@ import dev.dubhe.anvilcraft.network.SlotDisableChangePacket;
 import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import lombok.Getter;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
@@ -84,7 +85,7 @@ public class BatchCrafterScreen extends BaseMachineScreen<BatchCrafterMenu> impl
         if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
             ItemStack carriedItem = this.menu.getCarried().copy();
             int realSlotId = slot.getContainerSlot();
-            if (this.menu.isFilterEnabled()) {
+            if (!carriedItem.isEmpty() && this.menu.isFilterEnabled()) {
                 ItemStack filter = this.menu.getFilter(realSlotId);
                 if (this.menu.isSlotDisabled(realSlotId)) {
                     PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
@@ -94,7 +95,7 @@ public class BatchCrafterScreen extends BaseMachineScreen<BatchCrafterMenu> impl
                 this.menu.setFilter(realSlotId, carriedItem);
                 if (carriedItem.is(ModItems.FILTER) && (filter.isEmpty() || !FilterItem.filter(filter, carriedItem))) return;
                 slot.set(carriedItem);
-            } else {
+            } else if (Screen.hasShiftDown()) {
                 PacketDistributor.sendToServer(new SlotDisableChangePacket(
                     realSlotId,
                     carriedItem.isEmpty() && !this.menu.isSlotDisabled(realSlotId)

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BatchCrafterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/BatchCrafterScreen.java
@@ -3,7 +3,9 @@ package dev.dubhe.anvilcraft.client.gui.screen;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.itemhandler.SlotItemHandlerWithFilter;
 import dev.dubhe.anvilcraft.client.gui.component.EnableFilterButton;
+import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.inventory.BatchCrafterMenu;
+import dev.dubhe.anvilcraft.item.FilterItem;
 import dev.dubhe.anvilcraft.network.SlotDisableChangePacket;
 import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import lombok.Getter;
@@ -15,15 +17,12 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BiFunction;
 
 public class BatchCrafterScreen extends BaseMachineScreen<BatchCrafterMenu> implements IFilterScreen<BatchCrafterMenu> {
-    private static final ResourceLocation CONTAINER_LOCATION =
-        AnvilCraft.of("textures/gui/container/machine/background/auto_crafter.png");
-    BiFunction<Integer, Integer, EnableFilterButton> enableFilterButtonSupplier =
-        this.getEnableFilterButtonSupplier(116, 18);
+    private static final ResourceLocation CONTAINER_LOCATION = AnvilCraft.of("textures/gui/container/machine/background/auto_crafter.png");
+    BiFunction<Integer, Integer, EnableFilterButton> enableFilterButtonSupplier = this.getEnableFilterButtonSupplier(116, 18);
 
     @Getter
     private EnableFilterButton enableFilterButton = null;
@@ -43,25 +42,25 @@ public class BatchCrafterScreen extends BaseMachineScreen<BatchCrafterMenu> impl
     }
 
     @Override
-    protected void renderBg(@NotNull GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
+    protected void renderBg(GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
         int i = (this.width - this.imageWidth) / 2;
         int j = (this.height - this.imageHeight) / 2;
         guiGraphics.blit(CONTAINER_LOCATION, i, j, 0, 0, this.imageWidth, this.imageHeight);
     }
 
     @Override
-    public void renderSlot(@NotNull GuiGraphics guiGraphics, @NotNull Slot slot) {
+    public void renderSlot(GuiGraphics guiGraphics, Slot slot) {
         super.renderSlot(guiGraphics, slot);
         IFilterScreen.super.renderSlot(guiGraphics, slot);
     }
 
     @Override
-    protected void renderTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderTooltip(GuiGraphics guiGraphics, int x, int y) {
         super.renderTooltip(guiGraphics, x, y);
         this.renderSlotTooltip(guiGraphics, x, y);
     }
 
-    protected void renderSlotTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderSlotTooltip(GuiGraphics guiGraphics, int x, int y) {
         if (this.hoveredSlot == null) return;
         if (!(this.hoveredSlot instanceof SlotItemHandlerWithFilter)) return;
         if (!((SlotItemHandlerWithFilter) this.hoveredSlot).isFilter()) return;
@@ -81,25 +80,27 @@ public class BatchCrafterScreen extends BaseMachineScreen<BatchCrafterMenu> impl
     }
 
     @Override
-    protected void slotClicked(@NotNull Slot slot, int slotId, int mouseButton, @NotNull ClickType type) {
-            if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
-                ItemStack carriedItem = this.menu.getCarried();
-                int realSlotId = slot.getContainerSlot();
-                if (this.menu.isFilterEnabled()) {
+    protected void slotClicked(Slot slot, int slotId, int mouseButton, ClickType type) {
+        if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
+            ItemStack carriedItem = this.menu.getCarried().copy();
+            int realSlotId = slot.getContainerSlot();
+            if (this.menu.isFilterEnabled()) {
+                ItemStack filter = this.menu.getFilter(realSlotId);
+                if (this.menu.isSlotDisabled(realSlotId)) {
                     PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
-                    PacketDistributor.sendToServer(new SlotFilterChangePacket(realSlotId, carriedItem.copy()));
-                    menu.setSlotDisabled(realSlotId, false);
-                    menu.setFilter(realSlotId, carriedItem.copy());
-                    slot.set(carriedItem);
-                } else {
-                    if (carriedItem.isEmpty()) {
-                        PacketDistributor.sendToServer(
-                            new SlotDisableChangePacket(realSlotId, !this.menu.isSlotDisabled(realSlotId)));
-                    } else {
-                        PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
-                    }
+                    this.menu.setSlotDisabled(realSlotId, false);
                 }
+                PacketDistributor.sendToServer(new SlotFilterChangePacket(realSlotId, carriedItem));
+                this.menu.setFilter(realSlotId, carriedItem);
+                if (carriedItem.is(ModItems.FILTER) && (filter.isEmpty() || !FilterItem.filter(filter, carriedItem))) return;
+                slot.set(carriedItem);
+            } else {
+                PacketDistributor.sendToServer(new SlotDisableChangePacket(
+                    realSlotId,
+                    carriedItem.isEmpty() && !this.menu.isSlotDisabled(realSlotId)
+                ));
             }
+        }
         super.slotClicked(slot, slotId, mouseButton, type);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/FilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/FilterScreen.java
@@ -1,6 +1,5 @@
 package dev.dubhe.anvilcraft.client.gui.screen;
 
-import com.mojang.blaze3d.platform.InputConstants;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.gui.component.SwitchableImageButton;
 import dev.dubhe.anvilcraft.init.ModComponents;
@@ -49,26 +48,22 @@ public class FilterScreen extends AbstractContainerScreen<FilterMenu> implements
 
         FilterContainer container = this.getMenu().getContainer();
 
-        this.addRenderableWidget(
-            new SwitchableImageButton(
-                this.leftPos + 25,
-                this.topPos + 25,
-                INCLUDE_COMPONENTS,
-                container::includeComponents,
-                container::setIncludeComponents,
-                this::sync
-            )
-        );
-        this.addRenderableWidget(
-            new SwitchableImageButton(
-                this.leftPos + 25,
-                this.topPos + 43,
-                BLACK_LIST,
-                container::blackList,
-                container::setBlackList,
-                this::sync
-            )
-        );
+        this.addRenderableWidget(new SwitchableImageButton(
+            this.leftPos + 26,
+            this.topPos + 26,
+            INCLUDE_COMPONENTS,
+            container::includeComponents,
+            container::setIncludeComponents,
+            this::sync
+        ));
+        this.addRenderableWidget(new SwitchableImageButton(
+            this.leftPos + 26,
+            this.topPos + 44,
+            BLACK_LIST,
+            container::blackList,
+            container::setBlackList,
+            this::sync
+        ));
     }
 
     @Override
@@ -80,14 +75,7 @@ public class FilterScreen extends AbstractContainerScreen<FilterMenu> implements
 
     @Override
     protected void slotClicked(Slot slot, int slotId, int button, ClickType type) {
-        if (
-            type == ClickType.PICKUP
-            && slot instanceof FilterSlot filterSlot
-            && (
-                button == InputConstants.MOUSE_BUTTON_LEFT
-                || button == InputConstants.MOUSE_BUTTON_RIGHT
-            )
-        ) {
+        if (slot instanceof FilterSlot filterSlot) {
             ItemStack filterStack = this.menu.getCarried();
             if (!filterStack.isEmpty()) {
                 if (filterStack.has(ModComponents.FILTER_CONTENT)) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/FilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/FilterScreen.java
@@ -6,6 +6,7 @@ import dev.dubhe.anvilcraft.client.gui.component.SwitchableImageButton;
 import dev.dubhe.anvilcraft.init.ModComponents;
 import dev.dubhe.anvilcraft.inventory.FilterMenu;
 import dev.dubhe.anvilcraft.inventory.component.FilterSlot;
+import dev.dubhe.anvilcraft.inventory.container.FilterContainer;
 import dev.dubhe.anvilcraft.item.property.component.FilterContent;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -46,15 +47,15 @@ public class FilterScreen extends AbstractContainerScreen<FilterMenu> implements
     protected void init() {
         super.init();
 
-        FilterContent content = this.getMenu().getContainer().getContent();
+        FilterContainer container = this.getMenu().getContainer();
 
         this.addRenderableWidget(
             new SwitchableImageButton(
                 this.leftPos + 25,
                 this.topPos + 25,
                 INCLUDE_COMPONENTS,
-                content::includeComponents,
-                flag -> this.getMenu().getContainer().setContent(content.setIncludeComponents(flag)),
+                container::includeComponents,
+                container::setIncludeComponents,
                 this::sync
             )
         );
@@ -63,8 +64,8 @@ public class FilterScreen extends AbstractContainerScreen<FilterMenu> implements
                 this.leftPos + 25,
                 this.topPos + 43,
                 BLACK_LIST,
-                content::blackList,
-                flag -> this.getMenu().getContainer().setContent(content.setBlackList(flag)),
+                container::blackList,
+                container::setBlackList,
                 this::sync
             )
         );
@@ -81,10 +82,10 @@ public class FilterScreen extends AbstractContainerScreen<FilterMenu> implements
     protected void slotClicked(Slot slot, int slotId, int button, ClickType type) {
         if (
             type == ClickType.PICKUP
-                && slot instanceof FilterSlot filterSlot
-                && (
+            && slot instanceof FilterSlot filterSlot
+            && (
                 button == InputConstants.MOUSE_BUTTON_LEFT
-                    || button == InputConstants.MOUSE_BUTTON_RIGHT
+                || button == InputConstants.MOUSE_BUTTON_RIGHT
             )
         ) {
             ItemStack filterStack = this.menu.getCarried();

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IFilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IFilterScreen.java
@@ -15,7 +15,6 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
@@ -72,6 +71,7 @@ public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> ex
      * @param slot   槽位
      * @param filter 过滤
      */
+    @SuppressWarnings("UnusedReturnValue")
     default boolean setFilter(int slot, ItemStack filter) {
         return this.getFilterMenu().setFilter(slot, filter);
     }
@@ -136,7 +136,7 @@ public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> ex
      * @param guiGraphics 画布
      * @param crafterSlot 槽位
      */
-    default void renderDisabledSlot(@NotNull GuiGraphics guiGraphics, @NotNull Slot crafterSlot) {
+    default void renderDisabledSlot(GuiGraphics guiGraphics, Slot crafterSlot) {
         RenderSystem.enableDepthTest();
         guiGraphics.blit(DISABLED_SLOT, crafterSlot.x, crafterSlot.y, 0, 0, 16, 16, 16, 16);
     }
@@ -148,7 +148,7 @@ public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> ex
      * @param slot        槽位
      * @param stack       物品堆叠
      */
-    default void renderFilterItem(@NotNull GuiGraphics guiGraphics, @NotNull Slot slot, @NotNull ItemStack stack) {
+    default void renderFilterItem(GuiGraphics guiGraphics, Slot slot, ItemStack stack) {
         int i = slot.x;
         int j = slot.y;
         RenderHelper.renderItemWithTransparency(stack, guiGraphics.pose(), i, j, 0.52f);

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemCollectorScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemCollectorScreen.java
@@ -5,7 +5,9 @@ import dev.dubhe.anvilcraft.api.itemhandler.SlotItemHandlerWithFilter;
 import dev.dubhe.anvilcraft.client.gui.component.EnableFilterButton;
 import dev.dubhe.anvilcraft.client.gui.component.ItemCollectorButton;
 import dev.dubhe.anvilcraft.client.gui.component.TextWidget;
+import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.inventory.ItemCollectorMenu;
+import dev.dubhe.anvilcraft.item.FilterItem;
 import dev.dubhe.anvilcraft.network.SlotDisableChangePacket;
 import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import lombok.Getter;
@@ -19,16 +21,12 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.function.BiFunction;
 
-public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMenu>
-    implements IFilterScreen<ItemCollectorMenu> {
-    private static final ResourceLocation CONTAINER_LOCATION =
-        AnvilCraft.of("textures/gui/container/machine/background/item_collector.png");
-    BiFunction<Integer, Integer, EnableFilterButton> enableFilterButtonSupplier =
-        this.getEnableFilterButtonSupplier(75, 54);
+public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMenu> implements IFilterScreen<ItemCollectorMenu> {
+    private static final ResourceLocation CONTAINER_LOCATION = AnvilCraft.of("textures/gui/container/machine/background/item_collector.png");
+    BiFunction<Integer, Integer, EnableFilterButton> enableFilterButtonSupplier = this.getEnableFilterButtonSupplier(75, 54);
 
     @Getter
     private EnableFilterButton enableFilterButton = null;
@@ -47,74 +45,84 @@ public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMe
     @Override
     protected void init() {
         super.init();
-        this.enableFilterButton = enableFilterButtonSupplier.apply(this.leftPos, this.topPos);
+        this.enableFilterButton = this.enableFilterButtonSupplier.apply(this.leftPos, this.topPos);
         this.addRenderableWidget(this.enableFilterButton);
+        if (this.minecraft == null) return;
         // range
         this.addRenderableWidget(new TextWidget(
-            leftPos + 57,
-            topPos + 24,
+            this.leftPos + 57,
+            this.topPos + 24,
             20,
             8,
-            minecraft.font,
-            () -> Component.literal(
-                menu.getBlockEntity().getRangeRadius().get().toString())));
+            this.minecraft.font,
+            () -> Component.literal(this.menu.getBlockEntity().getRangeRadius().get().toString())
+        ));
         // cooldown
         this.addRenderableWidget(new TextWidget(
-            leftPos + 57,
-            topPos + 38,
+            this.leftPos + 57,
+            this.topPos + 38,
             20,
             8,
-            minecraft.font,
-            () -> Component.literal(
-                menu.getBlockEntity().getCooldown().get().toString())));
+            this.minecraft.font,
+            () -> Component.literal(this.menu.getBlockEntity().getCooldown().get().toString())
+        ));
         // power cost
         this.addRenderableWidget(new TextWidget(
-            leftPos + 43,
-            topPos + 51,
+            this.leftPos + 43,
+            this.topPos + 51,
             20,
             8,
-            minecraft.font,
-            () -> Component.literal(Integer.toString(menu.getBlockEntity().getInputPower()))));
+            this.minecraft.font,
+            () -> Component.literal(Integer.toString(this.menu.getBlockEntity().getInputPower()))
+        ));
         // range - +
-        this.addRenderableWidget(new ItemCollectorButton(leftPos + 43, topPos + 23, "minus", (b) -> {
-            menu.getBlockEntity().getRangeRadius().previous();
-            menu.getBlockEntity().getRangeRadius().notifyServer();
-        }));
-        this.addRenderableWidget(new ItemCollectorButton(leftPos + 81, topPos + 23, "add", (b) -> {
-            menu.getBlockEntity().getRangeRadius().next();
-            menu.getBlockEntity().getRangeRadius().notifyServer();
-        }));
+        this.addRenderableWidget(new ItemCollectorButton(
+            this.leftPos + 43, this.topPos + 23, "minus", (b) -> {
+            this.menu.getBlockEntity().getRangeRadius().previous();
+            this.menu.getBlockEntity().getRangeRadius().notifyServer();
+        }
+        ));
+        this.addRenderableWidget(new ItemCollectorButton(
+            this.leftPos + 81, this.topPos + 23, "add", (b) -> {
+            this.menu.getBlockEntity().getRangeRadius().next();
+            this.menu.getBlockEntity().getRangeRadius().notifyServer();
+        }
+        ));
         // cooldown - +
-        this.addRenderableWidget(new ItemCollectorButton(leftPos + 43, topPos + 37, "minus", (b) -> {
-            menu.getBlockEntity().getCooldown().previous();
-            menu.getBlockEntity().getCooldown().notifyServer();
-        }));
-        this.addRenderableWidget(new ItemCollectorButton(leftPos + 81, topPos + 37, "add", (b) -> {
-            menu.getBlockEntity().getCooldown().next();
-            menu.getBlockEntity().getCooldown().notifyServer();
-        }));
+        this.addRenderableWidget(new ItemCollectorButton(
+            this.leftPos + 43, this.topPos + 37, "minus", (b) -> {
+            this.menu.getBlockEntity().getCooldown().previous();
+            this.menu.getBlockEntity().getCooldown().notifyServer();
+        }
+        ));
+        this.addRenderableWidget(new ItemCollectorButton(
+            leftPos + 81, topPos + 37, "add", (b) -> {
+            this.menu.getBlockEntity().getCooldown().next();
+            this.menu.getBlockEntity().getCooldown().notifyServer();
+        }
+        ));
     }
 
     @Override
-    protected void renderBg(@NotNull GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
+    protected void renderBg(GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
         int i = (this.width - this.imageWidth) / 2;
         int j = (this.height - this.imageHeight) / 2;
         guiGraphics.blit(CONTAINER_LOCATION, i, j, 0, 0, this.imageWidth, this.imageHeight);
     }
 
     @Override
-    public void renderSlot(@NotNull GuiGraphics guiGraphics, @NotNull Slot slot) {
+    public void renderSlot(GuiGraphics guiGraphics, Slot slot) {
         super.renderSlot(guiGraphics, slot);
         IFilterScreen.super.renderSlot(guiGraphics, slot);
     }
 
     @Override
-    protected void renderTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderTooltip(GuiGraphics guiGraphics, int x, int y) {
         super.renderTooltip(guiGraphics, x, y);
         this.renderSlotTooltip(guiGraphics, x, y);
     }
 
-    protected void renderSlotTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderSlotTooltip(GuiGraphics guiGraphics, int x, int y) {
         if (this.hoveredSlot == null) return;
         if (!(this.hoveredSlot instanceof SlotItemHandlerWithFilter)) return;
         if (!((SlotItemHandlerWithFilter) this.hoveredSlot).isFilter()) return;
@@ -124,7 +132,7 @@ public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMe
     }
 
     @Override
-    public void render(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         super.render(guiGraphics, mouseX, mouseY, partialTick);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
     }
@@ -139,25 +147,27 @@ public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMe
         this.enableFilterButton.flush();
     }
 
-    protected void slotClicked(@NotNull Slot slot, int slotId, int mouseButton, @NotNull ClickType type) {
-            if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
-                ItemStack carriedItem = this.menu.getCarried();
-                int realSlotId = slot.getContainerSlot();
-                if (this.menu.isFilterEnabled()) {
+    protected void slotClicked(Slot slot, int slotId, int mouseButton, ClickType type) {
+        if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
+            ItemStack carriedItem = this.menu.getCarried().copy();
+            int realSlotId = slot.getContainerSlot();
+            if (this.menu.isFilterEnabled()) {
+                ItemStack filter = this.menu.getFilter(realSlotId);
+                if (this.menu.isSlotDisabled(realSlotId)) {
                     PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
-                    PacketDistributor.sendToServer(new SlotFilterChangePacket(realSlotId, carriedItem.copy()));
-                    menu.setSlotDisabled(realSlotId, false);
-                    menu.setFilter(realSlotId, carriedItem.copy());
-                    slot.set(carriedItem);
-                } else {
-                    if (carriedItem.isEmpty()) {
-                        PacketDistributor.sendToServer(
-                            new SlotDisableChangePacket(realSlotId, !this.menu.isSlotDisabled(realSlotId)));
-                    } else {
-                        PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
-                    }
+                    this.menu.setSlotDisabled(realSlotId, false);
                 }
+                PacketDistributor.sendToServer(new SlotFilterChangePacket(realSlotId, carriedItem));
+                this.menu.setFilter(realSlotId, carriedItem);
+                if (carriedItem.is(ModItems.FILTER) && (filter.isEmpty() || !FilterItem.filter(filter, carriedItem))) return;
+                slot.set(carriedItem);
+            } else {
+                PacketDistributor.sendToServer(new SlotDisableChangePacket(
+                    realSlotId,
+                    carriedItem.isEmpty() && !this.menu.isSlotDisabled(realSlotId)
+                ));
             }
+        }
         super.slotClicked(slot, slotId, mouseButton, type);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemCollectorScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemCollectorScreen.java
@@ -13,6 +13,7 @@ import dev.dubhe.anvilcraft.network.SlotFilterChangePacket;
 import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -151,7 +152,7 @@ public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMe
         if (slot instanceof SlotItemHandlerWithFilter && slot.getItem().isEmpty()) {
             ItemStack carriedItem = this.menu.getCarried().copy();
             int realSlotId = slot.getContainerSlot();
-            if (this.menu.isFilterEnabled()) {
+            if (!carriedItem.isEmpty() && this.menu.isFilterEnabled()) {
                 ItemStack filter = this.menu.getFilter(realSlotId);
                 if (this.menu.isSlotDisabled(realSlotId)) {
                     PacketDistributor.sendToServer(new SlotDisableChangePacket(realSlotId, false));
@@ -161,7 +162,7 @@ public class ItemCollectorScreen extends AbstractContainerScreen<ItemCollectorMe
                 this.menu.setFilter(realSlotId, carriedItem);
                 if (carriedItem.is(ModItems.FILTER) && (filter.isEmpty() || !FilterItem.filter(filter, carriedItem))) return;
                 slot.set(carriedItem);
-            } else {
+            } else if (Screen.hasShiftDown()) {
                 PacketDistributor.sendToServer(new SlotDisableChangePacket(
                     realSlotId,
                     carriedItem.isEmpty() && !this.menu.isSlotDisabled(realSlotId)

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemDetectorScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemDetectorScreen.java
@@ -23,7 +23,6 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
@@ -43,7 +42,7 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
         Component.translatable("screen.anvilcraft.filter.shift_to_scroll_faster")
             .withStyle(ChatFormatting.ITALIC, ChatFormatting.GRAY);
 
-    private CycleFilterModeButton cycleFilterModeButton;
+    protected CycleFilterModeButton cycleFilterModeButton;
 
     public ItemDetectorScreen(ItemDetectorMenu menu, Inventory playerInventory, Component title) {
         super(menu, playerInventory, title);
@@ -80,24 +79,35 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
             8,
             Minecraft.getInstance().font,
             () -> Component.literal(
-                String.valueOf(this.menu.getBlockEntity().getRange()))));
+                String.valueOf(this.menu.getBlockEntity().getRange()))
+        ));
         // range - +
-        this.addRenderableWidget(new ItemCollectorButton(leftPos + 43, topPos + 23, "minus", (b) -> {
-            this.menu.getBlockEntity().decreaseRange();
-            PacketDistributor.sendToServer(
-                new ItemDetectorChangeRangePacket(this.menu.getBlockEntity().getRange())
-            );
-        }));
-        this.addRenderableWidget(new ItemCollectorButton(leftPos + 81, topPos + 23, "add", (b) -> {
-            this.menu.getBlockEntity().increaseRange();
-            PacketDistributor.sendToServer(
-                new ItemDetectorChangeRangePacket(this.menu.getBlockEntity().getRange())
-            );
-        }));
+        this.addRenderableWidget(new ItemCollectorButton(
+            leftPos + 43,
+            topPos + 23,
+            "minus",
+            (b) -> {
+                this.menu.getBlockEntity().decreaseRange();
+                PacketDistributor.sendToServer(
+                    new ItemDetectorChangeRangePacket(this.menu.getBlockEntity().getRange())
+                );
+            }
+        ));
+        this.addRenderableWidget(new ItemCollectorButton(
+            leftPos + 81,
+            topPos + 23,
+            "add",
+            (b) -> {
+                this.menu.getBlockEntity().increaseRange();
+                PacketDistributor.sendToServer(
+                    new ItemDetectorChangeRangePacket(this.menu.getBlockEntity().getRange())
+                );
+            }
+        ));
     }
 
     @Override
-    public void renderSlot(@NotNull GuiGraphics guiGraphics, @NotNull Slot slot) {
+    public void renderSlot(GuiGraphics guiGraphics, Slot slot) {
         super.renderSlot(guiGraphics, slot);
         if (slot instanceof FilterOnlySlot && slot.getItem().isEmpty()) {
             this.renderDisabledSlot(guiGraphics, slot);
@@ -105,7 +115,7 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
     }
 
     @Override
-    protected void renderTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderTooltip(GuiGraphics guiGraphics, int x, int y) {
         super.renderTooltip(guiGraphics, x, y);
         this.renderSlotTooltip(guiGraphics, x, y);
     }
@@ -122,7 +132,7 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
             .orElse(false);
     }
 
-    protected void renderSlotTooltip(@NotNull GuiGraphics guiGraphics, int x, int y) {
+    protected void renderSlotTooltip(GuiGraphics guiGraphics, int x, int y) {
         if (this.hoveringEmptyFilterSlot()) {
             guiGraphics.renderTooltip(this.font, Component.translatable("screen.anvilcraft.slot.disable.tooltip"), x, y);
         }
@@ -145,11 +155,15 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
     }
 
     @Override
-    protected void slotClicked(@NotNull Slot slot, int slotId, int button, @NotNull ClickType type) {
-        if (type == ClickType.PICKUP
+    protected void slotClicked(Slot slot, int slotId, int button, ClickType type) {
+        if (
+            type == ClickType.PICKUP
             && slot instanceof FilterOnlySlot filterSlot
-            && (button == InputConstants.MOUSE_BUTTON_LEFT
-            || button == InputConstants.MOUSE_BUTTON_RIGHT)) {
+            && (
+                button == InputConstants.MOUSE_BUTTON_LEFT
+                || button == InputConstants.MOUSE_BUTTON_RIGHT
+            )
+        ) {
             ItemStack filterStack = this.menu.getCarried();
             int id = slot.getContainerSlot();
             if (!filterStack.isEmpty() && button == InputConstants.MOUSE_BUTTON_RIGHT) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemDetectorScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/ItemDetectorScreen.java
@@ -14,6 +14,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -156,15 +157,9 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
 
     @Override
     protected void slotClicked(Slot slot, int slotId, int button, ClickType type) {
-        if (
-            type == ClickType.PICKUP
-            && slot instanceof FilterOnlySlot filterSlot
-            && (
-                button == InputConstants.MOUSE_BUTTON_LEFT
-                || button == InputConstants.MOUSE_BUTTON_RIGHT
-            )
-        ) {
+        if (slot instanceof FilterOnlySlot filterSlot) {
             ItemStack filterStack = this.menu.getCarried();
+            if (filterStack.isEmpty() && !Screen.hasShiftDown()) return;
             int id = slot.getContainerSlot();
             if (!filterStack.isEmpty() && button == InputConstants.MOUSE_BUTTON_RIGHT) {
                 filterStack = filterStack.copyWithCount(1);
@@ -179,7 +174,7 @@ public class ItemDetectorScreen extends AbstractContainerScreen<ItemDetectorMenu
     }
 
     private int getScrollSpeed() {
-        return hasShiftDown() ? 5 : 1;
+        return Screen.hasShiftDown() ? 5 : 1;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/BaseChuteMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/BaseChuteMenu.java
@@ -15,17 +15,14 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Getter
 public abstract class BaseChuteMenu<T extends BaseChuteBlockEntity> extends BaseMachineMenu implements IFilterMenu {
-
     public final T blockEntity;
     private final Level level;
 
-    public BaseChuteMenu(
-        @Nullable MenuType<?> menuType, int containerId, Inventory inventory, @NotNull FriendlyByteBuf extraData) {
+    public BaseChuteMenu(@Nullable MenuType<?> menuType, int containerId, Inventory inventory, FriendlyByteBuf extraData) {
         this(menuType, containerId, inventory, inventory.player.level().getBlockEntity(extraData.readBlockPos()));
     }
 
@@ -47,14 +44,7 @@ public abstract class BaseChuteMenu<T extends BaseChuteBlockEntity> extends Base
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 3; ++j) {
-                this.addSlot(
-                    new SlotItemHandlerWithFilter(
-                        this.blockEntity.getItemHandler(),
-                        i * 3 + j,
-                        62 + j * 18,
-                        18 + i * 18
-                    )
-                );
+                this.addSlot(new SlotItemHandlerWithFilter(this.blockEntity.getItemHandler(), i * 3 + j, 62 + j * 18, 18 + i * 18));
             }
         }
     }
@@ -95,7 +85,7 @@ public abstract class BaseChuteMenu<T extends BaseChuteBlockEntity> extends Base
 
     @SuppressWarnings("DuplicatedCode")
     @Override
-    public @NotNull ItemStack quickMoveStack(@NotNull Player playerIn, int index) {
+    public ItemStack quickMoveStack(Player playerIn, int index) {
         Slot sourceSlot = slots.get(index);
         //noinspection ConstantValue
         if (sourceSlot == null || !sourceSlot.hasItem()) {
@@ -112,12 +102,7 @@ public abstract class BaseChuteMenu<T extends BaseChuteBlockEntity> extends Base
             }
         } else if (index < TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT) {
             // This is a TE slot so merge the stack into the players inventory
-            if (!moveItemStackTo(
-                sourceStack,
-                VANILLA_FIRST_SLOT_INDEX,
-                VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT,
-                false
-            )) {
+            if (!moveItemStackTo(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
                 return ItemStack.EMPTY;
             }
         } else {
@@ -159,14 +144,13 @@ public abstract class BaseChuteMenu<T extends BaseChuteBlockEntity> extends Base
             }
             // 当前槽位没有禁用，并且要放入的物品就是当前槽位的过滤器要过滤的物品，返回true
             // 如果未设置保留物品过滤，即所有槽位都没有被禁用，此时过滤器不会过滤任何物品，所以当前过滤器要过滤的物品为空时也应该返回true
-            ItemStack filterItem = depositorySlot.getFilterItem(9 - (45 - index));
-            return filterItem.isEmpty() || ItemStack.isSameItem(filterItem, stack) || FilterItem.filter(filterItem, stack);
+            return FilterItem.filter(depositorySlot.getFilterItem(9 - (45 - index)), stack);
         }
         return true;
     }
 
     @Override
-    public boolean stillValid(@NotNull Player player) {
+    public boolean stillValid(Player player) {
         return stillValid(ContainerLevelAccess.create(level, blockEntity.getBlockPos()), player, getBlock());
     }
 
@@ -178,7 +162,7 @@ public abstract class BaseChuteMenu<T extends BaseChuteBlockEntity> extends Base
     }
 
     @Override
-    public int getFilterSlotIndex(@NotNull Slot slot) {
+    public int getFilterSlotIndex(Slot slot) {
         return slot.index - 36;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/ItemCollectorMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/ItemCollectorMenu.java
@@ -17,7 +17,6 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterMenu, ContainerListener {
@@ -28,8 +27,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
     /**
      * 物品收集器 ScreenHandler
      */
-    public ItemCollectorMenu(
-        @Nullable MenuType<?> menuType, int containerId, Inventory inventory, @NotNull BlockEntity machine) {
+    public ItemCollectorMenu(@Nullable MenuType<?> menuType, int containerId, Inventory inventory, BlockEntity machine) {
         super(menuType, containerId);
         ItemCollectorMenu.checkContainerSize(inventory, 9);
 
@@ -41,8 +39,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 3; ++j) {
-                this.addSlot(new SlotItemHandlerWithFilter(
-                    this.blockEntity.getItemHandler(), i * 3 + j, 98 + j * 18, 18 + i * 18));
+                this.addSlot(new SlotItemHandlerWithFilter(this.blockEntity.getItemHandler(), i * 3 + j, 98 + j * 18, 18 + i * 18));
             }
         }
 
@@ -50,8 +47,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
         this.addSlotListener(this);
     }
 
-    public ItemCollectorMenu(
-        @Nullable MenuType<?> menuType, int containerId, Inventory inventory, @NotNull FriendlyByteBuf extraData) {
+    public ItemCollectorMenu(@Nullable MenuType<?> menuType, int containerId, Inventory inventory, FriendlyByteBuf extraData) {
         this(menuType, containerId, inventory, inventory.player.level().getBlockEntity(extraData.readBlockPos()));
     }
 
@@ -78,7 +74,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
     }
 
     @Override
-    public void setItem(int slotId, int stateId, @NotNull ItemStack stack) {
+    public void setItem(int slotId, int stateId, ItemStack stack) {
         super.setItem(slotId, stateId, stack);
         this.onChanged();
     }
@@ -95,7 +91,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
     private static final int TE_INVENTORY_SLOT_COUNT = 9; // must be the number of slots you have!
 
     @Override
-    public @NotNull ItemStack quickMoveStack(@NotNull Player playerIn, int index) {
+    public ItemStack quickMoveStack(Player playerIn, int index) {
         Slot sourceSlot = slots.get(index);
         //noinspection ConstantValue
         if (sourceSlot == null || !sourceSlot.hasItem()) {
@@ -112,12 +108,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
             }
         } else if (index < TE_INVENTORY_FIRST_SLOT_INDEX + TE_INVENTORY_SLOT_COUNT) {
             // This is a TE slot so merge the stack into the players inventory
-            if (!moveItemStackTo(
-                sourceStack,
-                VANILLA_FIRST_SLOT_INDEX,
-                VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT,
-                false
-            )) {
+            if (!moveItemStackTo(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
                 return ItemStack.EMPTY;
             }
         } else {
@@ -158,26 +149,23 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
             }
             // 当前槽位没有禁用，并且要放入的物品就是当前槽位的过滤器要过滤的物品，返回true
             // 如果未设置保留物品过滤，即所有槽位都没有被禁用，此时过滤器不会过滤任何物品，所以当前过滤器要过滤的物品为空时也应该返回true
-            ItemStack filterItem = depositorySlot.getFilterItem(9 - (45 - index));
-            return filterItem.isEmpty() || ItemStack.isSameItem(filterItem, stack) || FilterItem.filter(filterItem, stack);
+            return FilterItem.filter(depositorySlot.getFilterItem(9 - (45 - index)), stack);
         }
         return true;
     }
 
     @Override
-    public boolean stillValid(@NotNull Player player) {
-        return stillValid(
-            ContainerLevelAccess.create(level, blockEntity.getBlockPos()), player, ModBlocks.ITEM_COLLECTOR.get());
+    public boolean stillValid(Player player) {
+        return stillValid(ContainerLevelAccess.create(level, blockEntity.getBlockPos()), player, ModBlocks.ITEM_COLLECTOR.get());
     }
 
     @Override
-    public void slotChanged(
-        @NotNull AbstractContainerMenu containerToSend, int dataSlotIndex, @NotNull ItemStack stack) {
+    public void slotChanged(AbstractContainerMenu containerToSend, int dataSlotIndex, ItemStack stack) {
         onChanged();
     }
 
     @Override
-    public void dataChanged(@NotNull AbstractContainerMenu containerMenu, int dataSlotIndex, int value) {
+    public void dataChanged(AbstractContainerMenu containerMenu, int dataSlotIndex, int value) {
     }
 
     @Override
@@ -199,7 +187,7 @@ public class ItemCollectorMenu extends AbstractContainerMenu implements IFilterM
     }
 
     @Override
-    public int getFilterSlotIndex(@NotNull Slot slot) {
+    public int getFilterSlotIndex(Slot slot) {
         return slot.index - 36;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/container/FilterContainer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/container/FilterContainer.java
@@ -89,4 +89,20 @@ public class FilterContainer implements Container {
     public void sync() {
         PacketDistributor.sendToServer(new FilterContentSyncPacket(position, content));
     }
+
+    public boolean includeComponents() {
+        return this.getContent().includeComponents();
+    }
+
+    public boolean blackList() {
+        return this.getContent().blackList();
+    }
+
+    public void setIncludeComponents(boolean includeComponents) {
+        this.setContent(this.getContent().setIncludeComponents(includeComponents));
+    }
+
+    public void setBlackList(boolean blackList) {
+        this.setContent(this.getContent().setBlackList(blackList));
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/item/FilterItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FilterItem.java
@@ -25,8 +25,8 @@ public class FilterItem extends Item {
         super(properties);
     }
 
-    public static boolean filter(ItemStack filterStack, ItemStack stack) {
-        return FilterContent.filter(filterStack, stack, false, false);
+    public static boolean filter(ItemStack filter, ItemStack stack) {
+        return filter.isEmpty() || ItemStack.isSameItem(filter, stack) || FilterContent.filter(filter, stack, false, false);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/FilterItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FilterItem.java
@@ -26,7 +26,20 @@ public class FilterItem extends Item {
     }
 
     public static boolean filter(ItemStack filter, ItemStack stack) {
-        return filter.isEmpty() || ItemStack.isSameItem(filter, stack) || FilterContent.filter(filter, stack, false, false);
+        return filter.isEmpty()
+               || (
+                   filter.is(ModItems.FILTER)
+                   ? ItemStack.isSameItemSameComponents(filter, stack)
+                   : ItemStack.isSameItem(filter, stack)
+               )
+               || FilterContent.filter(filter, stack, false, false);
+    }
+
+    @Override
+    public void verifyComponentsAfterLoad(ItemStack stack) {
+        if (stack.is(ModItems.FILTER) && !stack.has(ModComponents.FILTER_CONTENT)) {
+            stack.set(ModComponents.FILTER_CONTENT, new FilterContent());
+        }
     }
 
     @Override
@@ -34,9 +47,6 @@ public class FilterItem extends Item {
         ItemStack itemstack = player.getItemInHand(usedHand);
         if (!itemstack.is(ModItems.FILTER)) return InteractionResultHolder.pass(itemstack);
         if (level.isClientSide()) return InteractionResultHolder.success(itemstack);
-        if (!itemstack.has(ModComponents.FILTER_CONTENT)) {
-            itemstack.set(ModComponents.FILTER_CONTENT, new FilterContent());
-        }
         int position = usedHand == InteractionHand.MAIN_HAND ? player.getInventory().selected : 151;
         ModMenuTypes.open((ServerPlayer) player, new FilterMenuProvider(position));
         return InteractionResultHolder.success(itemstack);

--- a/src/main/java/dev/dubhe/anvilcraft/item/property/component/FilterContent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/property/component/FilterContent.java
@@ -21,6 +21,7 @@ import net.minecraft.world.item.Items;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -85,14 +86,18 @@ public record FilterContent(NonNullList<ItemStack> list, boolean includeComponen
             if (filterStack.is(Items.NAME_TAG) && filterStack.has(DataComponents.CUSTOM_NAME)) {
                 Component name = filterStack.getOrDefault(DataComponents.CUSTOM_NAME, Component.empty());
                 String string = name.getString();
-                if (string.startsWith("#")) {
+                Pattern pattern = Pattern.compile("^#(([a-z0-9._-]*:[a-z0-9/._-]*)|[a-z0-9/._-]*)$");
+                if (pattern.matcher(string).matches()) {
                     TagKey<Item> tag = TagKey.create(Registries.ITEM, ResourceLocation.parse(string.substring(1)));
                     if (stack.is(tag)) return !isBlackList;
                 }
             }
             boolean flag = false;
-            if (!isIncludeComponents && ItemStack.isSameItem(filterStack, stack)) flag = true;
-            else if (isIncludeComponents && ItemStack.isSameItemSameComponents(filterStack, stack)) flag = true;
+            if (!isIncludeComponents && ItemStack.isSameItem(filterStack, stack)) {
+                flag = true;
+            } else if (isIncludeComponents && ItemStack.isSameItemSameComponents(filterStack, stack)) {
+                flag = true;
+            }
             if (flag) return !isBlackList;
             return isBlackList;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/network/SlotFilterChangePacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/SlotFilterChangePacket.java
@@ -53,12 +53,11 @@ public class SlotFilterChangePacket implements CustomPacketPayload {
     }
 
     @Override
-    @NotNull
     public Type<? extends CustomPacketPayload> type() {
         return TYPE;
     }
 
-    public static void serverHandler(SlotFilterChangePacket data, IPayloadContext context) {
+    public static void serverHandler(SlotFilterChangePacket data, @NotNull IPayloadContext context) {
         ServerPlayer player = (ServerPlayer) context.player();
         context.enqueueWork(() -> {
             if (!player.hasContainerOpen()) return;
@@ -69,7 +68,7 @@ public class SlotFilterChangePacket implements CustomPacketPayload {
         });
     }
 
-    public static void clientHandler(SlotFilterChangePacket data, IPayloadContext context) {
+    public static void clientHandler(SlotFilterChangePacket data, @NotNull IPayloadContext context) {
         Minecraft client = Minecraft.getInstance();
         context.enqueueWork(() -> {
             if (!(client.screen instanceof IFilterScreen<?> screen)) return;


### PR DESCRIPTION
- 在 FilterContainer 中添加 includeComponents 和 blackList 方法
- 在 FilterContainer 中添加 setIncludeComponents 和 setBlackList 方法
- 更新 FilterScreen 中的逻辑，使用 FilterContainer 的新方法
- 优化 FilterScreen 中的代码结构
- 重构了多个类中的过滤器处理逻辑，简化了代码
- 优化了过滤器屏幕组件的渲染和交互逻辑
- 调整了过滤器相关的网络包处理
- 在 BaseChuteScreen、BatchCrafterScreen、ItemCollectorScreen 和 ItemDetectorScreen 中增加了对空物品堆的检查
- 修改了过滤器槽的操作逻辑，只有在携带非空物品时才执行相关操作
- 在过滤器模式下，增加了对 Shift 键的检测来清除过滤
- 修复了使用 NAME_TAG 作为过滤器时，自定义名称含#号但非标签的情况导致的崩溃问题
- 优化了过滤器匹配逻辑，支持正则表达式验证标签格式
- 调整了普通物品和过滤器物品在匹配时的处理方式