### PR TITLE
Fix some bugs about sliding rails, pulse generator and advanced comparator. 修复一些关于滑轨，脉冲发生器和高级比较器的问题。

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/AdvancedComparatorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/AdvancedComparatorBlock.java
@@ -14,6 +14,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -233,7 +234,7 @@ public class AdvancedComparatorBlock extends HorizontalDirectionalBlock implemen
         Direction direction = state.getValue(AdvancedComparatorBlock.FACING).getOpposite();
         BlockPos neighbourPos = pos.relative(direction);
         boolean shouldPower = blockEntity.isOutputting();
-        int inputtingSignal = blockEntity.getInputtingSignal();
+        int inputtingSignal = Mth.clamp(blockEntity.getInputtingSignal(), 0, 15);
         Mode mode = blockEntity.getCompareMode();
         level.setBlockAndUpdate(pos,
             state.setValue(AdvancedComparatorBlock.POWERED, shouldPower)

--- a/src/main/java/dev/dubhe/anvilcraft/block/PulseGeneratorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/PulseGeneratorBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -121,6 +122,9 @@ public class PulseGeneratorBlock extends HorizontalDirectionalBlock implements I
     @Override
     protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
         if (!state.is(newState.getBlock())) {
+            if (level instanceof ServerLevel serverLevel) {
+                serverLevel.getBlockTicks().clearArea(new BoundingBox(pos));
+            }
             super.onRemove(state, level, pos, newState, false);
         }
         Direction facing = state.getValue(FACING);

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/AdvancedComparatorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/AdvancedComparatorBlockEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.util.Mth;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
@@ -138,7 +139,8 @@ public class AdvancedComparatorBlockEntity extends BlockEntity implements MenuPr
     }
 
     public void updateInputtingSignal(Level level, BlockPos pos, BlockState state) {
-        this.inputtingSignal = AdvancedComparatorBlock.getInputSignal(level, pos, state);
+        int signal = AdvancedComparatorBlock.getInputSignal(level, pos, state);
+        this.inputtingSignal = Mth.clamp(signal, 0, 15);
         if (this.isRedstoneControl()) {
             this.highLimit = AdvancedComparatorBlock.getAlternateSignal(level, pos, state, true);
             this.lowLimit = AdvancedComparatorBlock.getAlternateSignal(level, pos, state, false);

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
@@ -115,7 +115,14 @@ public class ActivatorSlidingRailBlock extends BaseSlidingRailBlock implements I
         if (!(state.getBlock() instanceof ActivatorSlidingRailBlock other)) return false;
         Direction otherFacing = state.getValue(FACING);
         if (facing.getAxis() != otherFacing.getAxis()) return false;
-        return level.hasNeighborSignal(pos)
+        boolean hasSideSignal = false;
+        for (Direction d : SIGNAL_SOURCE_SIDES) {
+            if (level.hasSignal(pos.relative(d), d)) {
+                hasSideSignal = true;
+                break;
+            }
+        }
+        return hasSideSignal
                || other.findActivatorSlidingRailSignal(level, pos, state, searchForward, recursionCount + 1);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
@@ -98,7 +98,7 @@ public class DetectorSlidingRailBlock extends BaseSlidingRailBlock implements IH
         if (
             state.getValue(POWERED)
             && level.getEntitiesOfClass(SlidingBlockEntity.class, new AABB(pos.above())).isEmpty()
-            && level.getEntitiesOfClass(ItemEntity.class, new AABB(pos.above())).isEmpty()
+            && level.getEntitiesOfClass(ItemEntity.class, new AABB(pos)).isEmpty()
         ) {
             level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_ALL);
             level.getBlockEntity(pos, ModBlockEntities.DETECTOR_SLIDING_RAIL.get()).ifPresent(DetectorSlidingRailBlockEntity::cleanPower);

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
@@ -111,7 +111,14 @@ public class PoweredSlidingRailBlock extends BaseSlidingRailBlock implements IHa
         if (!(state.getBlock() instanceof PoweredSlidingRailBlock other)) return false;
         Direction otherFacing = state.getValue(FACING);
         if (facing != otherFacing) return false;
-        return level.hasNeighborSignal(pos)
+        boolean hasSideSignal = false;
+        for (Direction d : SIGNAL_SOURCE_SIDES) {
+            if (level.hasSignal(pos.relative(d), d)) {
+                hasSideSignal = true;
+                break;
+            }
+        }
+        return hasSideSignal
                || other.findPoweredSlidingRailSignal(level, pos, state, searchForward, recursionCount + 1);
     }
 
@@ -204,13 +211,15 @@ public class PoweredSlidingRailBlock extends BaseSlidingRailBlock implements IHa
     @Override
     public void stepOn(Level level, BlockPos pos, BlockState state, Entity entity) {
         if (entity.getType() != EntityType.ITEM && !(entity instanceof LivingEntity)) return;
+        boolean isSneakPlayer = entity instanceof Player player && player.isShiftKeyDown();
         if (!state.getValue(POWERED)) {
-            ISlidingRail.absorbEntity(pos, entity);
-        } else {
-            if (entity instanceof Player player && player.isCrouching()) {
-                return;
+            if (!isSneakPlayer) {
+                ISlidingRail.absorbEntity(pos, entity);
             }
-            entity.setDeltaMovement(Vec3.ZERO.relative(state.getValue(FACING), 0.35));
+        } else {
+            if (!isSneakPlayer) {
+                entity.setDeltaMovement(Vec3.ZERO.relative(state.getValue(FACING), 0.35));
+            }
         }
     }
 


### PR DESCRIPTION
- 使动力滑轨和激活滑轨找寻信号时不再接受上方信号
- 修正探测滑轨熄灭时查找掉落物实体的范围
- 使动力滑轨上的玩家只有在主动潜行时才不会被吸引或加速
- 使高级比较器只能接收0-15范围内的信号
- 使脉冲发生器被移除时清除该格所有方块计划刻
- fixed #2851
- fixed #2827
- fixed #2709