### PR TITLE
Builder support for tutorials on adding power related blocks 添加电力相关方块的教程的 Builder 支持

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/support/PowerGridSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/PowerGridSupport.java
@@ -8,6 +8,7 @@ import dev.dubhe.anvilcraft.client.init.ModRenderTargets;
 import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
 import dev.dubhe.anvilcraft.client.renderer.Line;
 import dev.dubhe.anvilcraft.client.renderer.RenderState;
+import dev.dubhe.anvilcraft.constant.Constant;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
@@ -55,7 +56,7 @@ public class PowerGridSupport {
         for (SimplePowerGrid grid : PowerGridSupport.GRID_MAP.values()) {
             if (!grid.shouldRender(camera)) continue;
             if (!grid.getLevel().equals(level)) continue;
-            grid.getPowerTransmitterLines().forEach(it -> it.render(poseStack, consumer1, camera, 0x9966ccff));
+            grid.getPowerTransmitterLines().forEach(it -> it.render(poseStack, consumer1, camera, Constant.TRANSMITTER_LINE_COLOR));
         }
         bufferSource.endBatch();
     }
@@ -69,7 +70,7 @@ public class PowerGridSupport {
         for (SimplePowerGrid grid : PowerGridSupport.GRID_MAP.values()) {
             if (!grid.shouldRender(camera)) continue;
             if (!grid.getLevel().equals(level)) continue;
-            grid.getPowerTransmitterLines().forEach(it -> it.render(poseStack, consumer, camera, 0x9966ccff));
+            grid.getPowerTransmitterLines().forEach(it -> it.render(poseStack, consumer, camera, Constant.TRANSMITTER_LINE_COLOR));
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/constant/Constant.java
+++ b/src/main/java/dev/dubhe/anvilcraft/constant/Constant.java
@@ -1,0 +1,8 @@
+package dev.dubhe.anvilcraft.constant;
+
+public abstract class Constant {
+    public static final int TRANSMITTER_LINE_COLOR = 0x9966CCFF;
+
+    private Constant() {
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -623,7 +623,7 @@ public class ModBlocks {
                 .save(provider);
         })
         .register();
-    public static final BlockEntry<? extends Block> TRANSMISSION_POLE = REGISTRATE
+    public static final BlockEntry<TransmissionPoleBlock> TRANSMISSION_POLE = REGISTRATE
         .block("transmission_pole", TransmissionPoleBlock::new)
         .initialProperties(ModBlocks.MAGNET_BLOCK)
         .properties(properties -> properties.noOcclusion().lightLevel(state -> {

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderPlugin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderPlugin.java
@@ -10,7 +10,6 @@ import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
 import net.createmod.ponder.api.registration.PonderTagRegistrationHelper;
 import net.createmod.ponder.foundation.PonderIndex;
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.NotNull;
 
 import static dev.dubhe.anvilcraft.AnvilCraft.REGISTRATE;
 
@@ -21,7 +20,7 @@ public class AnvilCraftPonderPlugin implements PonderPlugin {
      * @return the ModID of the mod that added this plugin
      */
     @Override
-    public @NotNull String getModId() {
+    public String getModId() {
         return AnvilCraft.MOD_ID;
     }
 
@@ -29,7 +28,7 @@ public class AnvilCraftPonderPlugin implements PonderPlugin {
      * Register all the Ponder Scenes added by your Mod
      */
     @Override
-    public void registerScenes(@NotNull PonderSceneRegistrationHelper<ResourceLocation> helper) {
+    public void registerScenes(PonderSceneRegistrationHelper<ResourceLocation> helper) {
         AnvilCraftPonderScenes.register(helper);
     }
 
@@ -37,7 +36,7 @@ public class AnvilCraftPonderPlugin implements PonderPlugin {
      * Register all the Ponder Tags added by your Mod
      */
     @Override
-    public void registerTags(@NotNull PonderTagRegistrationHelper<ResourceLocation> helper) {
+    public void registerTags(PonderTagRegistrationHelper<ResourceLocation> helper) {
         AnvilCraftPonderTags.register(helper);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderScenes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderScenes.java
@@ -1,18 +1,23 @@
 package dev.dubhe.anvilcraft.integration.ponder;
 
 import dev.dubhe.anvilcraft.integration.ponder.scene.AnvilScene;
+import dev.dubhe.anvilcraft.integration.ponder.scene.power.TransmissionPoleScene;
 import dev.dubhe.anvilcraft.integration.ponder.scene.redstone.BlockComparatorScene;
 import dev.dubhe.anvilcraft.integration.ponder.scene.redstone.MagnetScene;
-import dev.dubhe.anvilcraft.integration.ponder.scene.SpaceOvercompressorScene;
+import dev.dubhe.anvilcraft.integration.ponder.scene.recipe.SpaceOvercompressorScene;
 import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.NotNull;
 
 public class AnvilCraftPonderScenes {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> helper) {
+    public static void register(PonderSceneRegistrationHelper<ResourceLocation> helper) {
+        // base
         AnvilScene.register(helper);
-        MagnetScene.register(helper);
+        // recipe
         SpaceOvercompressorScene.register(helper);
+        // redstone
+        MagnetScene.register(helper);
         BlockComparatorScene.register(helper);
+        // power
+        TransmissionPoleScene.register(helper);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/AnvilCraftPonderTags.java
@@ -8,7 +8,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import org.jetbrains.annotations.NotNull;
 
 public class AnvilCraftPonderTags {
     public static final ResourceLocation ANVIL = AnvilCraft.of("anvil");
@@ -16,7 +15,9 @@ public class AnvilCraftPonderTags {
 
     public static final ResourceLocation REDSTONE_COMPONENTS = AnvilCraft.of("redstone_components");
 
-    public static void register(@NotNull PonderTagRegistrationHelper<ResourceLocation> helper) {
+    public static final ResourceLocation POWER_COMPONENTS = AnvilCraft.of("power_components");
+
+    public static void register(PonderTagRegistrationHelper<ResourceLocation> helper) {
         PonderTagRegistrationHelper<RegistryEntry<?, ?>> registryTagHelper = helper.withKeyFunction(RegistryEntry::getId);
         PonderTagRegistrationHelper<Item> itemTagHelper = helper.withKeyFunction(BuiltInRegistries.ITEM::getKey);
 
@@ -39,6 +40,13 @@ public class AnvilCraftPonderTags {
             .item(ModBlocks.BLOCK_COMPARATOR, true, false)
             .title("Redstone components")
             .description("New redstone components")
+            .register();
+
+        helper.registerTag(POWER_COMPONENTS)
+            .addToIndex()
+            .item(ModBlocks.TRANSMISSION_POLE, true, false)
+            .title("Power components")
+            .description("Power components")
             .register();
 
 
@@ -64,5 +72,9 @@ public class AnvilCraftPonderTags {
             .add(ModBlocks.BLOCK_COMPARATOR)
             .add(ModBlocks.ITEM_DETECTOR)
             .add(ModBlocks.PULSE_GENERATOR);
+
+        registryTagHelper.addToTag(POWER_COMPONENTS)
+            .add(ModBlocks.TRANSMISSION_POLE)
+            .add(ModBlocks.REMOTE_TRANSMISSION_POLE);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/api/AnvilCraftSceneBuilder.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/api/AnvilCraftSceneBuilder.java
@@ -1,0 +1,115 @@
+package dev.dubhe.anvilcraft.integration.ponder.api;
+
+import dev.dubhe.anvilcraft.block.multipart.AbstractMultiPartBlock;
+import dev.dubhe.anvilcraft.block.state.ISimpleMultiPartBlockState;
+import dev.dubhe.anvilcraft.constant.Constant;
+import net.createmod.ponder.api.scene.SceneBuilder;
+import net.createmod.ponder.api.scene.Selection;
+import net.createmod.ponder.foundation.PonderScene;
+import net.createmod.ponder.foundation.PonderSceneBuilder;
+import net.createmod.ponder.foundation.SelectionImpl;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.phys.Vec3;
+
+public class AnvilCraftSceneBuilder extends PonderSceneBuilder {
+    private final EffectInstructions effects;
+    private final WorldInstructions world;
+    private final SpecialInstructions special;
+    private final OverlayInstructions overlay;
+
+    private AnvilCraftSceneBuilder(PonderScene ponderScene) {
+        super(ponderScene);
+        this.effects = new EffectInstructions();
+        this.world = new WorldInstructions();
+        this.special = new SpecialInstructions();
+        this.overlay = new OverlayInstructions();
+    }
+
+    public AnvilCraftSceneBuilder(SceneBuilder baseSceneBuilder) {
+        this(baseSceneBuilder.getScene());
+    }
+
+    @Override
+    public EffectInstructions effects() {
+        return this.effects;
+    }
+
+    @Override
+    public SpecialInstructions special() {
+        return this.special;
+    }
+
+    @Override
+    public WorldInstructions world() {
+        return this.world;
+    }
+
+    @Override
+    public OverlayInstructions overlay() {
+        return this.overlay;
+    }
+
+    public class WorldInstructions extends PonderWorldInstructions {
+        public <T extends Comparable<T>> Selection setMultiPartBlock(
+            BlockPos pos,
+            BlockState state,
+            boolean spawnParticles
+        ) {
+            int maxX = 0;
+            int maxY = 0;
+            int maxZ = 0;
+            int minX = 0;
+            int minY = 0;
+            int minZ = 0;
+            if (!(state.getBlock() instanceof AbstractMultiPartBlock<?> block)) {
+                this.setBlock(pos, state, spawnParticles);
+                return SelectionImpl.of(BoundingBox.fromCorners(pos, pos));
+            }
+            for (Enum<?> part : block.getParts()) {
+                if (!(part instanceof ISimpleMultiPartBlockState<?> state1)) continue;
+                Vec3i offset = state1.getOffset();
+                maxX = Math.max(maxX, offset.getX());
+                maxY = Math.max(maxY, offset.getY());
+                maxZ = Math.max(maxZ, offset.getZ());
+                minX = Math.min(minX, offset.getX());
+                minY = Math.min(minY, offset.getY());
+                minZ = Math.min(minZ, offset.getZ());
+                //noinspection unchecked
+                BlockState blockState = state.setValue((Property<T>) block.getPart(), (T) part);
+                this.setBlock(pos.offset(offset), blockState, spawnParticles);
+            }
+            return SelectionImpl.of(BoundingBox.fromCorners(
+                new Vec3i(minX, minY, minZ).offset(pos),
+                new Vec3i(maxX, maxY, maxZ).offset(pos)
+            ));
+        }
+    }
+
+    public class EffectInstructions extends PonderEffectInstructions {
+    }
+
+    public class SpecialInstructions extends PonderSpecialInstructions {
+    }
+
+    public class OverlayInstructions extends PonderOverlayInstructions {
+        public void showLine(int color, Vec3 start, Vec3 end, int duration, float thickness) {
+            AnvilCraftSceneBuilder.this.addInstruction(new LineInstruction(color, start, end, duration, thickness));
+        }
+
+        public void showLine(int color, Vec3 start, Vec3 end, int duration) {
+            this.showLine(color, start, end, duration, 1 / 16f);
+        }
+
+        public void showTransmitterLine(BlockPos start, BlockPos end, int duration) {
+            this.showLine(Constant.TRANSMITTER_LINE_COLOR, start.getCenter(), end.getCenter(), duration, 1 / 64f);
+        }
+
+        public void showBigLine(int color, Vec3 start, Vec3 end, int duration) {
+            this.showLine(color, start, end, duration, 1 / 8f);
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/api/LineInstruction.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/api/LineInstruction.java
@@ -1,0 +1,29 @@
+package dev.dubhe.anvilcraft.integration.ponder.api;
+
+import net.createmod.ponder.foundation.PonderScene;
+import net.createmod.ponder.foundation.instruction.TickingInstruction;
+import net.minecraft.world.phys.Vec3;
+
+public class LineInstruction extends TickingInstruction {
+    private final int color;
+    private final Vec3 start;
+    private final Vec3 end;
+    private final float thickness;
+
+    public LineInstruction(int color, Vec3 start, Vec3 end, int ticks, float thickness) {
+        super(false, ticks);
+        this.color = color;
+        this.start = start;
+        this.end = end;
+        this.thickness = thickness;
+    }
+
+    @Override
+    public void tick(PonderScene scene) {
+        super.tick(scene);
+        scene.getOutliner()
+            .showLine(start, start, end)
+            .lineWidth(thickness)
+            .colored(color);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/api/package-info.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/api/package-info.java
@@ -1,0 +1,7 @@
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package dev.dubhe.anvilcraft.integration.ponder.api;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/AnvilScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/AnvilScene.java
@@ -15,10 +15,9 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.Vec3;
-import org.jetbrains.annotations.NotNull;
 
 public class AnvilScene {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+    public static void register(PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
         PonderSceneRegistrationHelper<Item> helper = registrationHelper.withKeyFunction(BuiltInRegistries.ITEM::getKey);
         helper.forComponents(
                 Items.ANVIL,
@@ -32,7 +31,7 @@ public class AnvilScene {
             );
     }
 
-    private static void crafting(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    private static void crafting(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("anvil", "Use anvil to craft");
         scene.configureBasePlate(0, 0, 5);
 

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/power/TransmissionPoleScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/power/TransmissionPoleScene.java
@@ -1,0 +1,49 @@
+package dev.dubhe.anvilcraft.integration.ponder.scene.power;
+
+import com.tterrag.registrate.util.entry.ItemProviderEntry;
+import com.tterrag.registrate.util.entry.RegistryEntry;
+import dev.dubhe.anvilcraft.block.TransmissionPoleBlock;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.integration.ponder.AnvilCraftPonderTags;
+import dev.dubhe.anvilcraft.integration.ponder.api.AnvilCraftSceneBuilder;
+import net.createmod.ponder.api.registration.PonderSceneRegistrationHelper;
+import net.createmod.ponder.api.scene.SceneBuilder;
+import net.createmod.ponder.api.scene.SceneBuildingUtil;
+import net.createmod.ponder.api.scene.Selection;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+
+public class TransmissionPoleScene {
+    public static void register(PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+        PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> helper = registrationHelper.withKeyFunction(RegistryEntry::getId);
+        helper.forComponents(ModBlocks.TRANSMISSION_POLE)
+            .addStoryBoard("platform/555", TransmissionPoleScene::run, AnvilCraftPonderTags.REDSTONE_COMPONENTS);
+    }
+
+    public static void run(SceneBuilder scene, SceneBuildingUtil util) {
+        AnvilCraftSceneBuilder builder = new AnvilCraftSceneBuilder(scene);
+
+        builder.title("transmission_pole", "Use Transmission Pole to transmitting electricity");
+        builder.configureBasePlate(0, 0, 5);
+
+        Selection basePlate = util.select().fromTo(0, 0, 0, 5, 0, 5);
+        builder.world().showSection(basePlate, Direction.UP);
+        builder.idle(20);
+
+        Selection pole = builder.world().setMultiPartBlock(
+            new BlockPos(4, 1, 0),
+            ModBlocks.TRANSMISSION_POLE.getDefaultState().setValue(TransmissionPoleBlock.OVERLOAD, false),
+            false
+        );
+        Selection pole1 = builder.world().setMultiPartBlock(
+            new BlockPos(0, 1, 4),
+            ModBlocks.TRANSMISSION_POLE.getDefaultState().setValue(TransmissionPoleBlock.OVERLOAD, false),
+            false
+        );
+        builder.world().showIndependentSection(pole, Direction.NORTH);
+        builder.world().showIndependentSection(pole1, Direction.NORTH);
+        builder.overlay().showTransmitterLine(new BlockPos(4, 3, 0), new BlockPos(0, 3, 4), 600);
+        builder.idle(600);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/power/package-info.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/power/package-info.java
@@ -1,0 +1,7 @@
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package dev.dubhe.anvilcraft.integration.ponder.scene.power;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/recipe/SpaceOvercompressorScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/recipe/SpaceOvercompressorScene.java
@@ -1,4 +1,4 @@
-package dev.dubhe.anvilcraft.integration.ponder.scene;
+package dev.dubhe.anvilcraft.integration.ponder.scene.recipe;
 
 import com.tterrag.registrate.util.entry.ItemProviderEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -17,10 +17,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.Vec3;
-import org.jetbrains.annotations.NotNull;
 
 public class SpaceOvercompressorScene {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+    public static void register(PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
         PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> helper = registrationHelper.withKeyFunction(RegistryEntry::getId);
         helper.forComponents(
                 ModBlocks.SPACE_OVERCOMPRESSOR
@@ -31,7 +30,7 @@ public class SpaceOvercompressorScene {
             );
     }
 
-    private static void crafting(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    private static void crafting(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("space_overcompressor", "Use the Space Overcompressor to create the Neutronium Ingot");
         scene.configureBasePlate(0, 0, 5);
         scene.showBasePlate();
@@ -79,7 +78,10 @@ public class SpaceOvercompressorScene {
         }
         // 从空间超压器下方掉出中子锭
         scene.overlay().showText(100)
-            .text("When the Space Overcompressor has built up enough mass, a neutron ingot will form. It can pass through most blocks, so you'll need something like end dust to stop it.")
+            .text(
+                "When the Space Overcompressor has built up enough mass, a neutron ingot will form. "
+                + "It can pass through most blocks, so you'll need something like end dust to stop it."
+            )
             .pointAt(util.vector().blockSurface(util.grid().at(2, 1, 2), Direction.WEST))
             .attachKeyFrame()
             .placeNearTarget();

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/recipe/package-info.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/recipe/package-info.java
@@ -1,0 +1,7 @@
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package dev.dubhe.anvilcraft.integration.ponder.scene.recipe;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/redstone/BlockComparatorScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/redstone/BlockComparatorScene.java
@@ -15,22 +15,19 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CopperBulbBlock;
 import net.minecraft.world.level.block.RedstoneLampBlock;
-import org.jetbrains.annotations.NotNull;
 
 public class BlockComparatorScene {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+    public static void register(PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
         PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> helper = registrationHelper.withKeyFunction(RegistryEntry::getId);
-        helper.forComponents(
-                ModBlocks.BLOCK_COMPARATOR
-            )
+        helper.forComponents(ModBlocks.BLOCK_COMPARATOR)
             .addStoryBoard(
                 "platform/555",
                 BlockComparatorScene::run,
-                AnvilCraftPonderTags.REDSTONE_COMPONENTS);
-
+                AnvilCraftPonderTags.REDSTONE_COMPONENTS
+            );
     }
 
-    public static void run(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    public static void run(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("block_comparator", "Block Comparator");
         scene.configureBasePlate(0, 0, 5);
         scene.showBasePlate();

--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/redstone/MagnetScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/redstone/MagnetScene.java
@@ -23,11 +23,10 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.phys.Vec3;
-import org.jetbrains.annotations.NotNull;
 
 
 public class MagnetScene {
-    public static void register(@NotNull PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
+    public static void register(PonderSceneRegistrationHelper<ResourceLocation> registrationHelper) {
         PonderSceneRegistrationHelper<ItemProviderEntry<?, ?>> helper = registrationHelper.withKeyFunction(RegistryEntry::getId);
         helper.forComponents(
                 ModBlocks.MAGNET_BLOCK,
@@ -37,12 +36,14 @@ public class MagnetScene {
             .addStoryBoard(
                 "platform/555",
                 MagnetScene::thunder,
-                AnvilCraftPonderTags.MAGNET_BLOCK)
+                AnvilCraftPonderTags.MAGNET_BLOCK
+            )
             .addStoryBoard(
                 "platform/555",
                 MagnetScene::magnetizeIngot,
                 AnvilCraftPonderTags.MAGNET_BLOCK
-            ).addStoryBoard(
+            )
+            .addStoryBoard(
                 "platform/555",
                 MagnetScene::attractAnvil,
                 AnvilCraftPonderTags.MAGNET_BLOCK,
@@ -51,10 +52,11 @@ public class MagnetScene {
             .addStoryBoard(
                 "platform/555",
                 MagnetScene::rubCopperBlock,
-                AnvilCraftPonderTags.MAGNET_BLOCK);
+                AnvilCraftPonderTags.MAGNET_BLOCK
+            );
     }
 
-    private static void thunder(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    private static void thunder(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("magnet_thunder", "Get hollow magnet block");
         scene.configureBasePlate(0, 0, 5);
         scene.showBasePlate();
@@ -94,7 +96,7 @@ public class MagnetScene {
         scene.markAsFinished(); // 标记场景结束
     }
 
-    private static void magnetizeIngot(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    private static void magnetizeIngot(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("magnet_magnetize_ingot", "Get a magnet ingot through a hollow magnet block");
         scene.configureBasePlate(0, 0, 5);
         scene.showBasePlate();
@@ -134,7 +136,7 @@ public class MagnetScene {
         scene.markAsFinished(); // 标记场景结束
     }
 
-    private static void attractAnvil(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    private static void attractAnvil(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("magnet", "Use magnet to attract the anvil");
         scene.configureBasePlate(0, 0, 5);
         scene.showBasePlate();
@@ -174,7 +176,8 @@ public class MagnetScene {
         Selection redstoneBlock = util.select().position(3, 4, 2);
         scene.world().showIndependentSection(redstoneBlock, Direction.WEST);
         scene.idle(10);
-        scene.world().modifyBlock(new BlockPos(2, 4, 2),
+        scene.world().modifyBlock(
+            new BlockPos(2, 4, 2),
             bs -> bs.setValue(MagnetBlock.LIT, true),
             false
         );
@@ -192,7 +195,7 @@ public class MagnetScene {
         scene.markAsFinished();
     }
 
-    private static void rubCopperBlock(@NotNull SceneBuilder scene, @NotNull SceneBuildingUtil util) {
+    private static void rubCopperBlock(SceneBuilder scene, SceneBuildingUtil util) {
         scene.title("magnet_power_generation", "Generate electricity by rubbing a magnet and a copper block");
         scene.configureBasePlate(0, 0, 5);
         scene.showBasePlate();
@@ -203,7 +206,8 @@ public class MagnetScene {
         scene.world().setBlock(copperBlockPos, Blocks.COPPER_BLOCK.defaultBlockState(), false);
         scene.world().setBlock(magnetPos, ModBlocks.MAGNET_BLOCK.getDefaultState(), false);
         scene.world().showSection(util.select().position(copperBlockPos), Direction.DOWN);
-        ElementLink<WorldSectionElement> magnetElement = scene.world().showIndependentSection(util.select().position(magnetPos), Direction.DOWN);
+        ElementLink<WorldSectionElement> magnetElement = scene.world()
+            .showIndependentSection(util.select().position(magnetPos), Direction.DOWN);
         scene.world().moveSection(magnetElement, new Vec3(0, 0, 1), 5);
         scene.idle(20);
 
@@ -223,7 +227,8 @@ public class MagnetScene {
         scene.world().modifyBlock(pistonPos, state -> state.setValue(PistonBaseBlock.EXTENDED, true), false);
 
         BlockPos pistonHeadPos = new BlockPos(2, 1, 2);
-        scene.world().setBlock(pistonHeadPos, Blocks.PISTON_HEAD.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.NORTH), false);
+        scene.world()
+            .setBlock(pistonHeadPos, Blocks.PISTON_HEAD.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.NORTH), false);
         scene.world().showSection(util.select().position(pistonHeadPos), Direction.NORTH);
         scene.idle(30);
 


### PR DESCRIPTION
- 新增 AnvilCraftSceneBuilder 类用于创建自定义场景
- 添加 TransmissionPoleScene 类实现电力传输杆的教程
- 在 AnvilCraftPonderScenes 中注册新场景
- 更新 AnvilCraftPonderTags 添加电力组件标签
- 新增 LineInstruction 类用于在场景中显示线条
- 在 PowerGridSupport 中使用新颜色常量绘制电力传输线