### PR TITLE
Add the Broken Crystals type for breaking amethyst clusters 添加碎晶撼地破坏类型用于破坏紫水晶簇

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/DestroyType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/DestroyType.java
@@ -1,14 +1,15 @@
 package dev.dubhe.anvilcraft.event.giantanvil.shock;
 
+import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.AmethystClusterBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CaveVinesPlantBlock;
@@ -97,10 +98,7 @@ enum DestroyType {
                                 DestroyType.dropItems(itemStack, it, level);
                                 return true;
                             }
-                            if (blockState.is(BlockTags.JUNGLE_LOGS)) {
-                                return true;
-                            }
-                            return false;
+                            return blockState.is(BlockTags.JUNGLE_LOGS);
                         }
                     );
                 }
@@ -205,6 +203,21 @@ enum DestroyType {
                 level.destroyBlock(pos, false);
             }
         }
+    }, BROKEN_CRYSTALS {
+        @Override
+        void accept(ShockContext context, List<BlockPos> list, DestroyMode mode) {
+            Level level = context.level();
+            for (BlockPos blockPos : list) {
+                BlockState blockState = level.getBlockState(blockPos);
+                AnvilCraft.LOGGER.debug("block: {}", blockState.getBlock());
+                if (blockState.isAir() || !(blockState.getBlock() instanceof AmethystClusterBlock)) {
+                    continue;
+                }
+                level.destroyBlock(blockPos, false);
+                List<ItemStack> dropItems = mode.apply(blockState, blockPos, context);
+                DestroyType.dropItems(dropItems, blockPos, level);
+            }
+        }
     };
 
     public static final int TRAVERSE_DEPTH = 64;
@@ -214,8 +227,7 @@ enum DestroyType {
 
     private static void dropItems(List<ItemStack> itemStacks, BlockPos pos, Level level) {
         for (ItemStack itemStack : itemStacks) {
-            ItemEntity itemEntity = new ItemEntity(level, pos.getX(), pos.getY(), pos.getZ(), itemStack);
-            level.addFreshEntity(itemEntity);
+            Block.popResource(level, pos, itemStack);
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/GiantAnvilShockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/GiantAnvilShockEventListener.java
@@ -21,7 +21,6 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -77,7 +76,10 @@ public class GiantAnvilShockEventListener {
                     ).executes(it -> it.putAttachment(DESTROY_TYPE, DestroyType.CLEANING)),
                     TreeNode.<ShockContext>predicatedExecutable(it ->
                         it.unwrap().testCorner(Blocks.OBSIDIAN)
-                    ).executes(it -> it.putAttachment(DESTROY_TYPE, DestroyType.GENERAL))
+                    ).executes(it -> it.putAttachment(DESTROY_TYPE, DestroyType.GENERAL)),
+                    TreeNode.<ShockContext>predicatedExecutable(it ->
+                        it.unwrap().testCorner(Blocks.AMETHYST_BLOCK)
+                    ).executes(it -> it.putAttachment(DESTROY_TYPE, DestroyType.BROKEN_CRYSTALS))
                 )
             )
         ).then(
@@ -149,7 +151,7 @@ public class GiantAnvilShockEventListener {
     }
 
     @SubscribeEvent
-    public static void onLand(@NotNull AnvilEvent.GiantOnLand event) {
+    public static void onLand(AnvilEvent.GiantOnLand event) {
         ShockContext context = ShockContext.inflate(event);
         behaviorTree.run(context);
     }


### PR DESCRIPTION
- 新增 BROKEN_CRYSTALS 破坏类型，用于处理紫水晶簇方块的破坏逻辑
- 实现对紫水晶簇方块的识别与销毁功能
- 优化物品掉落方法，使用 Block.popResource 替代手动创建物品实体
- 添加对 AmethystClusterBlock 类型方块的判断与处理
- 更新 GiantAnvilShockEventListener 中的执行条件，增加对紫水晶块的检测分支
- Resolved #2962 