### PR TITLE
Offset Scene BasePlate Downward to Avoid UI Overlap at Zoom 4X 撼地思索大场景下移一格，防止在4X缩放中遮挡UI

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/structure/GiantAnvilScene.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/ponder/scene/structure/GiantAnvilScene.java
@@ -52,8 +52,9 @@ public class GiantAnvilScene {
         builder.configureBasePlate(0, 0, 33);
         // 摄像机缩放0.6f
         builder.scaleSceneView(0.6f);
+        // 下移一格
+        builder.setSceneOffsetY(-1);
         // 放置地板
-
         builder.showBasePlate();
         // 延时10gt
         builder.idle(10);
@@ -193,6 +194,8 @@ public class GiantAnvilScene {
         builder.configureBasePlate(0, 0, 33);
         // 摄像机缩放0.6f
         builder.scaleSceneView(0.6f);
+        // 下移一格
+        builder.setSceneOffsetY(-1);
         // 放置地板
         builder.showBasePlate();
         // 10gt延时
@@ -458,6 +461,8 @@ public class GiantAnvilScene {
         builder.scaleSceneView(0.6f);
         // 放置地板
         builder.showBasePlate();
+        // 下移一格
+        builder.setSceneOffsetY(-1);
         // 10gt延时
         builder.idle(10);
         // 放置重质铁块


### PR DESCRIPTION
3X还是会遮挡，不管了，再下挪更多就影响大缩放的效果了