### PR TITLE
Make the crafted frost metal heavy halberd, frost metal resonator, ember metal heavy halberd, and ember metal resonator have no multiphase properties 使合成出来的浮霜重戟、浮霜共振器、余烬重戟、余烬共振器上没有多相属性

### DIFF
--- a/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/ember_metal_heavy_halberd.json
+++ b/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/ember_metal_heavy_halberd.json
@@ -21,18 +21,7 @@
     "item": {
       "count": 1,
       "id": "anvilcraft:ember_metal_heavy_halberd"
-    },
-    "modifiers": [
-      {
-        "type": "anvilcraft:copy_data",
-        "types": [
-          {
-            "type": "anvilcraft:multiphase",
-            "input_type": "four"
-          }
-        ]
-      }
-    ]
+    }
   },
   "template": {
     "items": "anvilcraft:four_to_one_smithing_template"

--- a/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/ember_metal_resonator.json
+++ b/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/ember_metal_resonator.json
@@ -21,18 +21,7 @@
     "item": {
       "count": 1,
       "id": "anvilcraft:ember_metal_resonator"
-    },
-    "modifiers": [
-      {
-        "type": "anvilcraft:copy_data",
-        "types": [
-          {
-            "type": "anvilcraft:multiphase",
-            "input_type": "four"
-          }
-        ]
-      }
-    ]
+    }
   },
   "template": {
     "items": "anvilcraft:four_to_one_smithing_template"

--- a/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/frost_metal_heavy_halberd.json
+++ b/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/frost_metal_heavy_halberd.json
@@ -21,18 +21,7 @@
     "item": {
       "count": 1,
       "id": "anvilcraft:frost_metal_heavy_halberd"
-    },
-    "modifiers": [
-      {
-        "type": "anvilcraft:copy_data",
-        "types": [
-          {
-            "type": "anvilcraft:multiphase",
-            "input_type": "four"
-          }
-        ]
-      }
-    ]
+    }
   },
   "template": {
     "items": "anvilcraft:four_to_one_smithing_template"

--- a/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/frost_metal_resonator.json
+++ b/src/generated/resources/data/anvilcraft/recipe/four_to_one_smithing/frost_metal_resonator.json
@@ -21,18 +21,7 @@
     "item": {
       "count": 1,
       "id": "anvilcraft:frost_metal_resonator"
-    },
-    "modifiers": [
-      {
-        "type": "anvilcraft:copy_data",
-        "types": [
-          {
-            "type": "anvilcraft:multiphase",
-            "input_type": "four"
-          }
-        ]
-      }
-    ]
+    }
   },
   "template": {
     "items": "anvilcraft:four_to_one_smithing_template"

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/MultipleToOneSmithingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/MultipleToOneSmithingRecipeLoader.java
@@ -39,7 +39,7 @@ public class MultipleToOneSmithingRecipeLoader {
             .input(ModItems.FROST_METAL_AXE)
             .input(Items.TRIDENT)
             .input(Tags.Items.TOOLS_MACE)
-            .result(ModItems.FROST_METAL_HEAVY_HALBERD, MultiphaseData.four())
+            .result(ModItems.FROST_METAL_HEAVY_HALBERD)
             .save(provider);
         FourToOneSmithingRecipe.builder()
             .material(ModItems.HEAVY_HALBERD_CORE)
@@ -47,7 +47,7 @@ public class MultipleToOneSmithingRecipeLoader {
             .input(ModItems.EMBER_METAL_AXE)
             .input(Items.TRIDENT)
             .input(Tags.Items.TOOLS_MACE)
-            .result(ModItems.EMBER_METAL_HEAVY_HALBERD, MultiphaseData.four())
+            .result(ModItems.EMBER_METAL_HEAVY_HALBERD)
             .save(provider);
         FourToOneSmithingRecipe.builder()
             .material(ModItems.RESONATOR_CORE)
@@ -55,7 +55,7 @@ public class MultipleToOneSmithingRecipeLoader {
             .input(ModItems.FROST_METAL_SHOVEL)
             .input(ModItems.FROST_METAL_HOE)
             .input(ModItems.FROST_METAL_PICKAXE)
-            .result(ModItems.FROST_METAL_RESONATOR, MultiphaseData.four())
+            .result(ModItems.FROST_METAL_RESONATOR)
             .save(provider);
         FourToOneSmithingRecipe.builder()
             .material(ModItems.RESONATOR_CORE)
@@ -63,7 +63,7 @@ public class MultipleToOneSmithingRecipeLoader {
             .input(ModItems.EMBER_METAL_SHOVEL)
             .input(ModItems.EMBER_METAL_HOE)
             .input(ModItems.EMBER_METAL_PICKAXE)
-            .result(ModItems.EMBER_METAL_RESONATOR, MultiphaseData.four())
+            .result(ModItems.EMBER_METAL_RESONATOR)
             .save(provider);
         FourToOneSmithingRecipe.builder()
             .material(ModBlocks.FROST_METAL_BLOCK)


### PR DESCRIPTION
- 使合成出来的浮霜重戟、浮霜共振器、余烬重戟、余烬共振器上没有多相属性
- Fixed #2641 