### PR TITLE
Fix the fall distance calculation in the FallingSpectralBlockEntity landing event, and add special handling logic when the FallingSpectralBlockEntity into an End portal block 修复幻灵实体着陆事件中的坠落距离计算，增加对幻灵下落方块进入末地传送门时的特殊处理逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/injection/entity/IFallingBlockEntityExtension.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/injection/entity/IFallingBlockEntityExtension.java
@@ -4,4 +4,5 @@ public interface IFallingBlockEntityExtension {
     default float anvilcraft$getFallDistance() {
         throw new AssertionError();
     }
+    default boolean anvilcraft$isSpectral(){return false;}
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/injection/entity/IFallingBlockEntityExtension.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/injection/entity/IFallingBlockEntityExtension.java
@@ -4,5 +4,8 @@ public interface IFallingBlockEntityExtension {
     default float anvilcraft$getFallDistance() {
         throw new AssertionError();
     }
-    default boolean anvilcraft$isSpectral(){return false;}
+
+    default boolean anvilcraft$isSpectral() {
+        return false;
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
@@ -77,6 +77,16 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
     }
 
     @Override
+    public boolean anvilcraft$isSpectral() {
+        return true;
+    }
+
+    @Override
+    public float anvilcraft$getFallDistance() {
+        return 1.0F;
+    }
+
+    @Override
     public void tick() {
         if (this.blockState.isAir()) {
             this.discard();
@@ -90,7 +100,7 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
                 BlockPos blockPos = this.blockPosition();
                 if (this.onGround()) {
                     this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-                    AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, this, 1);
+                    AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, this, this.anvilcraft$getFallDistance());
                     NeoForge.EVENT_BUS.post(event);
                     this.level().playSound(null, blockPos, SoundEvents.ANVIL_LAND, SoundSource.BLOCKS, 1.0F, 1.0F);
                     this.discard();

--- a/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
@@ -90,7 +90,7 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
                 BlockPos blockPos = this.blockPosition();
                 if (this.onGround()) {
                     this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-                    AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, this, this.anvilcraft$getFallDistance());
+                    AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, this, 1);
                     NeoForge.EVENT_BUS.post(event);
                     this.level().playSound(null, blockPos, SoundEvents.ANVIL_LAND, SoundSource.BLOCKS, 1.0F, 1.0F);
                     this.discard();
@@ -101,9 +101,10 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
                 } else if (
                     !this.level().isClientSide()
                     && (
-                        this.time > 100 && (
-                            blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level()
-                                .getMaxBuildHeight()
+                        this.time > 100
+                        && (
+                            blockPos.getY() <= this.level().getMinBuildHeight()
+                            || blockPos.getY() > this.level().getMaxBuildHeight()
                         )
                         || this.time > 600
                     )

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EndPortalBlockMixin.java
@@ -34,10 +34,14 @@ abstract class EndPortalBlockMixin {
     private void fallBlockEntityInside(
         BlockState pState, Level pLevel, BlockPos pPos, Entity pEntity, CallbackInfo ci
     ) {
-        if (
-            pEntity instanceof FallingBlockEntity fallingBlockEntity
-            && !fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)
-        ) {
+        if (!(pEntity instanceof FallingBlockEntity fallingBlockEntity)) {
+            return;
+        }
+        if (fallingBlockEntity.anvilcraft$isSpectral()) {
+            fallingBlockEntity.discard();
+            return;
+        }
+        if (!fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)) {
             BlockState newState = ModBlocks.END_DUST.getDefaultState();
             if (fallingBlockEntity.blockState.is(BlockTags.ANVIL)) {
                 double rand = pLevel.random.nextDouble();


### PR DESCRIPTION
- fixed #2897