### PR TITLE
Players no longer insert items in offhand into magnetized node 修复玩家会将副手物品塞入磁化节点的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
@@ -59,10 +59,11 @@ public class PlayerEventListener {
     }
 
     @SubscribeEvent
-    public static void playerRightClick(PlayerInteractEvent.RightClickBlock event) {
+    public static void playerRightClickMagnetizedNode(PlayerInteractEvent.RightClickBlock event) {
+        InteractionHand hand = event.getHand();
+        if (hand != InteractionHand.MAIN_HAND) return;
         Level level = event.getLevel();
         BlockPos pos = event.getPos();
-        InteractionHand hand = event.getHand();
         Player player = event.getEntity();
         ItemStack item = player.getItemInHand(hand);
         List<MagnetizedNodeEntity> entities = level.getEntitiesOfClass(
@@ -76,22 +77,20 @@ public class PlayerEventListener {
         ) {
             return;
         }
-        if (player.isShiftKeyDown()) {
+        if (player.isShiftKeyDown() || entities.isEmpty()) {
             return;
         }
-        if (!entities.isEmpty()) {
-            MagnetizedNodeEntity first = entities.getFirst();
-            ItemStack stack = item.copy();
-            stack.setCount(1);
-            if (!player.isCreative()) {
-                item.shrink(1);
-            }
-            ItemEntity itemEntity = new ItemEntity(level, first.position().x, first.position().y, first.position().z, stack);
-            itemEntity.setDeltaMovement(0, 0, 0);
-            itemEntity.setPickUpDelay(60);
-            level.addFreshEntity(itemEntity);
-            event.setCanceled(true);
+        MagnetizedNodeEntity node = entities.getFirst();
+        ItemStack stack = item.copy();
+        stack.setCount(1);
+        if (!player.isCreative()) {
+            item.shrink(1);
         }
+        ItemEntity itemEntity = new ItemEntity(level, node.position().x, node.position().y, node.position().z, stack);
+        itemEntity.setDeltaMovement(0, 0, 0);
+        itemEntity.setPickUpDelay(60);
+        level.addFreshEntity(itemEntity);
+        event.setCanceled(true);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
- 修复了 #2806 的问题。
  - 根据 #2126 的设定，玩家互动只应将主手物品塞入磁化节点。
- fixed #2806 