### PR TITLE
use AT instead of Compound to get xp orb's count. 使用 AT 而不是 Compound 来读取经验球的堆叠数。

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/util/MagnetUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/MagnetUtil.java
@@ -80,10 +80,9 @@ public abstract class MagnetUtil {
         AABB aabb = new AABB(player.position().add(-radius, -radius, -radius), player.position().add(radius, radius, radius));
         level.getEntities(EntityTypeTest.forClass(ItemEntity.class), aabb, Entity::isAlive).forEach(e -> e.moveTo(player.position()));
         int totalXp = level.getEntities(EntityTypeTest.forClass(ExperienceOrb.class), aabb, Entity::isAlive).stream().mapToInt(e -> {
-            CompoundTag c = new CompoundTag(); // AT (make e.count public) not working for idea, idk why. use CompoundTag yet.
-            e.addAdditionalSaveData(c);
+            int xp = Math.max(e.count * e.value, 1);
             e.discard();
-            return Math.max(c.getShort("Value") * c.getInt("Count"), 1);
+            return xp;
         }).sum();
         if (totalXp > 0 && level instanceof ServerLevel serverLevel) ExperienceOrb.award(serverLevel, player.position(), totalXp);
         itemStack.hurtAndBreak(1, player, LivingEntity.getSlotForHand(usedHand));

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -115,3 +115,5 @@ public net.minecraft.core.Holder$Reference type
 public net.minecraft.core.Holder$Reference owner
 public-f net.minecraft.core.Holder$Reference tags
 public net.minecraft.core.Holder$Reference$Type
+
+public net.minecraft.world.entity.ExperienceOrb count


### PR DESCRIPTION
#2762 中使用 Compound ~~nbt~~ 获取经验球的堆叠数，可以使用 AT 来节约性能。
 - 使用 AT 将 ExperienceOrb.count 变成 public
 - 手持磁铁处理堆叠时直接读取其 count 和 value 而不再需要构造一个 Compound 了