### PR TITLE
Fix the internationalization issue of Tesla Tower entity ID filter 修复特斯拉塔实体 ID 过滤器的国际化问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/TeslaTowerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/TeslaTowerBlockEntity.java
@@ -171,8 +171,8 @@ public class TeslaTowerBlockEntity extends BlockEntity
         whiteList.add(Pair.of(new IsPlayerIdFilter(), player.getName().getString()));
         whiteList.add(Pair.of(new IsPetFilter(), ""));
         whiteList.add(Pair.of(new HasCustomNameFilter(), ""));
-        whiteList.add(Pair.of(new IsEntityIdFilter(), "entity.minecraft.villager"));
-        whiteList.add(Pair.of(new IsEntityIdFilter(), "entity.minecraft.wandering_trader"));
+        whiteList.add(Pair.of(new IsEntityIdFilter(), Component.translatable("entity.minecraft.villager").getString()));
+        whiteList.add(Pair.of(new IsEntityIdFilter(), Component.translatable("entity.minecraft.wandering_trader").getString()));
         whiteList.add(Pair.of(new IsFriendlyFilter(), ""));
         whiteList.add(Pair.of(new IsOnVehicleFilter(), ""));
     }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/TeslaTowerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/TeslaTowerScreen.java
@@ -247,7 +247,7 @@ public class TeslaTowerScreen extends AbstractContainerScreen<TeslaTowerMenu> {
             .toList()
         );
         allFilter.addAll(BuiltInRegistries.ENTITY_TYPE.stream()
-            .map(it -> Pair.of(TeslaFilter.getFilter("IsEntityIdFilter"), it.getDescriptionId()))
+            .map(it -> Pair.of(TeslaFilter.getFilter("IsEntityIdFilter"), Component.translatable(it.getDescriptionId()).getString()))
             .toList()
         );
         filteredFilters.addAll(allFilter);


### PR DESCRIPTION
修改前：
<img width="928" height="244" alt="11" src="https://github.com/user-attachments/assets/4a510208-de3e-4d3e-bfb4-9ddbf124d448" />

修改后：
<img width="524" height="173" alt="1" src="https://github.com/user-attachments/assets/e37fcd7d-1e11-4b24-950a-8e2d730f7613" />

关闭已修复的bug issue:
- Fixed #2602 