### PR TITLE
Magnet ingot conversion adjustment 磁铁锭转换调整

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/HollowMagnetBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/HollowMagnetBlock.java
@@ -1,10 +1,21 @@
 package dev.dubhe.anvilcraft.block;
 
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
@@ -15,6 +26,7 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.pathfinder.PathComputationType;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -92,5 +104,35 @@ public class HollowMagnetBlock extends MagnetBlock implements SimpleWaterloggedB
             levelAccessor.scheduleTick(blockPos, Fluids.WATER, Fluids.WATER.getTickDelay(levelAccessor));
         }
         return super.updateShape(blockState, direction, blockState2, levelAccessor, blockPos, blockPos2);
+    }
+
+    @Override
+    protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
+        if (level.isClientSide) {
+            return;
+        }
+        if (entity instanceof ItemEntity itemEntity) {
+            ItemStack item = itemEntity.getItem();
+            if (item.is(Items.IRON_INGOT) && item.getCount() == 1) {
+                if (itemEntity.getOwner() instanceof ServerPlayer) {
+                    if (level.random.nextDouble() <= 0.005) {
+                        itemEntity.setItem(new ItemStack(ModItems.MAGNET_INGOT.get()));
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
+        if (level.isClientSide) {
+            return ItemInteractionResult.sidedSuccess(true);
+        }
+        if (stack.is(Items.IRON_INGOT)) {
+            stack.consume(1, player);
+            level.setBlockAndUpdate(pos, ModBlocks.FERRITE_CORE_MAGNET_BLOCK.getDefaultState());
+            return ItemInteractionResult.sidedSuccess(false);
+        }
+        return super.useItemOn(stack, state, level, pos, player, hand, hitResult);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/HollowMagnetBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/HollowMagnetBlock.java
@@ -40,6 +40,7 @@ public class HollowMagnetBlock extends MagnetBlock implements SimpleWaterloggedB
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
     private static final VoxelShape REDUCE_AABB = Block.box(5.0, 0.0, 5.0, 11.0, 16.0, 11.0);
     private static final VoxelShape AABB = Shapes.join(Shapes.block(), REDUCE_AABB, BooleanOp.ONLY_FIRST);
+    private static int itemEntityHashCode = 0;
 
     public HollowMagnetBlock(Properties properties) {
         super(properties);
@@ -111,13 +112,20 @@ public class HollowMagnetBlock extends MagnetBlock implements SimpleWaterloggedB
         if (level.isClientSide) {
             return;
         }
+        if (state.getValue(LIT)) {
+            return;
+        }
         if (entity instanceof ItemEntity itemEntity) {
+            if (itemEntityHashCode == entity.hashCode()) {
+                return;
+            }
             ItemStack item = itemEntity.getItem();
             if (item.is(Items.IRON_INGOT) && item.getCount() == 1) {
                 if (itemEntity.getOwner() instanceof ServerPlayer) {
                     if (level.random.nextDouble() <= 0.005) {
                         itemEntity.setItem(new ItemStack(ModItems.MAGNET_INGOT.get()));
                     }
+                    itemEntityHashCode = entity.hashCode();
                 }
             }
         }

--- a/src/main/java/dev/dubhe/anvilcraft/block/MagnetBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/MagnetBlock.java
@@ -4,14 +4,18 @@ import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.entity.AnimateAscendingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.FallingBlockEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -22,6 +26,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -157,5 +162,20 @@ public class MagnetBlock extends Block implements IHammerRemovable {
         if (state.getValue(LIT) && !level.hasNeighborSignal(pos)) {
             level.setBlockAndUpdate(pos, state.cycle(LIT));
         }
+    }
+
+    @Override
+    protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+        if (level.isClientSide) {
+            return InteractionResult.sidedSuccess(true);
+        }
+        if (state.is(ModBlocks.MAGNET_BLOCK)) {
+            if (player.isShiftKeyDown()) {
+                player.addItem(ModItems.MAGNET_INGOT.asStack());
+                level.setBlockAndUpdate(pos, ModBlocks.HOLLOW_MAGNET_BLOCK.getDefaultState());
+                return InteractionResult.sidedSuccess(false);
+            }
+        }
+        return super.useWithoutItem(state, level, pos, player, hitResult);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModDispenserBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModDispenserBehavior.java
@@ -152,6 +152,12 @@ public class ModDispenserBehavior {
     private static ItemStack ironIngot(BlockSource source, ItemStack stack) {
         BlockPos blockPos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
         ServerLevel level = source.level();
+        if (level.getBlockState(blockPos).is(ModBlocks.HOLLOW_MAGNET_BLOCK)) {
+            level.setBlockAndUpdate(blockPos, ModBlocks.FERRITE_CORE_MAGNET_BLOCK.getDefaultState());
+            ItemStack stack1 = stack.copy();
+            stack1.shrink(1);
+            return stack1;
+        }
         List<IronGolem> entities =
             level
                 .getEntities(EntityTypeTest.forClass(IronGolem.class), new AABB(blockPos), Entity::isAlive)

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/DispenserBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/DispenserBlockMixin.java
@@ -1,0 +1,33 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.item.ModItems;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.dispenser.BlockSource;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.DispenserBlock;
+import net.minecraft.world.level.block.entity.DispenserBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(DispenserBlock.class)
+public class DispenserBlockMixin {
+    @Inject(
+        method = "dispenseFrom",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/level/ServerLevel;levelEvent(ILnet/minecraft/core/BlockPos;I)V"
+        )
+    )
+    private void dispenseFrom(ServerLevel level, BlockState state, BlockPos pos, CallbackInfo ci, @Local BlockSource blockSource, @Local DispenserBlockEntity dispenserBlockEntity) {
+        BlockPos pos1 = blockSource.pos().relative(state.getValue(DispenserBlock.FACING));
+        if (level.getBlockState(pos1).is(ModBlocks.MAGNET_BLOCK)) {
+            level.setBlockAndUpdate(pos1, ModBlocks.HOLLOW_MAGNET_BLOCK.getDefaultState());
+            dispenserBlockEntity.setItem(0, ModItems.MAGNET_INGOT.asStack());
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.dubhe.anvilcraft.api.event.ItemEntityEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IItemEntityExtension;
-import dev.dubhe.anvilcraft.block.HollowMagnetBlock;
 import dev.dubhe.anvilcraft.block.ItemCollectorBlock;
 import dev.dubhe.anvilcraft.block.entity.ItemCollectorBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
@@ -14,7 +13,6 @@ import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
@@ -24,7 +22,6 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -36,7 +33,6 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.EventHooks;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -54,14 +50,9 @@ import java.util.Objects;
 import static dev.dubhe.anvilcraft.block.entity.ItemCollectorBlockEntity.PoachingCollectorMap;
 
 @Mixin(ItemEntity.class)
-@SuppressWarnings("resource")
 abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
     @Shadow
     public abstract ItemStack getItem();
-
-    @Shadow
-    @Nullable
-    public abstract Entity getOwner();
 
     @Shadow
     public abstract void setItem(ItemStack stack);
@@ -131,25 +122,6 @@ abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
             }
         }
         return new Vec3(vec3.x, vec3.y * dy, vec3.z);
-    }
-
-    @Unique
-    private boolean anvilcraft$needMagnetization = true;
-
-    @Inject(method = "tick", at = @At(value = "HEAD"))
-    private void magnetization(CallbackInfo ci) {
-        if (this.getServer() == null) return;
-        ItemStack itemStack = this.getItem();
-        if (!itemStack.is(Items.IRON_INGOT)) return;
-        BlockState blockState = this.level().getBlockState(this.blockPosition());
-        if (!blockState.is(ModBlocks.HOLLOW_MAGNET_BLOCK.get()) || blockState.getValue(HollowMagnetBlock.LIT)) return;
-        if (this.getOwner() == null || !(this.getOwner() instanceof ServerPlayer)) return;
-        if (itemStack.getCount() != 1) return;
-        if (!this.anvilcraft$needMagnetization) return;
-        this.anvilcraft$needMagnetization = false;
-        if (this.level().random.nextInt(100) <= 10) {
-            this.setItem(new ItemStack(ModItems.MAGNET_INGOT.get()));
-        }
     }
 
     @Inject(method = "tick", at = @At(value = "HEAD"))

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -19,6 +19,7 @@
     "DispenseItemEmptyBottleBehaviorMixin",
     "DispenseItemEmptyBucketBehaviorMixin",
     "DispenseItemWaterBottleBehaviorMixin",
+    "DispenserBlockMixin",
     "EnchantmentHelperMixin",
     "EnchantmentPredicateMixin",
     "EndPortalBlockMixin",

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/basic/material.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/en_us/entries/basic/material.json
@@ -12,7 +12,7 @@
       "type": "patchouli:spotlight",
       "anchor": "magnet_ingot",
       "item": "anvilcraft:magnet_ingot",
-      "text": "首次获得磁铁，需要$(item)铁块$()被雷击转化为空心磁铁块，可以将其分解为磁铁锭。 $(br)$(li)之后可以$(thing)人工$()将铁锭$(thing)逐个$()丢入空心磁铁块中央的洞，将铁锭概率转化为磁铁锭。 $(li)具有发电能力后，可将铁锭充能为磁铁锭。"
+      "text": "首次获得磁铁，需要$(item)铁块$()被雷击转化为空心磁铁块，可以将其分解为磁铁锭。$(br)$(li)具有发电能力后，可将铁锭充能为磁铁锭。"
     },
     {
       "type": "patchouli:crafting",

--- a/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic/material.json
+++ b/src/main/resources/assets/anvilcraft/patchouli_books/guide/zh_cn/entries/basic/material.json
@@ -12,7 +12,7 @@
       "type": "patchouli:spotlight",
       "anchor": "magnet_ingot",
       "item": "anvilcraft:magnet_ingot",
-      "text": "首次获得磁铁，需要$(item)铁块$()被雷击转化为空心磁铁块，可以将其分解为磁铁锭。 $(br)$(li)之后可以$(thing)人工$()将铁锭$(thing)逐个$()丢入空心磁铁块中央的洞，将铁锭概率转化为磁铁锭。 $(li)具有发电能力后，可将铁锭充能为磁铁锭。"
+      "text": "首次获得磁铁，需要$(item)铁块$()被雷击转化为空心磁铁块，可以将其分解为磁铁锭。$(br)$(li)具有发电能力后，可将铁锭充能为磁铁锭。"
     },
     {
       "type": "patchouli:crafting",


### PR DESCRIPTION
- 空手shift右键可以把实心磁铁块变成空心磁铁块，并获得一个磁铁锭，添加了`DispenseBlockMixin`类以实现发射器行为
- 手持铁锭右键磁铁块消耗一个铁锭把空心磁铁块变成铁芯磁铁块，修改了`ModDispenseBehavior`类以实现发射器行为
- 把转换磁铁锭的代码移动到了`HollowMagnetBlock`类的`entityInside`方法里，同时把概率变为0.5%
- 移除了指南中关于人工将铁锭丢入空心磁铁块中心洞口的信息，将其转为彩蛋
- Resolved #2609 