### PR TITLE
Fix charger displayed in charging category is overloaded 修复充能配方的JEI界面中的充电器显示为过载的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/ChargerChargingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/ChargerChargingCategory.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.integration.jei.category;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import dev.dubhe.anvilcraft.block.ChargerBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.reicpe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
@@ -103,7 +104,7 @@ public class ChargerChargingCategory implements IRecipeCategory<RecipeHolder<Cha
         ChargerChargingRecipe recipe = recipeHolder.value();
         RenderSupport.renderBlock(
             guiGraphics,
-            recipe.getProcessingBlock().defaultBlockState(),
+            recipe.getProcessingBlock().defaultBlockState().setValue(ChargerBlock.OVERLOAD, false),
             81,
             40,
             10,


### PR DESCRIPTION
- 现在充能配方的JEI界面中显示的充电器与放电器不再是过载状态了。
<img width="877" height="748" alt="image" src="https://github.com/user-attachments/assets/29f7662d-c7f7-43d2-867c-2ffafa4da452" />
