### PR TITLE
fix got placement_too_close_to_another even the old heat collector is removed. 集热器被破坏后仍会被附近的集热器判定过近

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/HeatCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/HeatCollectorBlockEntity.java
@@ -86,6 +86,13 @@ public class HeatCollectorBlockEntity extends BlockEntity implements IPowerProdu
         HeatCollectorManager.removeHeatCollector(this.getPos(), this.getCurrentLevel());
     }
 
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        if (this.getCurrentLevel() == null) return;
+        HeatCollectorManager.removeHeatCollector(this.getPos(), this.getCurrentLevel());
+    }
+
     public void clientTick() {
         if (!this.isWorking()) return;
         rotation += (float) (getServerPower() * 0.03);


### PR DESCRIPTION
- fixed #2673
- 集热器被删除时将从 HeatCollectorManager 里移除自身。