### PR TITLE
Fix the block devourer behavior logic and add mineral spring probability block state support 修复方块吞噬者行为逻辑 添加矿物涌泉概率方块状态支持

### DIFF
--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_copper_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_copper_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "minecraft:raw_copper_block"
   },
-  "to_block": "minecraft:deepslate_copper_ore"
+  "to_block": {
+    "block": "minecraft:deepslate_copper_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_gold_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_gold_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "minecraft:raw_gold_block"
   },
-  "to_block": "minecraft:deepslate_gold_ore"
+  "to_block": {
+    "block": "minecraft:deepslate_gold_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_iron_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_iron_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "minecraft:raw_iron_block"
   },
-  "to_block": "minecraft:deepslate_iron_ore"
+  "to_block": {
+    "block": "minecraft:deepslate_iron_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_lead_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_lead_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_lead"
   },
-  "to_block": "anvilcraft:deepslate_lead_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_lead_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_silver_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_silver_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_silver"
   },
-  "to_block": "anvilcraft:deepslate_silver_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_silver_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_tin_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_tin_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_tin"
   },
-  "to_block": "anvilcraft:deepslate_tin_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_tin_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_titanium_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_titanium_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_titanium"
   },
-  "to_block": "anvilcraft:deepslate_titanium_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_titanium_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_tungsten_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_tungsten_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_tungsten"
   },
-  "to_block": "anvilcraft:deepslate_tungsten_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_tungsten_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_uranium_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_uranium_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_uranium"
   },
-  "to_block": "anvilcraft:deepslate_uranium_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_uranium_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_zinc_ore.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain/deepslate_zinc_ore.json
@@ -6,5 +6,7 @@
   "need_block": {
     "blocks": "#c:storage_blocks/raw_zinc"
   },
-  "to_block": "anvilcraft:deepslate_zinc_ore"
+  "to_block": {
+    "block": "anvilcraft:deepslate_zinc_ore"
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/earth_core_shard_ore_from_overworld.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/earth_core_shard_ore_from_overworld.json
@@ -1,9 +1,11 @@
 {
   "type": "anvilcraft:mineral_fountain_chance",
-  "chance": 0.01,
   "dimension": "minecraft:overworld",
   "from_block": {
     "blocks": "minecraft:deepslate"
   },
-  "to_block": "anvilcraft:earth_core_shard_ore"
+  "to_block": {
+    "block": "anvilcraft:earth_core_shard_ore",
+    "chance": 0.01
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/earth_core_shard_ore_from_the_nether.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/earth_core_shard_ore_from_the_nether.json
@@ -1,9 +1,11 @@
 {
   "type": "anvilcraft:mineral_fountain_chance",
-  "chance": 0.1,
   "dimension": "minecraft:the_nether",
   "from_block": {
     "blocks": "minecraft:deepslate"
   },
-  "to_block": "anvilcraft:earth_core_shard_ore"
+  "to_block": {
+    "block": "anvilcraft:earth_core_shard_ore",
+    "chance": 0.1
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/void_stone_from_overworld.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/void_stone_from_overworld.json
@@ -1,9 +1,11 @@
 {
   "type": "anvilcraft:mineral_fountain_chance",
-  "chance": 0.01,
   "dimension": "minecraft:overworld",
   "from_block": {
     "blocks": "minecraft:deepslate"
   },
-  "to_block": "anvilcraft:void_stone"
+  "to_block": {
+    "block": "anvilcraft:void_stone",
+    "chance": 0.01
+  }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/void_stone_from_the_end.json
+++ b/src/generated/resources/data/anvilcraft/recipe/mineral_fountain_chance/void_stone_from_the_end.json
@@ -1,9 +1,11 @@
 {
   "type": "anvilcraft:mineral_fountain_chance",
-  "chance": 0.1,
   "dimension": "minecraft:the_end",
   "from_block": {
     "blocks": "minecraft:deepslate"
   },
-  "to_block": "anvilcraft:void_stone"
+  "to_block": {
+    "block": "anvilcraft:void_stone",
+    "chance": 0.1
+  }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/anvil/BlockDevourerBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/anvil/BlockDevourerBehavior.java
@@ -35,8 +35,8 @@ public class BlockDevourerBehavior implements IAnvilBehavior {
             hitBlockState.getValue(BlockDevourerBlock.FACING) == Direction.DOWN
             && level.getBlockState(hitBlockPos.below()).getBlock().defaultDestroyTime() >= 0
         ) {
-            level.setBlock(hitBlockPos, Blocks.AIR.defaultBlockState(), 2);
-            level.setBlock(hitBlockPos.below(), hitBlockState.setValue(BlockDevourerBlock.TRIGGERED, true), 2);
+            level.setBlockAndUpdate(hitBlockPos, Blocks.AIR.defaultBlockState());
+            level.setBlockAndUpdate(hitBlockPos.below(), hitBlockState.setValue(BlockDevourerBlock.TRIGGERED, true));
             level.scheduleTick(hitBlockPos.below(), block, 4);
         }
         level.scheduleTick(hitBlockPos, block, 4);

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/MineralFountainBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/MineralFountainBlockEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -51,54 +52,55 @@ public class MineralFountainBlockEntity extends BlockEntity {
      * 矿物涌泉tick
      */
     public void tick() {
-        if (level == null) return;
-        if (tickCount > -1) tickCount--;
-        if (tickCount != 0) return;
+        if (this.level == null) return;
+        if (this.tickCount > -1) this.tickCount--;
+        if (this.tickCount != 0) return;
+        if (!(this.level instanceof ServerLevel serverLevel)) return;
         BlockState aroundState = getAroundBlock();
-        if (level.getMinBuildHeight() > getBlockPos().getY() || getBlockPos().getY() > level.getMinBuildHeight() + 8) {
+        if (this.level.getMinBuildHeight() > getBlockPos().getY() || getBlockPos().getY() > this.level.getMinBuildHeight() + 8) {
             return;
         }
-        BlockState aboveState = level.getBlockState(getBlockPos().above());
+        BlockState aboveState = this.level.getBlockState(getBlockPos().above());
         if (aroundState.is(Blocks.LAVA)) {
             if (aboveState.is(Blocks.AIR)) {
-                level.setBlockAndUpdate(getBlockPos().above(), Blocks.LAVA.defaultBlockState());
+                this.level.setBlockAndUpdate(getBlockPos().above(), Blocks.LAVA.defaultBlockState());
                 return;
             }
-            HeaterManager.addProducer(getBlockPos(), getLevel(), ModHeaterInfos.LAVA_MINERAL_FOUNTAIN);
+            HeaterManager.addProducer(getBlockPos(), serverLevel, ModHeaterInfos.LAVA_MINERAL_FOUNTAIN);
             return;
         } else if (aboveState.is(Blocks.AIR)) {
-            level.setBlockAndUpdate(getBlockPos().above(), ModBlocks.CINERITE.getDefaultState());
+            this.level.setBlockAndUpdate(getBlockPos().above(), ModBlocks.CINERITE.getDefaultState());
         } else {
             MineralFountainRecipe.Input input = new MineralFountainRecipe.Input(aroundState.getBlock(), aboveState.getBlock());
-            level.getRecipeManager()
+            this.level.getRecipeManager()
                 .getRecipeFor(ModRecipeTypes.MINERAL_FOUNTAIN.get(), input, level)
                 .ifPresent(recipe -> {
-                    var chanceList = level
+                    var chanceList = this.level
                         .getRecipeManager()
                         .getAllRecipesFor(ModRecipeTypes.MINERAL_FOUNTAIN_CHANCE.get())
                         .stream()
                         .filter(r -> r.value()
                             .getDimension()
-                            .equals(level.dimension().location()))
-                        .filter(r -> r.value().getFromBlock().test(level, aboveState, null))
+                            .equals(this.level.dimension().location())
+                        )
+                        .filter(r -> r.value().getFromBlock().test(this.level, aboveState, null))
                         .toList();
                     for (var changeRecipe : chanceList) {
-                        if (level.getRandom().nextDouble()
-                            <= changeRecipe.value().getChance()) {
-                            level.setBlockAndUpdate(
+                        if (this.level.getRandom().nextDouble() <= changeRecipe.value().getChance(serverLevel)) {
+                            this.level.setBlockAndUpdate(
                                 getBlockPos().above(),
-                                changeRecipe.value().getToBlock().defaultBlockState()
+                                changeRecipe.value().getToBlock().state()
                             );
                             return;
                         }
                     }
                     level.setBlockAndUpdate(
                         getBlockPos().above(),
-                        recipe.value().getToBlock().defaultBlockState()
+                        recipe.value().getToBlock().state()
                     );
                 });
         }
-        HeaterManager.removeProducer(getBlockPos(), getLevel(), ModHeaterInfos.LAVA_MINERAL_FOUNTAIN);
+        HeaterManager.removeProducer(getBlockPos(), serverLevel, ModHeaterInfos.LAVA_MINERAL_FOUNTAIN);
     }
 
     private static final Direction[] HORIZONTAL_DIRECTION = {
@@ -109,21 +111,20 @@ public class MineralFountainBlockEntity extends BlockEntity {
     };
 
     public BlockState getAroundBlock() {
-        if (level == null) {
+        if (this.level == null) {
             return Blocks.AIR.defaultBlockState();
         }
         List<BlockState> blockStates = Arrays.stream(HORIZONTAL_DIRECTION)
-            .map(direction -> level.getBlockState(getBlockPos().relative(direction)))
+            .map(direction -> this.level.getBlockState(getBlockPos().relative(direction)))
             .toList();
         BlockState firstState = blockStates.getFirst();
         long count = blockStates.stream()
-            .filter(s ->
-                        s.is(firstState.getBlock()) && (s.getFluidState().isEmpty() || s.getFluidState().isSource())
-            ).count();
+            .filter(s -> s.is(firstState.getBlock()) && (s.getFluidState().isEmpty() || s.getFluidState().isSource()))
+            .count();
         return count == 4 ? firstState : Blocks.AIR.defaultBlockState();
     }
 
     public void resetTickCount() {
-        if (tickCount <= 0) tickCount = 20;
+        if (this.tickCount <= 0) this.tickCount = 20;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/MineralFountainRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/MineralFountainRecipeLoader.java
@@ -27,29 +27,25 @@ public class MineralFountainRecipeLoader {
         MineralFountainChanceRecipe.builder()
             .dimension(Level.OVERWORLD.location())
             .fromBlock(Blocks.DEEPSLATE)
-            .toBlock(ModBlocks.VOID_STONE.get())
-            .chance(0.01)
+            .toBlock(ModBlocks.VOID_STONE.get(), 0.01f)
             .save(provider);
 
         MineralFountainChanceRecipe.builder()
             .dimension(Level.OVERWORLD.location())
             .fromBlock(Blocks.DEEPSLATE)
-            .toBlock(ModBlocks.EARTH_CORE_SHARD_ORE.get())
-            .chance(0.01)
+            .toBlock(ModBlocks.EARTH_CORE_SHARD_ORE.get(), 0.01f)
             .save(provider);
 
         MineralFountainChanceRecipe.builder()
             .dimension(Level.NETHER.location())
             .fromBlock(Blocks.DEEPSLATE)
-            .toBlock(ModBlocks.EARTH_CORE_SHARD_ORE.get())
-            .chance(0.1)
+            .toBlock(ModBlocks.EARTH_CORE_SHARD_ORE.get(), 0.1f)
             .save(provider);
 
         MineralFountainChanceRecipe.builder()
             .dimension(Level.END.location())
             .fromBlock(Blocks.DEEPSLATE)
-            .toBlock(ModBlocks.VOID_STONE.get())
-            .chance(0.1)
+            .toBlock(ModBlocks.VOID_STONE.get(), 0.1f)
             .save(provider);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/BoilingRecipeSchema.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/BoilingRecipeSchema.java
@@ -1,0 +1,169 @@
+package dev.dubhe.anvilcraft.integration.kubejs.recipe.anvil;
+
+import dev.anvilcraft.lib.recipe.component.ChanceItemStack;
+import dev.anvilcraft.lib.recipe.component.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftKubeRecipe;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftRecipeComponents;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.IDRecipeConstructor;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ChanceItemStackComponent;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ItemIngredientPredicateComponent;
+import dev.dubhe.anvilcraft.recipe.anvil.predicate.block.HasCauldron;
+import dev.dubhe.anvilcraft.recipe.anvil.util.WrapUtils;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.component.ComponentRole;
+import dev.latvian.mods.kubejs.recipe.component.NumberComponent;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.storage.loot.providers.number.BinomialDistributionGenerator;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface BoilingRecipeSchema {
+    @SuppressWarnings({"unused"})
+    class BoilingKubeRecipe extends AnvilCraftKubeRecipe {
+        public BoilingKubeRecipe cauldron(ResourceLocation fluid) {
+            this.setValue(FLUID, fluid);
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe cauldron(Block cauldron) {
+            return this.cauldron(WrapUtils.cauldron2Fluid(cauldron));
+        }
+
+        public BoilingKubeRecipe transform(ResourceLocation transform) {
+            this.setValue(TRANSFORM, transform);
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe transform(Block transform) {
+            return this.transform(WrapUtils.cauldron2Fluid(transform));
+        }
+
+        public BoilingKubeRecipe produceFluid(boolean produceFluid) {
+            if (!produceFluid) return this;
+            this.setValue(CONSUME, -1);
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe consumeFluid(boolean consumeFluid) {
+            if (!consumeFluid) return this;
+            this.setValue(CONSUME, 1);
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe requires(TagKey<Item> ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe requires(TagKey<Item> ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public BoilingKubeRecipe requires(ItemStack ingredient) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).build());
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe requires(ItemLike ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe requires(ItemLike ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public BoilingKubeRecipe result(ItemStack result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe result(ItemStack result, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(result.getCount(), chance));
+        }
+
+        public BoilingKubeRecipe result(ItemStack result) {
+            return this.result(result, ConstantValue.exactly(result.getCount()));
+        }
+
+        public BoilingKubeRecipe result(ItemLike result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public BoilingKubeRecipe result(ItemLike result, int count, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(count, chance));
+        }
+
+        public BoilingKubeRecipe result(ItemLike result, int count) {
+            return this.result(result, ConstantValue.exactly(count));
+        }
+
+        public BoilingKubeRecipe result(ItemLike result, float chance) {
+            return this.result(result, 1, chance);
+        }
+
+        public BoilingKubeRecipe result(ItemLike result) {
+            return this.result(result, ConstantValue.exactly(1.0f));
+        }
+
+        @Override
+        protected void validate() {
+        }
+    }
+
+    RecipeKey<List<ItemIngredientPredicate>> INGREDIENTS = ItemIngredientPredicateComponent.INSTANCE
+        .asList()
+        .inputKey("ingredients")
+        .defaultOptional();
+    RecipeKey<List<ChanceItemStack>> RESULTS = ChanceItemStackComponent.INSTANCE
+        .asList()
+        .inputKey("results")
+        .defaultOptional();
+    RecipeKey<ResourceLocation> FLUID = AnvilCraftRecipeComponents.RESOURCE_LOCATION
+        .key("fluid", ComponentRole.OUTPUT)
+        .optional(HasCauldron.EMPTY)
+        .alwaysWrite();
+    RecipeKey<Integer> CONSUME = NumberComponent.INT
+        .key("consume", ComponentRole.OUTPUT)
+        .optional(0)
+        .alwaysWrite();
+    RecipeKey<ResourceLocation> TRANSFORM = AnvilCraftRecipeComponents.RESOURCE_LOCATION
+        .key("transform", ComponentRole.OUTPUT)
+        .optional(HasCauldron.NULL)
+        .alwaysWrite();
+
+    RecipeSchema SCHEMA = new RecipeSchema(INGREDIENTS, RESULTS, FLUID, CONSUME, TRANSFORM)
+        .factory(new KubeRecipeFactory(AnvilCraft.of("boiling"), BoilingKubeRecipe.class, BoilingKubeRecipe::new))
+        .constructor(INGREDIENTS, RESULTS, FLUID, CONSUME, TRANSFORM)
+        .constructor(INGREDIENTS, RESULTS, FLUID, CONSUME)
+        .constructor(INGREDIENTS, RESULTS, FLUID)
+        .constructor(INGREDIENTS, RESULTS)
+        .constructor(new IDRecipeConstructor())
+        .constructor();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/CookingRecipeSchema.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/CookingRecipeSchema.java
@@ -1,0 +1,169 @@
+package dev.dubhe.anvilcraft.integration.kubejs.recipe.anvil;
+
+import dev.anvilcraft.lib.recipe.component.ChanceItemStack;
+import dev.anvilcraft.lib.recipe.component.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftKubeRecipe;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftRecipeComponents;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.IDRecipeConstructor;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ChanceItemStackComponent;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ItemIngredientPredicateComponent;
+import dev.dubhe.anvilcraft.recipe.anvil.predicate.block.HasCauldron;
+import dev.dubhe.anvilcraft.recipe.anvil.util.WrapUtils;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.component.ComponentRole;
+import dev.latvian.mods.kubejs.recipe.component.NumberComponent;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.storage.loot.providers.number.BinomialDistributionGenerator;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface CookingRecipeSchema {
+    @SuppressWarnings({"unused"})
+    class CookingKubeRecipe extends AnvilCraftKubeRecipe {
+        public CookingKubeRecipe cauldron(ResourceLocation fluid) {
+            this.setValue(FLUID, fluid);
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe cauldron(Block cauldron) {
+            return this.cauldron(WrapUtils.cauldron2Fluid(cauldron));
+        }
+
+        public CookingKubeRecipe transform(ResourceLocation transform) {
+            this.setValue(TRANSFORM, transform);
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe transform(Block transform) {
+            return this.transform(WrapUtils.cauldron2Fluid(transform));
+        }
+
+        public CookingKubeRecipe produceFluid(boolean produceFluid) {
+            if (!produceFluid) return this;
+            this.setValue(CONSUME, -1);
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe consumeFluid(boolean consumeFluid) {
+            if (!consumeFluid) return this;
+            this.setValue(CONSUME, 1);
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe requires(TagKey<Item> ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe requires(TagKey<Item> ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public CookingKubeRecipe requires(ItemStack ingredient) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).build());
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe requires(ItemLike ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe requires(ItemLike ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public CookingKubeRecipe result(ItemStack result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe result(ItemStack result, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(result.getCount(), chance));
+        }
+
+        public CookingKubeRecipe result(ItemStack result) {
+            return this.result(result, ConstantValue.exactly(result.getCount()));
+        }
+
+        public CookingKubeRecipe result(ItemLike result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public CookingKubeRecipe result(ItemLike result, int count, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(count, chance));
+        }
+
+        public CookingKubeRecipe result(ItemLike result, int count) {
+            return this.result(result, ConstantValue.exactly(count));
+        }
+
+        public CookingKubeRecipe result(ItemLike result, float chance) {
+            return this.result(result, 1, chance);
+        }
+
+        public CookingKubeRecipe result(ItemLike result) {
+            return this.result(result, ConstantValue.exactly(1.0f));
+        }
+
+        @Override
+        protected void validate() {
+        }
+    }
+
+    RecipeKey<List<ItemIngredientPredicate>> INGREDIENTS = ItemIngredientPredicateComponent.INSTANCE
+        .asList()
+        .inputKey("ingredients")
+        .defaultOptional();
+    RecipeKey<List<ChanceItemStack>> RESULTS = ChanceItemStackComponent.INSTANCE
+        .asList()
+        .inputKey("results")
+        .defaultOptional();
+    RecipeKey<ResourceLocation> FLUID = AnvilCraftRecipeComponents.RESOURCE_LOCATION
+        .key("fluid", ComponentRole.OUTPUT)
+        .optional(HasCauldron.EMPTY)
+        .alwaysWrite();
+    RecipeKey<Integer> CONSUME = NumberComponent.INT
+        .key("consume", ComponentRole.OUTPUT)
+        .optional(0)
+        .alwaysWrite();
+    RecipeKey<ResourceLocation> TRANSFORM = AnvilCraftRecipeComponents.RESOURCE_LOCATION
+        .key("transform", ComponentRole.OUTPUT)
+        .optional(HasCauldron.NULL)
+        .alwaysWrite();
+
+    RecipeSchema SCHEMA = new RecipeSchema(INGREDIENTS, RESULTS, FLUID, CONSUME, TRANSFORM)
+        .factory(new KubeRecipeFactory(AnvilCraft.of("cooking"), CookingKubeRecipe.class, CookingKubeRecipe::new))
+        .constructor(INGREDIENTS, RESULTS, FLUID, CONSUME, TRANSFORM)
+        .constructor(INGREDIENTS, RESULTS, FLUID, CONSUME)
+        .constructor(INGREDIENTS, RESULTS, FLUID)
+        .constructor(INGREDIENTS, RESULTS)
+        .constructor(new IDRecipeConstructor())
+        .constructor();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/ItemCompressRecipeSchema.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/ItemCompressRecipeSchema.java
@@ -1,0 +1,113 @@
+package dev.dubhe.anvilcraft.integration.kubejs.recipe.anvil;
+
+import dev.anvilcraft.lib.recipe.component.ChanceItemStack;
+import dev.anvilcraft.lib.recipe.component.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftKubeRecipe;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.IDRecipeConstructor;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ChanceItemStackComponent;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ItemIngredientPredicateComponent;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.storage.loot.providers.number.BinomialDistributionGenerator;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface ItemCompressRecipeSchema {
+    @SuppressWarnings({"unused"})
+    class ItemCrushKubeRecipe extends AnvilCraftKubeRecipe {
+        public ItemCrushKubeRecipe requires(TagKey<Item> ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe requires(TagKey<Item> ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public ItemCrushKubeRecipe requires(ItemStack ingredient) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).build());
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe requires(ItemLike ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe requires(ItemLike ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public ItemCrushKubeRecipe result(ItemStack result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe result(ItemStack result, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(result.getCount(), chance));
+        }
+
+        public ItemCrushKubeRecipe result(ItemStack result) {
+            return this.result(result, ConstantValue.exactly(result.getCount()));
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, int count, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(count, chance));
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, int count) {
+            return this.result(result, ConstantValue.exactly(count));
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, float chance) {
+            return this.result(result, 1, chance);
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result) {
+            return this.result(result, ConstantValue.exactly(1.0f));
+        }
+
+        @Override
+        protected void validate() {
+        }
+    }
+
+    RecipeKey<List<ItemIngredientPredicate>> INGREDIENTS = ItemIngredientPredicateComponent.INSTANCE
+        .asList()
+        .inputKey("ingredients")
+        .defaultOptional();
+    RecipeKey<List<ChanceItemStack>> RESULTS = ChanceItemStackComponent.INSTANCE
+        .asList()
+        .inputKey("results")
+        .defaultOptional();
+
+    RecipeSchema SCHEMA = new RecipeSchema(INGREDIENTS, RESULTS)
+        .factory(new KubeRecipeFactory(AnvilCraft.of("item_compress"), ItemCrushKubeRecipe.class, ItemCrushKubeRecipe::new))
+        .constructor(INGREDIENTS, RESULTS)
+        .constructor(new IDRecipeConstructor())
+        .constructor();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/ItemCrushRecipeSchema.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/ItemCrushRecipeSchema.java
@@ -1,0 +1,113 @@
+package dev.dubhe.anvilcraft.integration.kubejs.recipe.anvil;
+
+import dev.anvilcraft.lib.recipe.component.ChanceItemStack;
+import dev.anvilcraft.lib.recipe.component.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftKubeRecipe;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.IDRecipeConstructor;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ChanceItemStackComponent;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ItemIngredientPredicateComponent;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.storage.loot.providers.number.BinomialDistributionGenerator;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface ItemCrushRecipeSchema {
+    @SuppressWarnings({"unused"})
+    class ItemCrushKubeRecipe extends AnvilCraftKubeRecipe {
+        public ItemCrushKubeRecipe requires(TagKey<Item> ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe requires(TagKey<Item> ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public ItemCrushKubeRecipe requires(ItemStack ingredient) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).build());
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe requires(ItemLike ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe requires(ItemLike ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public ItemCrushKubeRecipe result(ItemStack result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe result(ItemStack result, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(result.getCount(), chance));
+        }
+
+        public ItemCrushKubeRecipe result(ItemStack result) {
+            return this.result(result, ConstantValue.exactly(result.getCount()));
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, int count, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(count, chance));
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, int count) {
+            return this.result(result, ConstantValue.exactly(count));
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result, float chance) {
+            return this.result(result, 1, chance);
+        }
+
+        public ItemCrushKubeRecipe result(ItemLike result) {
+            return this.result(result, ConstantValue.exactly(1.0f));
+        }
+
+        @Override
+        protected void validate() {
+        }
+    }
+
+    RecipeKey<List<ItemIngredientPredicate>> INGREDIENTS = ItemIngredientPredicateComponent.INSTANCE
+        .asList()
+        .inputKey("ingredients")
+        .defaultOptional();
+    RecipeKey<List<ChanceItemStack>> RESULTS = ChanceItemStackComponent.INSTANCE
+        .asList()
+        .inputKey("results")
+        .defaultOptional();
+
+    RecipeSchema SCHEMA = new RecipeSchema(INGREDIENTS, RESULTS)
+        .factory(new KubeRecipeFactory(AnvilCraft.of("item_crush"), ItemCrushKubeRecipe.class, ItemCrushKubeRecipe::new))
+        .constructor(INGREDIENTS, RESULTS)
+        .constructor(new IDRecipeConstructor())
+        .constructor();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/MeshRecipeSchema.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/MeshRecipeSchema.java
@@ -1,0 +1,113 @@
+package dev.dubhe.anvilcraft.integration.kubejs.recipe.anvil;
+
+import dev.anvilcraft.lib.recipe.component.ChanceItemStack;
+import dev.anvilcraft.lib.recipe.component.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftKubeRecipe;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.IDRecipeConstructor;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ChanceItemStackComponent;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ItemIngredientPredicateComponent;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.storage.loot.providers.number.BinomialDistributionGenerator;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface MeshRecipeSchema {
+    @SuppressWarnings({"unused"})
+    class MeshKubeRecipe extends AnvilCraftKubeRecipe {
+        public MeshKubeRecipe requires(TagKey<Item> ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public MeshKubeRecipe requires(TagKey<Item> ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public MeshKubeRecipe requires(ItemStack ingredient) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).build());
+            this.save();
+            return this;
+        }
+
+        public MeshKubeRecipe requires(ItemLike ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public MeshKubeRecipe requires(ItemLike ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public MeshKubeRecipe result(ItemStack result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public MeshKubeRecipe result(ItemStack result, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(result.getCount(), chance));
+        }
+
+        public MeshKubeRecipe result(ItemStack result) {
+            return this.result(result, ConstantValue.exactly(result.getCount()));
+        }
+
+        public MeshKubeRecipe result(ItemLike result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public MeshKubeRecipe result(ItemLike result, int count, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(count, chance));
+        }
+
+        public MeshKubeRecipe result(ItemLike result, int count) {
+            return this.result(result, ConstantValue.exactly(count));
+        }
+
+        public MeshKubeRecipe result(ItemLike result, float chance) {
+            return this.result(result, 1, chance);
+        }
+
+        public MeshKubeRecipe result(ItemLike result) {
+            return this.result(result, ConstantValue.exactly(1.0f));
+        }
+
+        @Override
+        protected void validate() {
+        }
+    }
+
+    RecipeKey<List<ItemIngredientPredicate>> INGREDIENTS = ItemIngredientPredicateComponent.INSTANCE
+        .asList()
+        .inputKey("ingredients")
+        .defaultOptional();
+    RecipeKey<List<ChanceItemStack>> RESULTS = ChanceItemStackComponent.INSTANCE
+        .asList()
+        .inputKey("results")
+        .defaultOptional();
+
+    RecipeSchema SCHEMA = new RecipeSchema(INGREDIENTS, RESULTS)
+        .factory(new KubeRecipeFactory(AnvilCraft.of("mesh"), MeshKubeRecipe.class, MeshKubeRecipe::new))
+        .constructor(INGREDIENTS, RESULTS)
+        .constructor(new IDRecipeConstructor())
+        .constructor();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/UnpackRecipeSchema.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/kubejs/recipe/anvil/UnpackRecipeSchema.java
@@ -1,0 +1,113 @@
+package dev.dubhe.anvilcraft.integration.kubejs.recipe.anvil;
+
+import dev.anvilcraft.lib.recipe.component.ChanceItemStack;
+import dev.anvilcraft.lib.recipe.component.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.AnvilCraftKubeRecipe;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.IDRecipeConstructor;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ChanceItemStackComponent;
+import dev.dubhe.anvilcraft.integration.kubejs.recipe.components.ItemIngredientPredicateComponent;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.storage.loot.providers.number.BinomialDistributionGenerator;
+import net.minecraft.world.level.storage.loot.providers.number.ConstantValue;
+import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface UnpackRecipeSchema {
+    @SuppressWarnings({"unused"})
+    class UnpackKubeRecipe extends AnvilCraftKubeRecipe {
+        public UnpackKubeRecipe requires(TagKey<Item> ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public UnpackKubeRecipe requires(TagKey<Item> ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public UnpackKubeRecipe requires(ItemStack ingredient) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).build());
+            this.save();
+            return this;
+        }
+
+        public UnpackKubeRecipe requires(ItemLike ingredient, int count) {
+            this.computeIfAbsent(INGREDIENTS, ArrayList::new)
+                .add(ItemIngredientPredicate.Builder.item().of(ingredient).withCount(count).build());
+            this.save();
+            return this;
+        }
+
+        public UnpackKubeRecipe requires(ItemLike ingredient) {
+            return this.requires(ingredient, 1);
+        }
+
+        public UnpackKubeRecipe result(ItemStack result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public UnpackKubeRecipe result(ItemStack result, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(result.getCount(), chance));
+        }
+
+        public UnpackKubeRecipe result(ItemStack result) {
+            return this.result(result, ConstantValue.exactly(result.getCount()));
+        }
+
+        public UnpackKubeRecipe result(ItemLike result, NumberProvider count) {
+            this.computeIfAbsent(RESULTS, ArrayList::new)
+                .add(ChanceItemStack.of(result, count));
+            this.save();
+            return this;
+        }
+
+        public UnpackKubeRecipe result(ItemLike result, int count, float chance) {
+            return this.result(result, BinomialDistributionGenerator.binomial(count, chance));
+        }
+
+        public UnpackKubeRecipe result(ItemLike result, int count) {
+            return this.result(result, ConstantValue.exactly(count));
+        }
+
+        public UnpackKubeRecipe result(ItemLike result, float chance) {
+            return this.result(result, 1, chance);
+        }
+
+        public UnpackKubeRecipe result(ItemLike result) {
+            return this.result(result, ConstantValue.exactly(1.0f));
+        }
+
+        @Override
+        protected void validate() {
+        }
+    }
+
+    RecipeKey<List<ItemIngredientPredicate>> INGREDIENTS = ItemIngredientPredicateComponent.INSTANCE
+        .asList()
+        .inputKey("ingredients")
+        .defaultOptional();
+    RecipeKey<List<ChanceItemStack>> RESULTS = ChanceItemStackComponent.INSTANCE
+        .asList()
+        .inputKey("results")
+        .defaultOptional();
+
+    RecipeSchema SCHEMA = new RecipeSchema(INGREDIENTS, RESULTS)
+        .factory(new KubeRecipeFactory(AnvilCraft.of("unpack"), UnpackKubeRecipe.class, UnpackKubeRecipe::new))
+        .constructor(INGREDIENTS, RESULTS)
+        .constructor(new IDRecipeConstructor())
+        .constructor();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/mineral/MineralFountainChanceRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/mineral/MineralFountainChanceRecipe.java
@@ -1,13 +1,13 @@
 package dev.dubhe.anvilcraft.recipe.mineral;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.anvilcraft.lib.recipe.component.BlockStatePredicate;
+import dev.anvilcraft.lib.recipe.component.ChanceBlockState;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.init.reicpe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.recipe.anvil.builder.AbstractRecipeBuilder;
-import dev.anvilcraft.lib.util.CodecUtil;
+import dev.dubhe.anvilcraft.util.RecipeUtil;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -16,9 +16,9 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -39,14 +39,16 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class MineralFountainChanceRecipe implements Recipe<MineralFountainChanceRecipe.Input> {
     private final ResourceLocation dimension;
     private final BlockStatePredicate fromBlock;
-    private final Block toBlock;
-    private final double chance;
+    private final ChanceBlockState toBlock;
 
-    public MineralFountainChanceRecipe(ResourceLocation dimension, BlockStatePredicate fromBlock, Block toBlock, double chance) {
+    public MineralFountainChanceRecipe(ResourceLocation dimension, BlockStatePredicate fromBlock, ChanceBlockState toBlock) {
         this.dimension = dimension;
         this.fromBlock = fromBlock;
         this.toBlock = toBlock;
-        this.chance = chance;
+    }
+
+    public double getChance(ServerLevel level) {
+        return this.toBlock.chance().getFloat(RecipeUtil.emptyLootContext(level));
     }
 
     @Contract(" -> new")
@@ -71,17 +73,21 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
 
     @Override
     public ItemStack assemble(Input input, HolderLookup.Provider provider) {
-        return this.toBlock.asItem() == Items.AIR ? ItemStack.EMPTY : new ItemStack(this.fromBlock.getStatesCache().getFirst().getBlock());
+        return this.toBlock.state().getBlock().asItem() == Items.AIR
+               ? ItemStack.EMPTY
+               : new ItemStack(this.fromBlock.getStatesCache().getFirst().getBlock());
     }
 
     @Override
     public ItemStack getResultItem(HolderLookup.Provider provider) {
-        return this.toBlock.asItem() == Items.AIR ? ItemStack.EMPTY : new ItemStack(this.fromBlock.getStatesCache().getFirst().getBlock());
+        return this.toBlock.state().getBlock().asItem() == Items.AIR
+               ? ItemStack.EMPTY
+               : new ItemStack(this.fromBlock.getStatesCache().getFirst().getBlock());
     }
 
     @Override
     public boolean matches(Input input, Level level) {
-        return input.dimension.equals(dimension) && fromBlock.test(level, input.fromBlock.defaultBlockState(), null);
+        return input.dimension.equals(this.dimension) && this.fromBlock.test(level, input.fromBlock.defaultBlockState(), null);
     }
 
     @Override
@@ -90,10 +96,9 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
     }
 
     public record Input(ResourceLocation dimension, Block fromBlock) implements RecipeInput {
-
         @Override
         public ItemStack getItem(int i) {
-            return new ItemStack(fromBlock);
+            return new ItemStack(this.fromBlock);
         }
 
         @Override
@@ -115,8 +120,9 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
                 BlockStatePredicate.CODEC
                     .fieldOf("from_block")
                     .forGetter(MineralFountainChanceRecipe::getFromBlock),
-                CodecUtil.BLOCK_CODEC.fieldOf("to_block").forGetter(MineralFountainChanceRecipe::getToBlock),
-                Codec.DOUBLE.fieldOf("chance").forGetter(MineralFountainChanceRecipe::getChance)
+                ChanceBlockState.CODEC
+                    .fieldOf("to_block")
+                    .forGetter(MineralFountainChanceRecipe::getToBlock)
             )
             .apply(ins, MineralFountainChanceRecipe::new));
 
@@ -126,32 +132,28 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
                 MineralFountainChanceRecipe::getDimension,
                 BlockStatePredicate.STREAM_CODEC,
                 MineralFountainChanceRecipe::getFromBlock,
-                CodecUtil.BLOCK_STREAM_CODEC,
+                ChanceBlockState.STREAM_CODEC,
                 MineralFountainChanceRecipe::getToBlock,
-                ByteBufCodecs.DOUBLE,
-                MineralFountainChanceRecipe::getChance,
                 MineralFountainChanceRecipe::new
             );
 
         @Override
         public MapCodec<MineralFountainChanceRecipe> codec() {
-            return CODEC;
+            return Serializer.CODEC;
         }
 
         @Override
         public StreamCodec<RegistryFriendlyByteBuf, MineralFountainChanceRecipe> streamCodec() {
-            return STREAM_CODEC;
+            return Serializer.STREAM_CODEC;
         }
     }
 
     @Setter
     @Accessors(fluent = true, chain = true)
     public static class Builder extends AbstractRecipeBuilder<MineralFountainChanceRecipe> {
-
         private ResourceLocation dimension;
         private BlockStatePredicate fromBlock;
-        private Block toBlock;
-        private double chance;
+        private ChanceBlockState toBlock;
 
         public Builder fromBlock(Block fromBlock) {
             this.fromBlock = BlockStatePredicate.builder().of(fromBlock).build();
@@ -163,9 +165,41 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
             return this;
         }
 
+        /**
+         * 添加结果方块
+         *
+         * @param result 结果方块
+         * @return 构建器实例
+         */
+        public Builder toBlock(ChanceBlockState result) {
+            this.toBlock = result;
+            return this;
+        }
+
+        /**
+         * 添加结果方块（指定概率）
+         *
+         * @param result 结果方块
+         * @param chance 概率
+         * @return 构建器实例
+         */
+        public Builder toBlock(Block result, float chance) {
+            return this.toBlock(new ChanceBlockState(result.defaultBlockState(), chance));
+        }
+
+        /**
+         * 添加结果方块（默认概率为1.0f）
+         *
+         * @param result 结果方块
+         * @return 构建器实例
+         */
+        public Builder toBlock(Block result) {
+            return this.toBlock(result, 1.0f);
+        }
+
         @Override
         public MineralFountainChanceRecipe buildRecipe() {
-            return new MineralFountainChanceRecipe(dimension, fromBlock, toBlock, chance);
+            return new MineralFountainChanceRecipe(this.dimension, this.fromBlock, this.toBlock);
         }
 
         @Override
@@ -174,23 +208,20 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
                 recipeOutput,
                 AnvilCraft.of(BuiltInRegistries.ITEM.getKey(getResult()).getPath())
                     .withPrefix(getType() + "/")
-                    .withSuffix("_from_" + dimension.getPath())
+                    .withSuffix("_from_" + this.dimension.getPath())
             );
         }
 
         @Override
         public void validate(ResourceLocation pId) {
-            if (dimension == null) {
+            if (this.dimension == null) {
                 throw new IllegalArgumentException("Dimension must be not null, RecipeId: " + pId);
             }
-            if (fromBlock == null) {
+            if (this.fromBlock == null) {
                 throw new IllegalArgumentException("FromBlock must be not null, RecipeId: " + pId);
             }
-            if (toBlock == null) {
+            if (this.toBlock == null) {
                 throw new IllegalArgumentException("ToBlock must be not null, RecipeId: " + pId);
-            }
-            if (chance <= 0 || chance > 1) {
-                throw new IllegalArgumentException("Chance must be between 0 and 1, RecipeId: " + pId);
             }
         }
 
@@ -201,7 +232,7 @@ public class MineralFountainChanceRecipe implements Recipe<MineralFountainChance
 
         @Override
         public Item getResult() {
-            return toBlock.asItem();
+            return this.toBlock.state().getBlock().asItem();
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/mineral/MineralFountainRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/mineral/MineralFountainRecipe.java
@@ -59,9 +59,9 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
 
     @Override
     public ItemStack assemble(Input input, HolderLookup.Provider provider) {
-        return this.toBlock.state().getBlock().asItem() == Items.AIR ?
-               ItemStack.EMPTY :
-               new ItemStack(this.needBlock.getStatesCache().getFirst().getBlock());
+        return this.toBlock.state().getBlock().asItem() == Items.AIR
+               ? ItemStack.EMPTY
+               : new ItemStack(this.needBlock.getStatesCache().getFirst().getBlock());
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/mineral/MineralFountainRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/mineral/MineralFountainRecipe.java
@@ -3,9 +3,9 @@ package dev.dubhe.anvilcraft.recipe.mineral;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.anvilcraft.lib.recipe.component.BlockStatePredicate;
+import dev.anvilcraft.lib.recipe.component.ChanceBlockState;
 import dev.dubhe.anvilcraft.init.reicpe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.recipe.anvil.builder.AbstractRecipeBuilder;
-import dev.anvilcraft.lib.util.CodecUtil;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -34,9 +34,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input> {
     private final BlockStatePredicate needBlock;
     private final BlockStatePredicate fromBlock;
-    private final Block toBlock;
+    private final ChanceBlockState toBlock;
 
-    public MineralFountainRecipe(BlockStatePredicate needBlock, BlockStatePredicate fromBlock, Block toBlock) {
+    public MineralFountainRecipe(BlockStatePredicate needBlock, BlockStatePredicate fromBlock, ChanceBlockState toBlock) {
         this.needBlock = needBlock;
         this.fromBlock = fromBlock;
         this.toBlock = toBlock;
@@ -59,7 +59,9 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
 
     @Override
     public ItemStack assemble(Input input, HolderLookup.Provider provider) {
-        return this.toBlock.asItem() == Items.AIR ? ItemStack.EMPTY : new ItemStack(this.needBlock.getStatesCache().getFirst().getBlock());
+        return this.toBlock.state().getBlock().asItem() == Items.AIR ?
+               ItemStack.EMPTY :
+               new ItemStack(this.needBlock.getStatesCache().getFirst().getBlock());
     }
 
     @Override
@@ -69,12 +71,16 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
 
     @Override
     public ItemStack getResultItem(HolderLookup.Provider provider) {
-        return this.toBlock.asItem() == Items.AIR ? ItemStack.EMPTY : new ItemStack(this.needBlock.getStatesCache().getFirst().getBlock());
+        return this.toBlock.state().getBlock().asItem() == Items.AIR
+               ? ItemStack.EMPTY
+               : new ItemStack(this.needBlock.getStatesCache().getFirst().getBlock());
     }
 
     @Override
     public boolean matches(Input input, Level level) {
-        if (!this.needBlock.test(level, input.needBlock.defaultBlockState(), null)) return false;
+        if (!this.needBlock.test(level, input.needBlock.defaultBlockState(), null)) {
+            return false;
+        }
         return this.fromBlock.test(level, input.fromBlock.defaultBlockState(), null);
     }
 
@@ -84,10 +90,9 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
     }
 
     public record Input(Block needBlock, Block fromBlock) implements RecipeInput {
-
         @Override
         public ItemStack getItem(int i) {
-            return new ItemStack(needBlock);
+            return new ItemStack(this.needBlock);
         }
 
         @Override
@@ -110,7 +115,7 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
             BlockStatePredicate.CODEC
                 .fieldOf("from_block")
                 .forGetter(MineralFountainRecipe::getFromBlock),
-            CodecUtil.BLOCK_CODEC
+            ChanceBlockState.CODEC
                 .fieldOf("to_block")
                 .forGetter(MineralFountainRecipe::getToBlock)
         ).apply(ins, MineralFountainRecipe::new));
@@ -121,19 +126,19 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
                 MineralFountainRecipe::getNeedBlock,
                 BlockStatePredicate.STREAM_CODEC,
                 MineralFountainRecipe::getFromBlock,
-                CodecUtil.BLOCK_STREAM_CODEC,
+                ChanceBlockState.STREAM_CODEC,
                 MineralFountainRecipe::getToBlock,
                 MineralFountainRecipe::new
             );
 
         @Override
         public MapCodec<MineralFountainRecipe> codec() {
-            return CODEC;
+            return Serializer.CODEC;
         }
 
         @Override
         public StreamCodec<RegistryFriendlyByteBuf, MineralFountainRecipe> streamCodec() {
-            return STREAM_CODEC;
+            return Serializer.STREAM_CODEC;
         }
     }
 
@@ -142,7 +147,7 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
     public static class Builder extends AbstractRecipeBuilder<MineralFountainRecipe> {
         private BlockStatePredicate needBlock;
         private BlockStatePredicate fromBlock;
-        private Block toBlock;
+        private ChanceBlockState toBlock;
 
         public Builder needBlock(Block needBlock) {
             this.needBlock = BlockStatePredicate.builder().of(needBlock).build();
@@ -164,20 +169,41 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
             return this;
         }
 
+        /**
+         * 添加结果方块
+         *
+         * @param result 结果方块
+         * @return 构建器实例
+         */
+        public Builder toBlock(ChanceBlockState result) {
+            this.toBlock = result;
+            return this;
+        }
+
+        /**
+         * 添加结果方块（默认概率为1.0f）
+         *
+         * @param result 结果方块
+         * @return 构建器实例
+         */
+        public Builder toBlock(Block result) {
+            return this.toBlock(new ChanceBlockState(result.defaultBlockState(), 1.0f));
+        }
+
         @Override
         public MineralFountainRecipe buildRecipe() {
-            return new MineralFountainRecipe(needBlock, fromBlock, toBlock);
+            return new MineralFountainRecipe(this.needBlock, this.fromBlock, this.toBlock);
         }
 
         @Override
         public void validate(ResourceLocation pId) {
-            if (needBlock == null) {
+            if (this.needBlock == null) {
                 throw new IllegalArgumentException("needBlock must not be null, RecipeId: " + pId);
             }
-            if (fromBlock == null) {
+            if (this.fromBlock == null) {
                 throw new IllegalArgumentException("fromBlock must not be null, RecipeId: " + pId);
             }
-            if (toBlock == null) {
+            if (this.toBlock == null) {
                 throw new IllegalArgumentException("toBlock must not be null, RecipeId: " + pId);
             }
         }
@@ -189,7 +215,7 @@ public class MineralFountainRecipe implements Recipe<MineralFountainRecipe.Input
 
         @Override
         public Item getResult() {
-            return toBlock.asItem();
+            return this.toBlock.state().getBlock().asItem();
         }
     }
 }


### PR DESCRIPTION
- fixed #2911
- 将 setBlock 方法替换为 setBlockAndUpdate 方法
- 确保方块状态更新后能正确触发后续逻辑
- 保持原有的 tick 调度逻辑不变
- fixed #2610
- 新增 ChanceBlockState 组件以支持概率方块转换
- 修改矿物涌泉配方结构以兼容新的方块状态定义
- 更新矿物涌泉逻辑以处理带概率的方块转换
- 为矿物涌泉概率配方添加服务端检查
- 调整配方序列化方式以提高数据一致性