### PR TITLE
Fix bugs of pressure plate 修复压力板的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/plate/TimeCountedPressurePlateBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/plate/TimeCountedPressurePlateBlockEntity.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block.entity.plate;
 
+import dev.dubhe.anvilcraft.block.plate.TimeCountedPressurePlateBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
@@ -11,7 +12,6 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.phys.AABB;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -28,19 +28,19 @@ public class TimeCountedPressurePlateBlockEntity extends BlockEntity {
         this(ModBlockEntities.TIME_COUNTED_PRESSURE_PLATE.get(), pos, blockState, needTick);
     }
 
-    public static @NotNull TimeCountedPressurePlateBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
+    public static TimeCountedPressurePlateBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         return new TimeCountedPressurePlateBlockEntity(type, pos, blockState, 10);
     }
 
     @Override
-    protected void saveAdditional(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
+    protected void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.saveAdditional(tag, registries);
         tag.putInt("tick", this.tick);
         tag.putInt("NeedTick", this.needTick);
     }
 
     @Override
-    protected void loadAdditional(@NotNull CompoundTag tag, HolderLookup.@NotNull Provider registries) {
+    protected void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.loadAdditional(tag, registries);
         this.tick = tag.getInt("tick");
         this.needTick = tag.getInt("NeedTick");
@@ -50,9 +50,17 @@ public class TimeCountedPressurePlateBlockEntity extends BlockEntity {
         return Math.clamp(tick / (needTick == 0 ? 1 : needTick), 0, 15);
     }
 
-    public void tick(@NotNull Level level, BlockPos pos) {
-        List<LivingEntity> entities = level.getEntities(EntityTypeTest.forClass(LivingEntity.class), new AABB(pos), entity -> true);
-        if (!entities.isEmpty()) tick++;
-        else if (tick > 0) tick--;
+    public void tick(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        if (state.getBlock() instanceof TimeCountedPressurePlateBlock plate) {
+            List<LivingEntity> entities = level.getEntities(EntityTypeTest.forClass(LivingEntity.class), new AABB(pos), entity -> true);
+            if (!entities.isEmpty()) {
+                if (tick < plate.needTick * 15) {
+                    tick++;
+                }
+            } else if (tick > 0) {
+                tick--;
+            }
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -4613,7 +4613,6 @@ public class ModBlocks {
         "bronze",
         BRONZE_BLOCK,
         PlayerHungerPressurePlateBlock::new,
-
         ModItemTags.BRONZE_INGOTS
     );
 

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -187,7 +187,6 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.ColorRGBA;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -4604,17 +4603,18 @@ public class ModBlocks {
         PlayerInHandItemDurabilityPressurePlateBlock::new,
         ModItemTags.PLUTONIUM_INGOTS
     );
-    public static final BlockEntry<? extends PowerLevelPressurePlateBlock> BRONZE_PRESSURE_PLATE = registerPressurePlate(
-        "bronze",
-        BRONZE_BLOCK,
-        PlayerInventoryPressurePlateBlock::new,
-        ModItemTags.BRONZE_INGOTS
-    );
     public static final BlockEntry<? extends PowerLevelPressurePlateBlock> BRASS_PRESSURE_PLATE = registerPressurePlate(
         "brass",
         BRASS_BLOCK,
-        PlayerHungerPressurePlateBlock::new,
+        PlayerInventoryPressurePlateBlock::new,
         ModItemTags.BRASS_INGOTS
+    );
+    public static final BlockEntry<? extends PowerLevelPressurePlateBlock> BRONZE_PRESSURE_PLATE = registerPressurePlate(
+        "bronze",
+        BRONZE_BLOCK,
+        PlayerHungerPressurePlateBlock::new,
+
+        ModItemTags.BRONZE_INGOTS
     );
 
     public static void register() {


### PR DESCRIPTION
- 调整青铜和黄铜压力板的注册顺序
- 更改黄铜压力板继承自PlayerInventoryPressurePlateBlock
- 移除TimeCountedPressurePlateBlockEntity中不必要的NotNull注解
- 修复TimeCountedPressurePlateBlockEntity的tick方法逻辑，确保实体检测和计数正确
- 优化时间计数压力板实体的保存和加载方法参数类型
- 更新createBlockEntity方法的返回类型，移除不必要的NotNull注解
- Fixed #2922 