### PR TITLE
Fix bugs about amulet box 修复护符盒相关问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/amulet/AmuletManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/amulet/AmuletManager.java
@@ -100,7 +100,7 @@ public class AmuletManager {
             .findFirst());
     }
 
-    public void startRaffle(ServerPlayer player, DamageSource source, boolean isConsumedInBox) {
+    public void startRaffle(ServerPlayer player, DamageSource source) {
         Optional<AmuletType> typeOp = this.getTypeMatchedDamage(player, source, player.registryAccess()).map(Holder::value);
         if (typeOp.isEmpty()) return;
         AmuletType type = typeOp.get();
@@ -109,12 +109,12 @@ public class AmuletManager {
         if (!InventoryUtil.getItemInCompat(player, stack -> ItemStack.isSameItem(stack, amulet)).isEmpty()) return;
 
         RandomSource random = player.getRandom();
-        int probability = Math.min(this.getRaffleProbability(player, source, isConsumedInBox), 100);
+        int probability = Math.min(this.getRaffleProbability(player, source), 100);
         if (probability > random.nextIntBetweenInclusive(0, 100)) {
             player.getInventory().placeItemBackInInventory(amulet.copy());
             this.setRaffleProbability(player, source, 0);
         } else {
-            this.setRaffleProbability(player, source, Math.min(probability + (isConsumedInBox ? 10 : 5), 100));
+            this.setRaffleProbability(player, source, Math.min(probability + 10, 100));
         }
     }
 
@@ -122,17 +122,17 @@ public class AmuletManager {
         return player.getData(ModDataAttachments.AMULET_RAFFLE_PROBABILITY).getProbability(type);
     }
 
-    public int getRaffleProbability(Player player, DamageSource source, boolean isConsumedInBox) {
+    public int getRaffleProbability(Player player, DamageSource source) {
         Optional<Holder<AmuletType>> type = Optional.empty();
         if (player instanceof ServerPlayer serverPlayer) {
             type = this.getTypeMatchedDamage(serverPlayer, source, serverPlayer.registryAccess());
         }
-        return type.map(holder -> this.getRaffleProbability(player, holder, isConsumedInBox)).orElse(0);
+        return type.map(holder -> this.getRaffleProbability(player, holder)).orElse(0);
     }
 
-    public int getRaffleProbability(Player player, Holder<AmuletType> type, boolean isConsumedInBox) {
+    public int getRaffleProbability(Player player, Holder<AmuletType> type) {
         if (!this.hasAmuletInInventory(player, type)) {
-            return getStoredRaffleProbability(player, type.value()) + (isConsumedInBox ? 20 : 5);
+            return getStoredRaffleProbability(player, type.value()) + 20;
         } else {
             return 0;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
@@ -91,13 +91,11 @@ public class PlayerEventListener {
     @SuppressWarnings("DataFlowIssue")
     @SubscribeEvent
     public static void onPlayerUsingTotem(LivingUseTotemEvent event) {
-        if (event.getEntity() instanceof ServerPlayer player
-            && player.getItemInHand(event.getHandHolding()).is(ModItems.AMULET_BOX.asItem())
-        ) {
-            ItemStack availableItem = player.getItemInHand(event.getHandHolding());
-            BoxContents boxContents = availableItem.get(ModComponents.BOX_CONTENTS);
-            AmuletManager.INSTANCE.startRaffle(player, event.getSource(), !boxContents.totems().isEmpty());
-        }
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        ItemStack inHand = player.getItemInHand(event.getHandHolding());
+        if (!inHand.is(ModItems.AMULET_BOX.asItem())) return;
+        if (inHand.getOrDefault(ModComponents.BOX_CONTENTS, BoxContents.EMPTY).totems().isEmpty()) return;
+        AmuletManager.INSTANCE.startRaffle(player, event.getSource());
     }
 
     @SubscribeEvent

--- a/src/main/java/dev/dubhe/anvilcraft/item/amulet/AmuletBoxItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/amulet/AmuletBoxItem.java
@@ -4,7 +4,7 @@ import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.item.property.component.BoxContents;
-import dev.dubhe.anvilcraft.util.InventoryUtil;
+import dev.dubhe.anvilcraft.util.ColorUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.screens.Screen;
@@ -12,8 +12,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
-import net.minecraft.util.FastColor;
-import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.damagesource.DamageSource;
@@ -33,6 +31,7 @@ import net.minecraft.world.level.Level;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
+import java.util.Optional;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -57,11 +56,10 @@ public class AmuletBoxItem extends Item {
             slot.set(popped);
             playRemoveOneSound(player);
         } else {
-            if (!mutable.tryInsert(other)) {
-                return false;
-            }
+            Optional<ItemStack> remain = mutable.tryInsert(other);
+            if (remain.isEmpty()) return false;
             playInsertSound(player);
-            slot.set(ItemStack.EMPTY);
+            slot.set(remain.get());
         }
         itemStack.set(ModComponents.BOX_CONTENTS, mutable.immutable());
         return true;
@@ -85,10 +83,11 @@ public class AmuletBoxItem extends Item {
             playRemoveOneSound(player);
             broadcastChangesOnContainerMenu(player);
         } else {
-            if (!contents.tryInsert(other)) return false;
+            Optional<ItemStack> remain = contents.tryInsert(other);
+            if (remain.isEmpty()) return false;
             playInsertSound(player);
             broadcastChangesOnContainerMenu(player);
-            slotAccess.set(ItemStack.EMPTY);
+            slotAccess.set(remain.get());
         }
         box.set(ModComponents.BOX_CONTENTS, contents.immutable());
         return true;
@@ -102,12 +101,12 @@ public class AmuletBoxItem extends Item {
             BoxContents contents = box.getOrDefault(ModComponents.BOX_CONTENTS, BoxContents.EMPTY);
             BoxContents.Mutable mutable = contents.mutable();
             if (!player.isShiftKeyDown()) {
-                List<ItemStack> items = InventoryUtil.getItems(inventory);
-                for (ItemStack stack : items) {
+                for (int i = 0; i < inventory.getContainerSize(); i++) {
+                    ItemStack stack = inventory.getItem(i);
                     if (stack.isEmpty() || !stack.is(ModItemTags.TOTEM)) continue;
-                    if (mutable.tryInsert(stack.copy())) {
-                        inventory.removeItem(stack);
-                    }
+                    Optional<ItemStack> remain = mutable.tryInsert(stack.copy());
+                    if (remain.isEmpty()) continue;
+                    inventory.setItem(i, remain.get());
                 }
                 playInsertSound(player);
                 box.set(ModComponents.BOX_CONTENTS, mutable.immutable());
@@ -145,22 +144,7 @@ public class AmuletBoxItem extends Item {
     @Override
     public int getBarColor(ItemStack itemStack) {
         BoxContents contents = itemStack.getOrDefault(ModComponents.BOX_CONTENTS, BoxContents.EMPTY);
-        return lerpColor(contents.usage() / (float) CAPACITY, BAR_COLOR, FULL_BAR_COLOR);
-    }
-
-    private int lerpColor(float ratio, int from, int to) {
-        int r1 = FastColor.ARGB32.red(from);
-        int g1 = FastColor.ARGB32.green(from);
-        int b1 = FastColor.ARGB32.blue(from);
-        int r2 = FastColor.ARGB32.red(to);
-        int g2 = FastColor.ARGB32.green(to);
-        int b2 = FastColor.ARGB32.blue(to);
-        return FastColor.ARGB32.color(
-            255,
-            (int) Mth.lerp(ratio, r1, r2),
-            (int) Mth.lerp(ratio, g1, g2),
-            (int) Mth.lerp(ratio, b1, b2)
-        );
+        return ColorUtil.lerpColor(contents.usage() / (float) CAPACITY, BAR_COLOR, FULL_BAR_COLOR);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/property/component/BoxContents.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/property/component/BoxContents.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.ToIntFunction;
 
 @SuppressWarnings("unused")
@@ -85,19 +86,20 @@ public record BoxContents(List<ItemStack> amulets, List<ItemStack> totems, int s
             this.selection = contents.selection;
         }
 
-        public boolean tryInsert(ItemStack itemStack) {
+        public Optional<ItemStack> tryInsert(ItemStack itemStack) {
+            if (itemStack.isEmpty()) return Optional.of(ItemStack.EMPTY);
             if (itemStack.getItem() instanceof AmuletItem item) {
-                if (this.usage + item.getWeight() > AmuletBoxItem.CAPACITY) return false;
+                if (this.usage + item.getWeight() > AmuletBoxItem.CAPACITY) return Optional.empty();
                 this.usage += item.getWeight();
-                this.amulets.add(itemStack.copy());
-                return true;
+                this.amulets.add(itemStack.split(1));
+                return Optional.of(itemStack);
             } else if (itemStack.is(ModItemTags.TOTEM)) {
-                if (this.usage + 1 > AmuletBoxItem.CAPACITY) return false;
+                if (this.usage + 1 > AmuletBoxItem.CAPACITY) return Optional.empty();
                 this.usage++;
-                this.totems.add(itemStack.copy());
-                return true;
+                this.totems.add(itemStack.split(1));
+                return Optional.of(itemStack);
             }
-            return false;
+            return Optional.empty();
         }
 
         public ItemStack pop() {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -141,13 +141,13 @@ public abstract class LivingEntityMixin extends Entity {
         for (InteractionHand hand : InteractionHand.values()) {
             ItemStack stack = this.getItemInHand(hand);
             for (Item item : totemMap.keySet()) {
-                if (stack.is(item) && CommonHooks.onLivingUseTotem(self, damageSource, stack, hand)) {
-                    TotemHandler handler1 = totemMap.get(item);
-                    if (!handler1.canExecute(damageSource, self, stack)) continue;
-                    totemItem = stack;
-                    handler = handler1;
-                    break handLoop;
-                }
+                if (!stack.is(item)) continue;
+                TotemHandler handler1 = totemMap.get(item);
+                if (!handler1.canExecute(damageSource, self, stack)) continue;
+                if (!CommonHooks.onLivingUseTotem(self, damageSource, stack, hand)) continue;
+                totemItem = stack;
+                handler = handler1;
+                break handLoop;
             }
         }
 

--- a/src/main/java/dev/dubhe/anvilcraft/util/ColorUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/ColorUtil.java
@@ -2,12 +2,12 @@ package dev.dubhe.anvilcraft.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.jetbrains.annotations.Contract;
+import net.minecraft.util.FastColor;
+import net.minecraft.util.Mth;
 import org.jetbrains.annotations.NotNull;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ColorUtil {
-    @Contract("_, _, _ -> new")
     public static float @NotNull [] rgbToHsv(int r, int g, int b) {
         float rNorm = r / 255.0f;
         float gNorm = g / 255.0f;
@@ -34,7 +34,6 @@ public class ColorUtil {
         return new float[]{h, s * 100, cMax * 100};
     }
 
-    @Contract("_, _, _ -> new")
     public static int @NotNull [] hsvToRgb(float h, float s, float v) {
         float c = v / 100 * s / 100;
         float x = c * (1 - Math.abs(((h / 60) % 2) - 1));
@@ -83,5 +82,20 @@ public class ColorUtil {
         g = (int) (g * ratio);
         b = (int) (b * ratio);
         return (r << 16) | (g << 8) | b;
+    }
+
+    public static int lerpColor(float ratio, int from, int to) {
+        int r1 = FastColor.ARGB32.red(from);
+        int g1 = FastColor.ARGB32.green(from);
+        int b1 = FastColor.ARGB32.blue(from);
+        int r2 = FastColor.ARGB32.red(to);
+        int g2 = FastColor.ARGB32.green(to);
+        int b2 = FastColor.ARGB32.blue(to);
+        return FastColor.ARGB32.color(
+            255,
+            (int) Mth.lerp(ratio, r1, r2),
+            (int) Mth.lerp(ratio, g1, g2),
+            (int) Mth.lerp(ratio, b1, b2)
+        );
     }
 }


### PR DESCRIPTION
- 在精妙背包等物品堆内数量大于99的场景内使用护符盒右键收入不死图腾时一次全部收入导致单个物品堆内数量过大而崩溃
- 护符盒内没有不死图腾时死亡仍会抽取护符