### PR TITLE
remove useless util/function/Function.java interface, there's already a Consumer interface from java.util.function. 删掉无用的自定义接口 util/function/Function.java，因为这实际上就是 Consumer。

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/multipart/FlexibleMultiPartBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/multipart/FlexibleMultiPartBlock.java
@@ -2,7 +2,6 @@ package dev.dubhe.anvilcraft.block.multipart;
 
 import dev.dubhe.anvilcraft.block.state.IFlexibleMultiPartBlockState;
 import dev.dubhe.anvilcraft.util.Util;
-import dev.dubhe.anvilcraft.util.function.Function;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
@@ -25,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -46,13 +46,13 @@ public abstract class FlexibleMultiPartBlock<
 
     public abstract T getAdditionalProperty();
 
-    public void forEachPart(Level level, BlockPos pos, Function<BlockPos> function) {
+    public void forEachPart(Level level, BlockPos pos, Consumer<BlockPos> function) {
         BlockState state = level.getBlockState(pos);
         if (!state.is(this)) return;
         for (P part : getParts()) {
             BlockPos partPos = pos.offset(this.offsetFrom(state, part));
             if (level.getBlockState(partPos).is(this)) {
-                function.invoke(partPos);
+                function.accept(partPos);
             }
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/AnvilCollisionCraftRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/AnvilCollisionCraftRecipeLoader.java
@@ -7,12 +7,11 @@ import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.recipe.anvil.collision.AnvilCollisionCraftRecipe;
-import dev.dubhe.anvilcraft.util.function.Function;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import org.jetbrains.annotations.NotNull;
+import java.util.function.Consumer;
 
 public class AnvilCollisionCraftRecipeLoader {
     public static void init(RegistrateRecipeProvider provider) {
@@ -129,9 +128,9 @@ public class AnvilCollisionCraftRecipeLoader {
             .save(provider);
     }
 
-    private static void forEachAnvil(Function<Block> block, Block @NotNull ... anvils) {
+    private static void forEachAnvil(Consumer<Block> block, Block @NotNull ... anvils) {
         for (Block anvil : anvils) {
-            block.invoke(anvil);
+            block.accept(anvil);
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/function/Function.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/function/Function.java
@@ -1,5 +1,0 @@
-package dev.dubhe.anvilcraft.util.function;
-
-public interface Function<T> {
-    void invoke(T t);
-}


### PR DESCRIPTION
removed util/function/Function.java
- replaced all related code to `Consumer`(java.util.function)