### PR TITLE
fix #2774 resin block disappear when catching mobs. 修复树脂块捕捉生物后产物消失的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/item/HasMobBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/item/HasMobBlockItem.java
@@ -140,7 +140,7 @@ public class HasMobBlockItem extends BlockItem {
             villager.releasePoi(MemoryModuleType.MEETING_POINT);
         }
         entity.remove(Entity.RemovalReason.DISCARDED);
-        if (player != null) player.getInventory().placeItemBackInInventory(stack);
+        if (player != null) player.getInventory().placeItemBackInInventory(newStack);
         return newStack;
     }
 


### PR DESCRIPTION
 - fixed #2774
 - 修理了 #2774 中树脂块抓捕生物时产物消失的 bug
 - 本应该是将产物树脂块塞进玩家背包结果写成了将消耗掉树脂块之后的空气塞进了背包