### PR TITLE
Fix bugs of overseer, pulse generator and spectral anvil. 修复监督者，脉冲发生器和幻灵铁砧的一些问题。

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/world/load/LoadChuckData.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/world/load/LoadChuckData.java
@@ -49,8 +49,8 @@ public class LoadChuckData {
     ) {
         List<ChunkPos> chunkPosList = new ArrayList<>();
         ChunkPos centerChunkPos = new ChunkPos(centerPos);
-        for (int x = centerChunkPos.x - level; x < centerChunkPos.x + level; x++) {
-            for (int z = centerChunkPos.z - level; z < centerChunkPos.z + level; z++) {
+        for (int x = centerChunkPos.x - level; x <= centerChunkPos.x + level; x++) {
+            for (int z = centerChunkPos.z - level; z <= centerChunkPos.z + level; z++) {
                 chunkPosList.add(new ChunkPos(x, z));
             }
         }

--- a/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
@@ -131,7 +131,7 @@ public class SpectralAnvilBlock extends Block implements IHammerRemovable {
         ).isEmpty()) {
             FallingSpectralBlockEntity.fall(
                 level,
-                pos.above(),
+                pos,
                 level.getBlockState(pos).setValue(POWERED, false),
                 false,
                 true

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/OverseerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/OverseerBlockEntity.java
@@ -58,12 +58,12 @@ public class OverseerBlockEntity extends BlockEntity {
             boolean newRandomTick = this.waterLoggedBlockCount >= 4;
             if (newlevel == oldlevel && newRandomTick == oldRandomTick) {
                 return;
-            };
-            if (oldlevel >-1 || LevelLoadManager.checkRegistered(pos)) {
+            }
+            if (oldlevel > -1 || LevelLoadManager.checkRegistered(pos)) {
                 LevelLoadManager.unregister(pos, level);
                 oldlevel = -1;
                 oldRandomTick = false;
-            };
+            }
             if (newlevel >=0) {
                 LevelLoadManager.register(
                     pos,

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/OverseerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/OverseerBlockEntity.java
@@ -18,6 +18,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class OverseerBlockEntity extends BlockEntity {
     private int waterLoggedBlockCount = 0;
+    private int oldlevel = -1;
+    private boolean oldRandomTick = false;
 
     public OverseerBlockEntity(BlockPos pos, BlockState blockState) {
         this(ModBlockEntities.OVERSEER.get(), pos, blockState);
@@ -52,17 +54,28 @@ public class OverseerBlockEntity extends BlockEntity {
                 }
                 return;
             }
-            BlockState updatedState = level.getBlockState(pos);
-            if (!LevelLoadManager.checkRegistered(pos)) {
+            int newlevel = checkBaseSupportsLevel(level, pos);
+            boolean newRandomTick = this.waterLoggedBlockCount >= 4;
+            if (newlevel == oldlevel && newRandomTick == oldRandomTick) {
+                return;
+            };
+            if (oldlevel >-1 || LevelLoadManager.checkRegistered(pos)) {
+                LevelLoadManager.unregister(pos, level);
+                oldlevel = -1;
+                oldRandomTick = false;
+            };
+            if (newlevel >=0) {
                 LevelLoadManager.register(
                     pos,
                     LoadChuckData.createLoadChuckData(
-                        updatedState.getValue(OverseerBlock.LEVEL),
+                        newlevel,
                         pos,
                         (this.waterLoggedBlockCount >= 4),
                         serverLevel),
                     serverLevel);
             }
+            oldlevel = newlevel;
+            oldRandomTick = newRandomTick;
         }
     }
 
@@ -75,7 +88,8 @@ public class OverseerBlockEntity extends BlockEntity {
                 if (!currentState.is(ModBlockTags.OVERSEER_BASE)) {
                     return -1;
                 }
-                if (currentState.hasProperty(BlockStateProperties.WATERLOGGED)) {
+                if (currentState.hasProperty(BlockStateProperties.WATERLOGGED)
+                    && currentState.getValue(BlockStateProperties.WATERLOGGED)) {
                     waterLogged++;
                 }
             }
@@ -86,27 +100,13 @@ public class OverseerBlockEntity extends BlockEntity {
     private int checkBaseSupportsLevel(Level level, BlockPos selfPos) {
         int supportLevel = 0;
         int waterLoggedBlockCount = 0;
-        BlockPos.MutableBlockPos pos = selfPos.mutable();
-        pos.move(Direction.DOWN);
-        int tBase = checkBaseAt(level, pos);
-        if (tBase == -1) {
-            return 0;
-        }
-        waterLoggedBlockCount += tBase;
-        supportLevel++;
-
-        pos.move(Direction.DOWN);
-        tBase = checkBaseAt(level, pos);
-        if (tBase != -1) {
+        BlockPos.MutableBlockPos pos = selfPos.mutable().move(Direction.DOWN);
+        for (int i = 0; i < 3; i++) {
+            int tBase = checkBaseAt(level, pos);
+            if (tBase == -1) break;
             waterLoggedBlockCount += tBase;
             supportLevel++;
-        }
-
-        pos.move(Direction.DOWN);
-        tBase = checkBaseAt(level, pos);
-        if (tBase != -1) {
-            waterLoggedBlockCount += tBase;
-            supportLevel++;
+            pos.move(Direction.DOWN);
         }
         this.waterLoggedBlockCount = waterLoggedBlockCount;
         return supportLevel;
@@ -120,10 +120,10 @@ public class OverseerBlockEntity extends BlockEntity {
             BlockPos pos = getBlockPos().relative(Direction.Axis.Y, i);
             BlockState state = level.getBlockState(pos);
             if (level.getBlockState(pos).is(ModBlocks.OVERSEER_BLOCK)) {
-                level.setBlockAndUpdate(pos, state.setValue(OverseerBlock.LEVEL, supportsLevel));
+                level.setBlock(pos, state.setValue(OverseerBlock.LEVEL, supportsLevel),2);
             }
         }
-        return supportsLevel > 0;
+        return supportsLevel >= 0;
     }
 
     private boolean checkBlocks() {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/OverseerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/OverseerBlockEntity.java
@@ -64,7 +64,7 @@ public class OverseerBlockEntity extends BlockEntity {
                 oldlevel = -1;
                 oldRandomTick = false;
             }
-            if (newlevel >=0) {
+            if (newlevel >= 0) {
                 LevelLoadManager.register(
                     pos,
                     LoadChuckData.createLoadChuckData(
@@ -120,7 +120,7 @@ public class OverseerBlockEntity extends BlockEntity {
             BlockPos pos = getBlockPos().relative(Direction.Axis.Y, i);
             BlockState state = level.getBlockState(pos);
             if (level.getBlockState(pos).is(ModBlocks.OVERSEER_BLOCK)) {
-                level.setBlock(pos, state.setValue(OverseerBlock.LEVEL, supportsLevel),2);
+                level.setBlock(pos, state.setValue(OverseerBlock.LEVEL, supportsLevel), 2);
             }
         }
         return supportsLevel >= 0;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/PulseGeneratorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/PulseGeneratorBlockEntity.java
@@ -105,6 +105,7 @@ public class PulseGeneratorBlockEntity extends BlockEntity implements MenuProvid
         CompoundTag data = new CompoundTag();
         data.putByte("StartMode", this.startMode.index());
         data.putBoolean("OutputMode", this.outputInvert);
+        data.putBoolean("Inputting", this.isInputtingSignal);
         data.putInt("WaitingTime", this.waitingTime);
         data.putInt("SignalDuration", this.signalDuration);
         return data;
@@ -113,6 +114,7 @@ public class PulseGeneratorBlockEntity extends BlockEntity implements MenuProvid
     public PulseGeneratorBlockEntity readDataNbt(CompoundTag data) {
         this.startMode = Mode.fromIndex(data.getByte("StartMode"));
         this.outputInvert = data.getBoolean("OutputMode");
+        this.isInputtingSignal = data.getBoolean("Inputting");
         this.waitingTime = data.getInt("WaitingTime");
         this.signalDuration = data.getInt("SignalDuration");
         return this;
@@ -135,7 +137,9 @@ public class PulseGeneratorBlockEntity extends BlockEntity implements MenuProvid
 
     public void setStartMode(int mode) {
         this.startMode = Mode.fromIndex(mode % 3);
-        if (this.startMode.equals(Mode.LOOP) && !this.isInputtingSignal && this.level != null) {
+        if (this.startMode != Mode.LOOP) {
+            this.isDeadlock = false;
+        } else if (!this.isInputtingSignal && this.level != null) {
             Util.castSafely(this.getBlockState().getBlock(), PulseGeneratorBlock.class)
                 .ifPresent(block -> block.update(this.level, this.getBlockPos(), this::getBlockState));
         }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/FallingSpectralBlockEntity.java
@@ -299,7 +299,7 @@ public class FallingSpectralBlockEntity extends FallingBlockEntity {
         FallingSpectralBlockEntity fallingBlockEntity = new FallingSpectralBlockEntity(
             level,
             (double) pos.getX() + 0.5,
-            (double) pos.getY() - 0.96,
+            pos.getY(),
             (double) pos.getZ() + 0.5,
             blockState.hasProperty(BlockStateProperties.WATERLOGGED)
                 ? blockState.setValue(BlockStateProperties.WATERLOGGED, false)

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -269,6 +269,10 @@ public abstract class EntityMixin implements IEntityExtension {
     private void handlePortal(CallbackInfo ci) {
         //noinspection ConstantValue
         if (!(((Object) this) instanceof FallingBlockEntity fallingBlockEntity)) return;
+        if (fallingBlockEntity.anvilcraft$isSpectral()) {
+            fallingBlockEntity.discard();
+            return;
+        }
         if (!fallingBlockEntity.blockState.is(ModBlockTags.END_PORTAL_UNABLE_CHANGE)) {
             BlockState newState = ModBlocks.END_DUST.getDefaultState();
             if (fallingBlockEntity.blockState.is(BlockTags.ANVIL)) {

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -22,7 +22,6 @@
     "DispenserBlockMixin",
     "EnchantmentHelperMixin",
     "EnchantmentPredicateMixin",
-    "EndPortalBlockMixin",
     "EntityMixin",
     "EntityTypeBuilderMixin",
     "ExplosionMixin",


### PR DESCRIPTION
- 修正了监督者的加载范围，现在和todo里一致了。
- 现在变更底座层数会同步改变加载范围。
- 现在底座必须连续。
- 现在改变层数时监督者方块不会发出nc更新。
- 修复进入世界时，下降沿脉冲发生器在不被更新的情况下第一次无响应的问题。
- 修复在有信号输入的情况下直接切出循环模式导致的死锁问题。
- 同步了幻灵铁砧实体和普通铁砧实体的生成位置。
- 取消加载功能冲突的EndPortalBlockMixin
- fix #2927 
- fix #2854 