### PR TITLE
Prevent client-side execution of placement checks by adding block state transition logic when entities teleport through portals 防止客户端侧执行放置检查，添加实体穿越传送门时的方块状态转换逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/HeatCollectorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/HeatCollectorBlock.java
@@ -74,7 +74,9 @@ public class HeatCollectorBlock extends BaseEntityBlock implements IHammerRemova
 
     @Override
     public @Nullable BlockState getStateForPlacement(BlockPlaceContext context) {
-        HeatCollectorManager.checkWhenPlaceCollector(context, context.getClickedPos(), context.getLevel());
+        if (!context.getLevel().isClientSide()) {
+            HeatCollectorManager.checkWhenPlaceCollector(context, context.getClickedPos(), context.getLevel());
+        }
         return super.getStateForPlacement(context);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -8,9 +8,13 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IEntityExtension;
 import dev.dubhe.anvilcraft.block.entity.DeflectionRingBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.util.SpectralAnvilConversionUtil;
 import dev.dubhe.anvilcraft.util.Util;
 import it.unimi.dsi.fastutil.Pair;
 import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.Pose;
@@ -18,6 +22,8 @@ import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Portal;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
@@ -249,5 +255,29 @@ public abstract class EntityMixin implements IEntityExtension {
             )
         );
         NeoForge.EVENT_BUS.post(new AnvilEvent.CollisionBlock(level, blockPos, self, beforeBoundingMovement.get().length()));
+    }
+
+    @Inject(
+        method = "handlePortal",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/Entity;changeDimension("
+                     + "Lnet/minecraft/world/level/portal/DimensionTransition;"
+                     + ")Lnet/minecraft/world/entity/Entity;"
+        )
+    )
+    private void handlePortal(CallbackInfo ci) {
+        //noinspection ConstantValue
+        if (!(((Object) this) instanceof FallingBlockEntity fallingBlockEntity)) return;
+        if (!fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)) {
+            BlockState newState = ModBlocks.END_DUST.getDefaultState();
+            if (fallingBlockEntity.blockState.is(BlockTags.ANVIL)) {
+                double rand = this.level.random.nextDouble();
+                if (rand < SpectralAnvilConversionUtil.chance(fallingBlockEntity.blockState.getBlock())) {
+                    newState = ModBlocks.SPECTRAL_ANVIL.getDefaultState();
+                }
+            }
+            fallingBlockEntity.blockState = newState;
+        }
     }
 }


### PR DESCRIPTION
- fixed #2886
- 在放置热收集器时，确保仅在服务端执行检查逻辑
- 避免客户端不必要的状态验证调用
- 提高方块放置时的性能与稳定性
- fixed #2828
- 在 EntityMixin 中注入 handlePortal 方法，处理下落方块穿越传送门时的状态变化
- 新增对 ModBlockTags.END_PORTAL_UNABLE_CHANGE 标签的判断，阻止特定方块转换
- 当下落方块为铁砧类方块时，根据随机概率将其转换为幽灵铁砧
- 其他可转换的下落方块默认转换为末地尘方块
- 添加必要的导入语句以支持新增功能逻辑