### PR TITLE
Add carousel for Repair Material and Result Material of Royal Grindstone 为皇家砂轮的修复材料和结果材料添加轮播图

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/RoyalGrindstoneScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/RoyalGrindstoneScreen.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.client.gui.screen;
 
+import com.mojang.datafixers.util.Pair;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.inventory.RoyalGrindstoneMenu;
 import net.minecraft.client.gui.GuiGraphics;
@@ -12,9 +13,15 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 
 public class RoyalGrindstoneScreen extends AbstractContainerScreen<RoyalGrindstoneMenu> {
+    private int tickCounter = 0;
+    private int recipeIndex = 0;
+
     private static final ResourceLocation GRINDSTONE_LOCATION =
         AnvilCraft.of("textures/gui/container/smithing/background/royal_grindstone.png");
 
@@ -36,35 +43,72 @@ public class RoyalGrindstoneScreen extends AbstractContainerScreen<RoyalGrindsto
         this.renderLabels(guiGraphics);
     }
 
-    protected void renderBg(@NotNull GuiGraphics guiGraphics, float partialTick, int mouseX, int mouseY) {
+    protected void renderBg(@NotNull GuiGraphics g, float partialTick, int mouseX, int mouseY) {
         int i = (this.width - this.imageWidth) / 2;
         int j = (this.height - this.imageHeight) / 2;
-        guiGraphics.blit(GRINDSTONE_LOCATION, i, j, 0, 0, this.imageWidth, this.imageHeight);
-        guiGraphics.setColor(1f, 1f, 1f, 1);
-        final int maskColor = 0x55777777;
-        ItemStack repairMaterialSlotsItem = this.menu.getSlot(1).getItem();
-        ItemStack resultMaterialSlotsItem = this.menu.getSlot(3).getItem();
-        if (repairMaterialSlotsItem.isEmpty() && resultMaterialSlotsItem.isEmpty()) {
-            guiGraphics.renderItem(
-                RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL.getDefaultInstance(), i + 89, j + 22, (int) (partialTick * 100));
-            guiGraphics.renderItem(
-                RoyalGrindstoneMenu.REPAIR_COST_RECIPES.get(RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL).getSecond().getDefaultInstance(), i + 89, j + 47, (int) (partialTick * 100));
-            guiGraphics.fill(RenderType.guiOverlay(), i + 89, j + 22, i + 89 + 16, j + 22 + 16, maskColor);
-            guiGraphics.fill(RenderType.guiOverlay(), i + 89, j + 47, i + 89 + 16, j + 47 + 16, maskColor);
-        } else if (resultMaterialSlotsItem.isEmpty()) {
-            guiGraphics.renderItem(
-                RoyalGrindstoneMenu.REPAIR_COST_RECIPES.get(repairMaterialSlotsItem.getItem()).getSecond().getDefaultInstance(), i + 89, j + 47, (int) (partialTick * 100));
-            guiGraphics.fill(RenderType.guiOverlay(), i + 89, j + 47, i + 89 + 16, j + 47 + 16, maskColor);
-        } else if (repairMaterialSlotsItem.isEmpty()) {
-            Item repairItem = RoyalGrindstoneMenu.REPAIR_COST_RECIPES.entrySet().stream()
-                .filter(entry -> entry.getValue().getSecond() == resultMaterialSlotsItem.getItem())
+        g.blit(GRINDSTONE_LOCATION, i, j, 0, 0, this.imageWidth, this.imageHeight);
+        g.setColor(1f, 1f, 1f, 1);
+        ItemStack repairToolItem = this.menu.getSlot(0).getItem();
+        ItemStack repairItem = this.menu.getSlot(1).getItem();
+        ItemStack resultItem = this.menu.getSlot(3).getItem();
+        List<Map.Entry<Item, Pair<Integer, Item>>> recipes =
+            new ArrayList<>(RoyalGrindstoneMenu.REPAIR_COST_RECIPES.entrySet());
+
+        ItemStack displayRepair = ItemStack.EMPTY;
+        ItemStack displayResult = ItemStack.EMPTY;
+        if (repairItem.isEmpty() && resultItem.isEmpty()) {
+            if (this.menu.totalCurseCount > 0 && this.menu.totalRepairCost <= 0) {
+                displayRepair = RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL.getDefaultInstance();
+                displayResult = RoyalGrindstoneMenu.REPAIR_COST_RECIPES
+                    .get(RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL)
+                    .getSecond().getDefaultInstance();
+            } else if (repairToolItem.isEmpty()) {
+                var entry = recipes.get(recipeIndex);
+                displayRepair = entry.getKey().getDefaultInstance();
+                displayResult = entry.getValue().getSecond().getDefaultInstance();
+            } else {
+                var entry = getCurrentRecipe(recipes, this.menu.totalRepairCost);
+                displayRepair = entry.getKey().getDefaultInstance();
+                displayResult = entry.getValue().getSecond().getDefaultInstance();
+            }
+        } else if (resultItem.isEmpty()) {
+            displayResult = RoyalGrindstoneMenu.REPAIR_COST_RECIPES.get(repairItem.getItem()).getSecond().getDefaultInstance();
+        } else if (repairItem.isEmpty()) {
+            Item repair = RoyalGrindstoneMenu.REPAIR_COST_RECIPES.entrySet().stream()
+                .filter(e -> e.getValue().getSecond() == resultItem.getItem())
                 .map(Map.Entry::getKey)
                 .findFirst()
                 .orElse(RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL);
-            guiGraphics.renderItem(repairItem.getDefaultInstance(), i + 89, j + 22, (int) (partialTick * 100));
-            guiGraphics.fill(RenderType.guiOverlay(), i + 89, j + 22, i + 89 + 16, j + 22 + 16, maskColor);
+            displayRepair = repair.getDefaultInstance();
         }
+
+        if (!displayRepair.isEmpty()) renderMaskedItem(g, displayRepair, i + 89, j + 22);
+        if (!displayResult.isEmpty()) renderMaskedItem(g, displayResult, i + 89, j + 47);
     }
+
+    private void renderMaskedItem(GuiGraphics g, ItemStack stack, int x, int y) {
+        final int maskColor = 0x55777777;
+        g.renderItem(stack, x, y, 0);
+        g.fill(RenderType.guiOverlay(), x, y, x + 16, y + 16, maskColor);
+    }
+
+    private Map.Entry<Item, Pair<Integer, Item>> getCurrentRecipe(List<Map.Entry<Item, Pair<Integer, Item>>> recipes, int repairCost) {
+        recipes.sort(Comparator.comparingInt(entry -> entry.getValue().getFirst()));
+        recipeIndex = recipeIndex % recipes.size();
+        int checked = 0;
+        while (checked < recipes.size()) {
+            Map.Entry<Item, Pair<Integer, Item>> candidate = recipes.get(recipeIndex);
+            int requiredCost = candidate.getValue().getFirst();
+            if (requiredCost <= repairCost) return candidate;
+            recipeIndex = (recipeIndex + 1) % recipes.size();
+            checked++;
+        }
+        return Map.entry(
+            RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL,
+            RoyalGrindstoneMenu.REPAIR_COST_RECIPES.get(RoyalGrindstoneMenu.DEFAULT_REPAIR_MATERIAL)
+        );
+    }
+
 
     protected void renderLabels(GuiGraphics guiGraphics) {
         if (this.menu.getSlot(2).hasItem()) {
@@ -99,5 +143,12 @@ public class RoyalGrindstoneScreen extends AbstractContainerScreen<RoyalGrindsto
         x += i;
         y += j;
         guiGraphics.drawString(this.font, component, x + 2, y - 10, 8453920);
+    }
+
+    @Override
+    protected void containerTick() {
+        super.containerTick();
+        tickCounter++;
+        if (tickCounter % (20 * 3) == 0) recipeIndex = (recipeIndex + 1) % RoyalGrindstoneMenu.REPAIR_COST_RECIPES.size();
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -169,11 +169,10 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         }
         if (repairTool.isEmpty()
             || repairMaterialSlotItem.isEmpty()
-            || this.currentRecipe == null)
-        {
+            || this.currentRecipe == null) {
             this.usedGold = 0;
             return ItemStack.EMPTY;
-        };
+        }
         int repairMaterialUsable = Math.min(repairMaterialSlotItem.getCount(), currentRecipe.getSecond().getDefaultMaxStackSize() - resultMaterialSlotItem.getCount());
         int perUnitRepair = this.currentRecipe.getFirst();
         int maxUnitsByCost = repairCost / perUnitRepair;

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -82,6 +82,11 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
                 super.setChanged();
                 RoyalGrindstoneMenu.this.slotsChanged(this);
             }
+
+            @Override
+            public int getMaxStackSize() {
+                return 1;
+            }
         };
         this.resultToolSlots = new ResultContainer();
         this.repairMaterialSlots = new SimpleContainer(1) {
@@ -113,9 +118,11 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
 
             public void onTake(@NotNull Player player, @NotNull ItemStack stack) {
                 player.playSound(SoundEvents.GRINDSTONE_USE);
+                if (currentRecipe != null) {
+                    resultMaterialSlots.setItem(2, new ItemStack(currentRecipe.getSecond(), usedGold + resultMaterialSlots.getItem(2).getCount()));
+                    repairMaterialSlots.setItem(0, new ItemStack(repairMaterial, repairMaterialSlots.getItem(0).getCount() - usedGold));
+                }
                 repairToolSlots.setItem(0, ItemStack.EMPTY);
-                repairMaterialSlots.setItem(0, new ItemStack(repairMaterial, repairMaterialSlots.getItem(0).getCount() - usedGold));
-                resultMaterialSlots.setItem(2, new ItemStack(currentRecipe.getSecond(), usedGold + resultMaterialSlots.getItem(2).getCount()));
             }
         });
         this.addSlot(new Slot(this.resultMaterialSlots, 2, 89, 47) {
@@ -136,33 +143,22 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
     }
 
     private ItemStack createResult() {
+        this.totalRepairCost = 0;
+        this.totalCurseCount = 0;
+        this.removedRepairCost = 0;
+        this.removedCurseCount = 0;
         ItemStack repairTool = repairToolSlots.getItem(0);
-        ItemStack repairSlotItem = repairMaterialSlots.getItem(0);
-        ItemStack resultSlotItem = resultMaterialSlots.getItem(0);
-        this.repairMaterial = repairSlotItem.getItem();
-        if (repairTool.isEmpty() || repairSlotItem.isEmpty()) return ItemStack.EMPTY;
-        this.currentRecipe = REPAIR_COST_RECIPES.getOrDefault(repairSlotItem.getItem(), null);
-        if (this.currentRecipe == null) return ItemStack.EMPTY;
-        if (!resultSlotItem.isEmpty() && !resultSlotItem.is(this.currentRecipe.getSecond())) return ItemStack.EMPTY;
-
-        int repairMaterialUsable = Math.min(repairSlotItem.getCount(), currentRecipe.getSecond().getDefaultMaxStackSize() - resultSlotItem.getCount());
+        ItemStack repairMaterialSlotItem = repairMaterialSlots.getItem(0);
+        ItemStack resultMaterialSlotItem = resultMaterialSlots.getItem(0);
+        this.repairMaterial = repairMaterialSlotItem.getItem();
         ItemStack result = repairTool.copy();
+        this.currentRecipe = REPAIR_COST_RECIPES.getOrDefault(repairMaterialSlotItem.getItem(), null);
         int repairCost = repairTool.getOrDefault(DataComponents.REPAIR_COST, 0);
         this.totalRepairCost = repairCost;
-        int perUnitRepair = this.currentRecipe.getFirst();
-        int maxUnitsByCost = repairCost / perUnitRepair;
-        this.usedGold = Math.min(maxUnitsByCost, repairMaterialUsable);
-        int maxRemovable = perUnitRepair * this.usedGold;
-        repairMaterialUsable -= this.usedGold;
-        removedRepairCost = Math.min(repairCost, maxRemovable);
-        int remainRepairCost = repairCost - removedRepairCost;
-        result.set(DataComponents.REPAIR_COST, remainRepairCost);
         DataComponentType<ItemEnchantments> enchantmentComponent = result.is(Items.ENCHANTED_BOOK)
                                                                    ? DataComponents.STORED_ENCHANTMENTS
                                                                    : DataComponents.ENCHANTMENTS;
         ItemEnchantments enchantments = result.get(enchantmentComponent);
-        this.totalCurseCount = 0;
-        this.removedCurseCount = 0;
         ItemEnchantments.Mutable mutEnch = null;
         if (enchantments != null) {
             this.totalCurseCount = (int) enchantments.keySet()
@@ -171,8 +167,23 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
                 .count();
             mutEnch = new ItemEnchantments.Mutable(enchantments);
         }
-        if (repairSlotItem.is(DEFAULT_REPAIR_MATERIAL)
-            && repairSlotItem.getCount() - this.usedGold >= GOLD_PER_CURSE
+        if (repairTool.isEmpty()
+            || repairMaterialSlotItem.isEmpty()
+            || this.currentRecipe == null) {
+            this.usedGold = 0;
+            return ItemStack.EMPTY;
+        };
+        int repairMaterialUsable = Math.min(repairMaterialSlotItem.getCount(), currentRecipe.getSecond().getDefaultMaxStackSize() - resultMaterialSlotItem.getCount());
+        int perUnitRepair = this.currentRecipe.getFirst();
+        int maxUnitsByCost = repairCost / perUnitRepair;
+        this.usedGold = Math.min(maxUnitsByCost, repairMaterialUsable);
+        int maxRemovable = perUnitRepair * this.usedGold;
+        repairMaterialUsable -= this.usedGold;
+        removedRepairCost = Math.min(repairCost, maxRemovable);
+        int remainRepairCost = repairCost - removedRepairCost;
+        result.set(DataComponents.REPAIR_COST, remainRepairCost);
+        if (repairMaterialSlotItem.is(DEFAULT_REPAIR_MATERIAL)
+            && repairMaterialSlotItem.getCount() - this.usedGold >= GOLD_PER_CURSE
             && mutEnch != null) {
             Iterator<Holder<Enchantment>> iterator = mutEnch.keySet().iterator();
             while (iterator.hasNext() && repairMaterialUsable >= GOLD_PER_CURSE) {
@@ -211,8 +222,9 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
                 ItemStack gold;
                 if (itemStack.isDamageableItem() || itemStack.is(Items.ENCHANTED_BOOK) || itemStack.isEnchanted()) {
                     if (!this.getSlot(0).hasItem()) {
-                        this.getSlot(0).setByPlayer(itemStack);
-                        this.getSlot(index).setByPlayer(ItemStack.EMPTY);
+                        this.getSlot(0).setByPlayer(itemStack.copyWithCount(1));
+                        itemStack.shrink(1);
+                        this.getSlot(index).setByPlayer(itemStack.isEmpty() ? ItemStack.EMPTY : itemStack);
                     } else {
                         return ItemStack.EMPTY;
                     }
@@ -245,7 +257,8 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
     @Override
     public void slotsChanged(@NotNull Container container) {
         super.slotsChanged(container);
-        resultToolSlots.setItem(2, createResult());
+        if (container.equals(this.repairMaterialSlots)
+            || container.equals(this.repairToolSlots)) resultToolSlots.setItem(2, createResult());
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -169,7 +169,8 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         }
         if (repairTool.isEmpty()
             || repairMaterialSlotItem.isEmpty()
-            || this.currentRecipe == null) {
+            || this.currentRecipe == null)
+        {
             this.usedGold = 0;
             return ItemStack.EMPTY;
         };


### PR DESCRIPTION
实现以下

- 默认状态下 (未放置工具及修复材料)  - 轮播所有的修复材料及它的结果材料
- 放置只有诅咒 (没有附魔惩罚) 的工具  - 只显示能去除诅咒的修复材料 (金锭) 的虚影
- 放置附魔惩罚 > 9 的工具 - 显示所有可去除附魔 >= 9 惩罚的修复材料的轮播图虚影
- 放置附魔惩罚 < 9 的工具 - 只显示所有可去除附魔 <= 9 惩罚的修复材料的虚影

轮播间隔 3 * 20 tick

使皇家砂轮修复工具栏位只能放入一个物品（最大堆叠1）