### PR TITLE
Add Gravity System 添加重力系统

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -224,6 +224,7 @@
   "block.anvilcraft.black_chocolate_block": "ǝʇɐןoɔoɥƆ ʞɔɐןᗺ ɟo ʞɔoןᗺ",
   "block.anvilcraft.black_chocolate_slab": "qɐןS ǝʇɐןoɔoɥƆ ʞɔɐןᗺ",
   "block.anvilcraft.black_chocolate_stairs": "sɹıɐʇS ǝʇɐןoɔoɥƆ ʞɔɐןᗺ",
+  "block.anvilcraft.black_hole": "ǝןoH ʞɔɐןᗺ",
   "block.anvilcraft.block_comparator": "ɹoʇɐɹɐdɯoƆ ʞɔoןᗺ",
   "block.anvilcraft.block_devourer": "ɹǝɹnoʌǝᗡ ʞɔoןᗺ",
   "block.anvilcraft.block_placer": "ɹǝɔɐןԀ ʞɔoןᗺ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -224,6 +224,7 @@
   "block.anvilcraft.black_chocolate_block": "Block of Black Chocolate",
   "block.anvilcraft.black_chocolate_slab": "Black Chocolate Slab",
   "block.anvilcraft.black_chocolate_stairs": "Black Chocolate Stairs",
+  "block.anvilcraft.black_hole": "Black Hole",
   "block.anvilcraft.block_comparator": "Block Comparator",
   "block.anvilcraft.block_devourer": "Block Devourer",
   "block.anvilcraft.block_placer": "Block Placer",

--- a/src/generated/resources/assets/anvilcraft/models/item/black_hole.json
+++ b/src/generated/resources/assets/anvilcraft/models/item/black_hole.json
@@ -1,0 +1,3 @@
+{
+  "parent": "anvilcraft:block/black_hole"
+}

--- a/src/generated/resources/data/anvilcraft/loot_table/blocks/black_hole.json
+++ b/src/generated/resources/data/anvilcraft/loot_table/blocks/black_hole.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "anvilcraft:black_hole"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "anvilcraft:blocks/black_hole"
+}

--- a/src/generated/resources/data/anvilcraft/recipe/neutron_irradiator.json
+++ b/src/generated/resources/data/anvilcraft/recipe/neutron_irradiator.json
@@ -6,7 +6,7 @@
       "item": "anvilcraft:negative_matter_block"
     },
     "I": {
-      "item": "anvilcraft:neutronium_ingot"
+      "tag": "anvilcraft:uncharged_neutronium_ingots"
     },
     "N": {
       "item": "anvilcraft:negative_matter"

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlackHoleBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlackHoleBlock.java
@@ -45,4 +45,9 @@ public class BlackHoleBlock extends Block implements EntityBlock {
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new BlackHoleBlockEntity(pos, state);
     }
+    
+    @Override
+    public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
+        return 15;
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlackHoleBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlackHoleBlock.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.block;
 
-import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
-import dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity;
+import dev.dubhe.anvilcraft.block.entity.BlackHoleBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -10,19 +9,11 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
-public class NeutronIrradiatorBlock extends Block implements IHammerRemovable, EntityBlock {
-    public static VoxelShape MODEL = Shapes.or(
-        Block.box(0, 0, 0, 16, 10, 16),
-        Block.box(13, 10, 0, 16, 12, 3),
-        Block.box(0, 10, 0, 3, 12, 3),
-        Block.box(0, 10, 13, 3, 12, 16),
-        Block.box(13, 10, 13, 16, 12, 16),
-        Block.box(4, 10, 4, 12, 16, 12)
-    );
+public class BlackHoleBlock extends Block implements EntityBlock {
+    public static final VoxelShape MODEL = Block.box(4, 4, 4, 12, 12, 12);
 
     @Override
     public VoxelShape getShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext) {
@@ -45,13 +36,13 @@ public class NeutronIrradiatorBlock extends Block implements IHammerRemovable, E
     ) {
     }
 
-    public NeutronIrradiatorBlock(Properties properties) {
+    public BlackHoleBlock(Properties properties) {
         super(properties);
     }
 
     @Nullable
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        return new NeutronIrradiatorBlockEntity(pos, state);
+        return new BlackHoleBlockEntity(pos, state);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlackHoleBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlackHoleBlock.java
@@ -45,9 +45,4 @@ public class BlackHoleBlock extends Block implements EntityBlock {
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new BlackHoleBlockEntity(pos, state);
     }
-    
-    @Override
-    public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
-        return 15;
-    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/LevitationPowderBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/LevitationPowderBlock.java
@@ -1,46 +1,48 @@
 package dev.dubhe.anvilcraft.block;
 
+import com.mojang.serialization.MapCodec;
 import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
-public class LevitationPowderBlock extends Block {
+public class LevitationPowderBlock extends FallingBlock {
     public LevitationPowderBlock(Properties properties) {
         super(properties);
     }
 
     @Override
-    protected void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+    protected MapCodec<? extends FallingBlock> codec() {
+        return null;
+    }
+
+    @Override
+protected void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        super.tick(state, level, pos, random);
+        // 和上方重力方块交换位置
         BlockState above = level.getBlockState(pos.above());
-        // noinspection deprecation
-        if (above.getBlock() instanceof FallingBlock || above.isAir() || above.liquid()) {
+        if (above.getBlock() instanceof FallingBlock && !(above.getBlock() instanceof LevitationPowderBlock)) {
+            if (above.getBlock() instanceof Fallable) {
+                FallingBlockEntity.fall(level, pos.above(), above);
+            }
             LevitatingBlockEntity.levitate(level, pos, state);
         }
     }
 
     @Override
     protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
-        level.scheduleTick(pos, this, this.getDelayAfterPlace());
+        level.scheduleTick(pos, this, 2);
     }
 
     @Override
     protected void neighborChanged(
-        BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos,
-        boolean movedByPiston
-    ) {
-        BlockState above = level.getBlockState(pos.above());
-        // noinspection deprecation
-        if (above.getBlock() instanceof FallingBlock || above.isAir() || above.liquid()) {
-            level.scheduleTick(pos, this, this.getDelayAfterPlace());
-        }
-    }
-
-    protected int getDelayAfterPlace() {
-        return 2;
+        BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
+        level.scheduleTick(pos, this, 2);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -320,7 +321,8 @@ public abstract class BaseChuteBlockEntity
      * 收到包 -> 读取NBT -> 覆盖本地数据
      */
     @Override
-    public void onDataPacket(net.minecraft.network.Connection net,
+    public void onDataPacket(
+        Connection net,
         ClientboundBlockEntityDataPacket pkt,
         HolderLookup.Provider lookupProvider
     ) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
@@ -11,7 +11,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -161,7 +160,7 @@ public abstract class BaseChuteBlockEntity
                                 }
                                 if (sameItemCount < slotLimit) {
                                     ItemStack droppedItemStack = stack.copy();
-                                    int droppedItemCount = 
+                                    int droppedItemCount =
                                         Math.min(stack.getCount(), slotLimit - sameItemCount);
                                     droppedItemStack.setCount(droppedItemCount);
                                     stack.setCount(stack.getCount() - droppedItemCount);
@@ -321,7 +320,10 @@ public abstract class BaseChuteBlockEntity
      * 收到包 -> 读取NBT -> 覆盖本地数据
      */
     @Override
-    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt, HolderLookup.Provider lookupProvider) {
+    public void onDataPacket(net.minecraft.network.Connection net,
+        ClientboundBlockEntityDataPacket pkt,
+        HolderLookup.Provider lookupProvider
+    ) {
         CompoundTag tag = pkt.getTag();
         this.loadAdditional(tag, lookupProvider);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
@@ -11,7 +11,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -321,8 +320,7 @@ public abstract class BaseChuteBlockEntity
      * 收到包 -> 读取NBT -> 覆盖本地数据
      */
     @Override
-    public void onDataPacket(
-        Connection net,
+    public void onDataPacket(net.minecraft.network.Connection net,
         ClientboundBlockEntityDataPacket pkt,
         HolderLookup.Provider lookupProvider
     ) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BlackHoleBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BlackHoleBlockEntity.java
@@ -1,0 +1,17 @@
+package dev.dubhe.anvilcraft.block.entity;
+
+import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class BlackHoleBlockEntity extends BlockEntity {
+    public BlackHoleBlockEntity(BlockPos pos, BlockState blockState) {
+        super(ModBlockEntities.BLACK_HOLE.get(), pos, blockState);
+    }
+
+    public static BlackHoleBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
+        return new BlackHoleBlockEntity(pos, blockState);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.block.entity;
 
 import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
-import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
@@ -9,6 +8,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -21,31 +21,27 @@ public class NeutronIrradiatorBlockEntity extends BlockEntity {
         super(ModBlockEntities.NEUTRON_IRRADIATOR.get(), pos, blockState);
     }
 
-    //    public static void tick(Level level, BlockPos pos, BlockState state, NeutronIrradiatorBlockEntity blockEntity) {
-    //        if (level.getGameTime() % 2 != 0) return;
-    //        // 定义检测范围 - 中子辐照器自身及上方7格范围
-    //        AABB detectionArea = new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + RANGE + 1, pos.getZ() + 1);
-    //        // 获取范围内的所有实体
-    //        level.getEntitiesOfClass(
-    //            Entity.class,
-    //            detectionArea,
-    //            entity -> entity instanceof ItemEntity || entity instanceof FallingBlockEntity || entity instanceof LivingEntity
-    //        ).forEach(entity -> {
-    //            if (entity instanceof FallingBlockEntity) { // 特殊处理下落方块瞬间落地
-    //                double distanceToIrradiator = entity.getY() - (pos.getY() + 0.9);
-    //                entity.setDeltaMovement(entity.getDeltaMovement().x, -7, entity.getDeltaMovement().z);
-    //                // 距离10倍增加fallDistance
-    //                entity.fallDistance += 10 * Math.abs(distanceToIrradiator);
-    //            } else if (entity instanceof LevitatingBlockEntity) { // 特殊处理漂浮粉块实体，增加重力速度到3倍
-    //                entity.setDeltaMovement(entity.getDeltaMovement().x, entity.getDeltaMovement().y * 3, entity.getDeltaMovement().z);
-    //            } else if (entity.getDeltaMovement().y < 0) { // 增加其他实体重力速度到3倍，fallDistance也3倍
-    //                entity.setDeltaMovement(entity.getDeltaMovement().x, entity.getDeltaMovement().y * 3, entity.getDeltaMovement().z);
-    //                entity.fallDistance *= 3;
-    //            } else if (entity.getDeltaMovement().y > 0) { // 上升的实体更快的减速
-    //                entity.setDeltaMovement(entity.getDeltaMovement().x, entity.getDeltaMovement().y / 3, entity.getDeltaMovement().z);
-    //            }
-    //        });
-    //    }
+    public static void tick(Level level, BlockPos pos, BlockState state, NeutronIrradiatorBlockEntity blockEntity) {
+        if (level.getGameTime() % 2 != 0) return;
+
+        // 定义检测范围 - 中子辐照器自身及上方7格范围
+        AABB detectionArea = new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + RANGE + 1, pos.getZ() + 1);
+        // 获取范围内的所有实体
+        level.getEntitiesOfClass(
+            Entity.class,
+            detectionArea,
+            entity -> entity instanceof ItemEntity || entity instanceof FallingBlockEntity || entity instanceof LivingEntity
+        ).forEach(entity -> {
+            // 铁砧瞬间落地且10倍fallDistance
+            if (entity instanceof FallingBlockEntity fallingBlock) {
+                if (fallingBlock.getBlockState().getBlock() instanceof AnvilBlock) {
+                    double distanceToIrradiator = entity.getY() - (pos.getY() + 0.9);
+                    entity.setDeltaMovement(entity.getDeltaMovement().x, -7, entity.getDeltaMovement().z);
+                    entity.fallDistance += (float) (10 * Math.abs(distanceToIrradiator));
+                }
+            }
+        });
+    }
 
     public static NeutronIrradiatorBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         return new NeutronIrradiatorBlockEntity(pos, blockState);

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
@@ -1,7 +1,9 @@
 package dev.dubhe.anvilcraft.block.entity;
 
+import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -14,5 +16,14 @@ public class NeutronIrradiatorBlockEntity extends BlockEntity {
 
     public static NeutronIrradiatorBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         return new NeutronIrradiatorBlockEntity(pos, blockState);
+    }
+
+    public static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
+        for (int dy = 1; dy <= 7; dy++) {
+            if (level.getBlockState(pos.below(dy)).getBlock() instanceof NeutronIrradiatorBlock) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
@@ -1,9 +1,7 @@
 package dev.dubhe.anvilcraft.block.entity;
 
-import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -16,14 +14,5 @@ public class NeutronIrradiatorBlockEntity extends BlockEntity {
 
     public static NeutronIrradiatorBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         return new NeutronIrradiatorBlockEntity(pos, blockState);
-    }
-
-    public static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
-        for (int dy = 1; dy <= 7; dy++) {
-            if (level.getBlockState(pos.below(dy)).getBlock() instanceof NeutronIrradiatorBlock) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/NeutronIrradiatorBlockEntity.java
@@ -1,65 +1,18 @@
 package dev.dubhe.anvilcraft.block.entity;
 
-import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.AABB;
 
 public class NeutronIrradiatorBlockEntity extends BlockEntity {
-    public static final int RANGE = 7;
 
     public NeutronIrradiatorBlockEntity(BlockPos pos, BlockState blockState) {
         super(ModBlockEntities.NEUTRON_IRRADIATOR.get(), pos, blockState);
     }
 
-    public static void tick(Level level, BlockPos pos, BlockState state, NeutronIrradiatorBlockEntity blockEntity) {
-        if (level.getGameTime() % 2 != 0) return;
-
-        // 定义检测范围 - 中子辐照器自身及上方7格范围
-        AABB detectionArea = new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + RANGE + 1, pos.getZ() + 1);
-        // 获取范围内的所有实体
-        level.getEntitiesOfClass(
-            Entity.class,
-            detectionArea,
-            entity -> entity instanceof ItemEntity || entity instanceof FallingBlockEntity || entity instanceof LivingEntity
-        ).forEach(entity -> {
-            // 铁砧瞬间落地且10倍fallDistance
-            if (entity instanceof FallingBlockEntity fallingBlock) {
-                if (fallingBlock.getBlockState().getBlock() instanceof AnvilBlock) {
-                    double distanceToIrradiator = entity.getY() - (pos.getY() + 0.9);
-                    entity.setDeltaMovement(entity.getDeltaMovement().x, -7, entity.getDeltaMovement().z);
-                    entity.fallDistance += (float) (10 * Math.abs(distanceToIrradiator));
-                }
-            }
-        });
-    }
-
     public static NeutronIrradiatorBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         return new NeutronIrradiatorBlockEntity(pos, blockState);
-    }
-
-    public static boolean isInIrradiatorRange(Level level, BlockPos pos) {
-        // 检查下方最多7格内是否有中子辐照器
-        for (int i = 0; i <= RANGE; i++) {
-            BlockPos checkPos = pos.below(i);
-            BlockState blockState = level.getBlockState(checkPos);
-
-            if (blockState.getBlock() instanceof NeutronIrradiatorBlock) {
-                BlockEntity blockEntity = level.getBlockEntity(checkPos);
-                if (blockEntity != null && blockEntity.getType() == ModBlockEntities.NEUTRON_IRRADIATOR.get()) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/entity/CauldronOutletRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/entity/CauldronOutletRenderer.java
@@ -9,8 +9,15 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CauldronOutletRenderer extends EntityRenderer<CauldronOutletEntity> {
     private final CauldronOutletModel model;
@@ -31,6 +38,52 @@ public class CauldronOutletRenderer extends EntityRenderer<CauldronOutletEntity>
     ) {
         poseStack.pushPose();
 
+        // 视觉平滑移动处理
+        BlockPos currentPos = entity.getCauldronPos();
+        PistonMovingBlockEntity targetPiston = null;
+        BlockPos pistonPos = null;
+
+        // 搜索脚下和四周的活塞
+        List<BlockPos> searchPositions = new ArrayList<>();
+        searchPositions.add(currentPos);
+        for (Direction dir : Direction.values()) {
+            searchPositions.add(currentPos.relative(dir));
+        }
+
+        for (BlockPos pos : searchPositions) {
+            if (entity.level().getBlockState(pos).is(Blocks.MOVING_PISTON)) {
+                BlockEntity be = entity.level().getBlockEntity(pos);
+                if (be instanceof PistonMovingBlockEntity pbe) {
+                    // 计算这个活塞是从哪儿推过来的
+                    Direction moveDir = pbe.isExtending() ? pbe.getDirection() : pbe.getDirection().getOpposite();
+                    BlockPos origin = pos.relative(moveDir.getOpposite());
+
+                    // 如果来源位置就是我的脚下，那它就是我的锅
+                    if (origin.equals(currentPos)) {
+                        targetPiston = pbe;
+                        pistonPos = pos;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // 找到了关联活塞，进行视觉修正
+        if (targetPiston != null) {
+            // 获取平滑移动进度
+            float xOff = targetPiston.getXOff(partialTicks);
+            float yOff = targetPiston.getYOff(partialTicks);
+            float zOff = targetPiston.getZOff(partialTicks);
+
+            // 计算位移差值：目标位置 - 当前位置 + 动画偏移
+            double dx = (pistonPos.getX() - currentPos.getX()) + xOff;
+            double dy = (pistonPos.getY() - currentPos.getY()) + yOff;
+            double dz = (pistonPos.getZ() - currentPos.getZ()) + zOff;
+
+            poseStack.translate(dx, dy, dz);
+        }
+
+        // 不同方向的模型渲染
         Direction direction = entity.getAttachedDirection();
         switch (direction) {
             case DOWN -> {
@@ -54,9 +107,6 @@ public class CauldronOutletRenderer extends EntityRenderer<CauldronOutletEntity>
             case EAST -> {
                 poseStack.translate(0.0, 0.18375, 0.0);
                 poseStack.mulPose(Axis.ZP.rotationDegrees(-120));
-            }
-            default -> {
-                break;
             }
         }
         poseStack.scale(0.73f, 0.73f, 0.73f);

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/entity/CauldronOutletRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/entity/CauldronOutletRenderer.java
@@ -71,14 +71,14 @@ public class CauldronOutletRenderer extends EntityRenderer<CauldronOutletEntity>
         // 找到了关联活塞，进行视觉修正
         if (targetPiston != null) {
             // 获取平滑移动进度
-            float xOff = targetPiston.getXOff(partialTicks);
-            float yOff = targetPiston.getYOff(partialTicks);
-            float zOff = targetPiston.getZOff(partialTicks);
+            float xoff = targetPiston.getXOff(partialTicks);
+            float yoff = targetPiston.getYOff(partialTicks);
+            float zoff = targetPiston.getZOff(partialTicks);
 
             // 计算位移差值：目标位置 - 当前位置 + 动画偏移
-            double dx = (pistonPos.getX() - currentPos.getX()) + xOff;
-            double dy = (pistonPos.getY() - currentPos.getY()) + yOff;
-            double dz = (pistonPos.getZ() - currentPos.getZ()) + zOff;
+            double dx = (pistonPos.getX() - currentPos.getX()) + xoff;
+            double dy = (pistonPos.getY() - currentPos.getY()) + yoff;
+            double dz = (pistonPos.getZ() - currentPos.getZ()) + zoff;
 
             poseStack.translate(dx, dy, dz);
         }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
@@ -18,6 +18,9 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.phys.AABB;
@@ -42,6 +45,11 @@ public class CauldronOutletEntity extends Entity {
     private Direction attachedDirection = Direction.UP;
     private BlockState cauldronState;
 
+    // 标记是否处于活塞推动状态
+    private boolean wasMoving = false;
+    // 目标位置
+    private BlockPos targetPos = null;
+
     public CauldronOutletEntity(EntityType<?> entityType, Level level) {
         super(entityType, level);
         this.noPhysics = true;
@@ -65,11 +73,121 @@ public class CauldronOutletEntity extends Entity {
     @Override
     public void tick() {
         super.tick();
-        BlockState currentState = this.level().getBlockState(this.cauldronPos);
-        if (!this.level().isClientSide && !currentState.is(BlockTags.CAULDRONS)) {
-            this.kill();
-            return;
+
+        if (!this.level().isClientSide) {
+            BlockState currentState = this.level().getBlockState(this.cauldronPos);
+
+            // 0. 防止滑步
+            // 如果有目标位置，在到达之前不要进行新的检测，防止连环推时输出口滑过好几格
+            if (this.targetPos != null) {
+                BlockState targetState = this.level().getBlockState(this.targetPos);
+
+                // A：目标已经变成了炼药锅 -> 移动结束，落地
+                if (targetState.is(BlockTags.CAULDRONS)) {
+                    moveToBlock(this.targetPos, targetState);
+                    // 落地瞬间暂不处理物品
+                    return;
+                }
+                // B：目标还是移动活塞 -> 正在动画中，原地等待
+                else if (targetState.is(Blocks.MOVING_PISTON)) {
+                    // 保持 wasMoving 为 true，防止被误杀
+                    this.wasMoving = true;
+                    return;
+                }
+                // C：目标变成了空气或其他 -> 追踪丢失 ，进入下面的步骤 3 尝试找回
+                else {
+                    this.targetPos = null;
+                }
+            }
+
+            // 1. 主动移动检测
+            // 检查脚下的方块是不是变成了b36
+            if (currentState.is(Blocks.MOVING_PISTON)) {
+                BlockEntity be = this.level().getBlockEntity(this.cauldronPos);
+                if (be instanceof PistonMovingBlockEntity pistonBe) {
+                    Direction moveDir = getMovementDirection(pistonBe);
+
+                    if (pistonBe.isSourcePiston()) {
+                        // A：我是源头。炼药锅正在离我而去 -> 立即追过去
+                        BlockPos destPos = this.cauldronPos.relative(moveDir);
+                        manualMove(destPos);
+                        return;
+                    } else {
+                        // B：我是目的地。说明有方块正在推入这里 -> 检查是不是连环推
+                        BlockPos nextPos = this.cauldronPos.relative(moveDir);
+                        BlockState nextState = this.level().getBlockState(nextPos);
+
+                        boolean isChainPush = false;
+                        if (nextState.is(Blocks.MOVING_PISTON)) {
+                            BlockEntity nextBe = this.level().getBlockEntity(nextPos);
+                            // 检查链条一致性
+                            if (nextBe instanceof PistonMovingBlockEntity nextPistonBe && nextPistonBe.getMovedState()
+                                .is(BlockTags.CAULDRONS) && !nextPistonBe.isSourcePiston() && getMovementDirection(nextPistonBe).equals(
+                                moveDir)) {
+                                isChainPush = true;
+                            }
+                        }
+
+                        if (isChainPush) {
+                            // 确认是连环推 -> 移动到下一格
+                            manualMove(nextPos);
+                        } else {
+                            // 只是普通的被推入，原地等待变回实体
+                            this.wasMoving = true;
+                        }
+                        return;
+                    }
+                }
+                this.wasMoving = true;
+                return;
+            }
+
+            // 3. 扫描周围的方块
+            // 只有当没有锁定目标时才扫描
+            if (this.targetPos == null) {
+                boolean foundPullingPiston = false;
+                for (Direction dir : Direction.values()) {
+                    BlockPos neighborPos = this.cauldronPos.relative(dir);
+                    BlockState neighborState = this.level().getBlockState(neighborPos);
+
+                    if (neighborState.is(Blocks.MOVING_PISTON)) {
+                        BlockEntity be = this.level().getBlockEntity(neighborPos);
+                        if (be instanceof PistonMovingBlockEntity pistonBe && !pistonBe.isSourcePiston()) {
+                            Direction moveDir = getMovementDirection(pistonBe);
+                            BlockPos originPos = neighborPos.relative(moveDir.getOpposite());
+
+                            if (originPos.equals(this.cauldronPos)) {
+                                // 发现拉取 -> 锁定目标到邻居
+                                manualMove(neighborPos);
+                                foundPullingPiston = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (foundPullingPiston) return;
+            }
+
+            // 4. 确认状态
+            if (currentState.is(BlockTags.CAULDRONS)) {
+                // 安全：脚下是炼药锅
+                this.wasMoving = false;
+                this.targetPos = null;
+
+                if (currentState != this.cauldronState) {
+                    this.cauldronState = currentState;
+                }
+                // 继续执行物品逻辑
+            } else {
+                if (!this.wasMoving && this.targetPos == null) {
+                    // 如果不在移动状态且没有目标位置，则销毁实体
+                    this.kill();
+                }
+                return;
+            }
         }
+
+        // 物品输出逻辑
         AABB aabb = new AABB(
             cauldronPos.getX() - 0.01,
             cauldronPos.getY() - 0.01,
@@ -79,7 +197,6 @@ public class CauldronOutletEntity extends Entity {
             cauldronPos.getZ() + 1.01
         );
         level().getEntities(EntityType.ITEM, aabb, entity -> !entity.anvilcraft$isAdsorbable()).forEach(entity -> {
-            // 将物品从口的方向推出，先移动到口外一点，再给0.1动量
             Vec3 ejectPos = this.position()
                 .add(attachedDirection.getStepX() * 0.25, attachedDirection.getStepY() * 0.25, attachedDirection.getStepZ() * 0.25);
             Vec3 motion = new Vec3(
@@ -89,13 +206,43 @@ public class CauldronOutletEntity extends Entity {
             );
             entity.moveTo(ejectPos);
             entity.setDeltaMovement(motion);
-            // 移除铁砧加工标记，防止被其他炼药锅口连续吸走
             entity.anvilcraft$setIsAdsorbable(true);
             if (!this.level().isClientSide && this.level() instanceof ServerLevel serverLevel) {
                 serverLevel.getChunkSource().broadcast(entity, new ClientboundTeleportEntityPacket(entity));
                 serverLevel.getChunkSource().broadcast(entity, new ClientboundSetEntityMotionPacket(entity));
             }
         });
+    }
+
+    // 辅助方法：统一处理移动和锁定
+    private void manualMove(BlockPos destPos) {
+        // 更新物理位置
+        moveToBlock(destPos, this.level().getBlockState(destPos));
+        // 设置状态
+        this.wasMoving = true;
+        // 锁定目标
+        this.targetPos = destPos;
+    }
+
+    /**
+     * 获取活塞移动方块的真实移动方向。
+     * 推出时(Extending)：方向为活塞朝向。
+     * 拉回时(!Extending)：方向为活塞朝向的反方向。
+     */
+    private Direction getMovementDirection(PistonMovingBlockEntity be) {
+        return be.isExtending() ? be.getDirection() : be.getDirection().getOpposite();
+    }
+
+    private void moveToBlock(BlockPos pos, BlockState state) {
+        // 计算偏移量，保持实体相对于方块的位置不变
+        Vec3 offset = this.position().subtract(Vec3.atLowerCornerOf(this.cauldronPos));
+        this.cauldronPos = pos;
+        this.cauldronState = state;
+        this.setPos(Vec3.atLowerCornerOf(pos).add(offset));
+        this.entityData.set(DATA_CAULDRON_POS, pos);
+        // 重置状态
+        this.wasMoving = false;
+        this.targetPos = null;
     }
 
     @Override
@@ -107,7 +254,7 @@ public class CauldronOutletEntity extends Entity {
     protected void defineSynchedData(SynchedEntityData.Builder builder) {
         builder.define(DATA_CAULDRON_POS, BlockPos.ZERO)
             .define(DATA_ATTACHED_DIRECTION, Direction.UP)
-            .define(DATA_CAULDRON_STATE, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState());
+            .define(DATA_CAULDRON_STATE, Blocks.AIR.defaultBlockState());
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
@@ -82,20 +82,14 @@ public class CauldronOutletEntity extends Entity {
             if (this.targetPos != null) {
                 BlockState targetState = this.level().getBlockState(this.targetPos);
 
-                // A：目标已经变成了炼药锅 -> 移动结束，落地
-                if (targetState.is(BlockTags.CAULDRONS)) {
+                if (targetState.is(BlockTags.CAULDRONS)) { // A：目标已经变成了炼药锅 -> 移动结束，落地
                     moveToBlock(this.targetPos, targetState);
                     // 落地瞬间暂不处理物品
                     return;
-                }
-                // B：目标还是移动活塞 -> 正在动画中，原地等待
-                else if (targetState.is(Blocks.MOVING_PISTON)) {
-                    // 保持 wasMoving 为 true，防止被误杀
+                } else if (targetState.is(Blocks.MOVING_PISTON)) { // B：目标还是移动活塞 -> 正在动画中，原地等待
                     this.wasMoving = true;
                     return;
-                }
-                // C：目标变成了空气或其他 -> 追踪丢失 ，进入下面的步骤 3 尝试找回
-                else {
+                } else { // C：目标变成了空气或其他 -> 追踪丢失 ，进入下面的步骤 3 尝试找回
                     this.targetPos = null;
                 }
             }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -5,14 +5,18 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
 
 public class LevitatingBlockEntity extends FallingBlockEntity {
 
     public LevitatingBlockEntity(EntityType<? extends FallingBlockEntity> entityType, Level level) {
         super(entityType, level);
         this.setNoGravity(false);
+        this.refreshDimensions();
     }
 
     private LevitatingBlockEntity(Level level, double x, double y, double z, BlockState state) {
@@ -40,7 +44,7 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
         level.addFreshEntity(levitating);
         return levitating;
     }
-    
+
     @Override
     public void tick() {
         super.tick();

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
-import dev.dubhe.anvilcraft.util.GravityManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
@@ -53,8 +52,8 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
             pos.getY(),
             (double) pos.getZ() + 0.5,
             blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                ? blockState.setValue(BlockStateProperties.WATERLOGGED, false)
-                : blockState
+            ? blockState.setValue(BlockStateProperties.WATERLOGGED, false)
+            : blockState
         );
         level.setBlock(pos, blockState.getFluidState().createLegacyBlock(), 3);
         level.addFreshEntity(levitating);
@@ -64,71 +63,68 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
     @Override
     public void tick() {
         this.setNoGravity(true);
-
         if (this.blockState.isAir()) {
             this.discard();
-            return;
-        }
+        } else {
+            Block block = this.blockState.getBlock();
+            ++this.time;
+            BlockPos blockPos = this.blockPosition();
 
-        Block block = this.blockState.getBlock();
-        ++this.time;
-        BlockPos blockPos = this.blockPosition();
-        int y = blockPos.getY();
-
-        if (y <= this.level().getMinBuildHeight() || y > this.level().getMaxBuildHeight() + 64) {
-            this.discard();
-            return;
-        }
-
-        Vec3 movement = GravityManager.applyGravity(this, this.getDeltaMovement());
-
-        if (this.checkCanMove(this.level(), blockPos)) {
-            this.setDeltaMovement(movement.add(0.0, 0.04, 0.0));
-        } else if (!this.level().isClientSide) {
-            BlockState blockState = this.level().getBlockState(blockPos);
-            this.setDeltaMovement(movement.multiply(0.7, -0.5, 0.7));
-
-            if (!blockState.is(Blocks.MOVING_PISTON)) {
-                if (this.cancelDrop) {
-                    this.discard();
-                    this.callOnBrokenAfterFall(block, blockPos);
-                } else {
-                    handleBlockPlacementOrDrop(block, blockPos, blockState);
-                }
-            }
-        }
-
-        this.move(MoverType.SELF, this.getDeltaMovement());
-        this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
-    }
-
-    private void handleBlockPlacementOrDrop(Block block, BlockPos pos, BlockState currentState) {
-        boolean canBeReplaced = currentState.canBeReplaced(
-            new DirectionalPlaceContext(this.level(), pos, Direction.DOWN, ItemStack.EMPTY, Direction.UP)
-        );
-        boolean canSurvive = this.blockState.canSurvive(this.level(), pos);
-
-        if (canBeReplaced && canSurvive) {
-            if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                && this.level().getFluidState(pos).getType() == Fluids.WATER) {
-                this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-            }
-
-            if (this.level().setBlock(pos, this.blockState, 3)) {
-                ((ServerLevel) this.level()).getChunkSource().chunkMap
-                    .broadcast(this, new ClientboundBlockUpdatePacket(pos, this.level().getBlockState(pos)));
+            if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
                 this.discard();
-                if (block instanceof Fallable fallable) {
-                    fallable.onLand(this.level(), pos, this.blockState, currentState, this);
-                }
-                return;
-            }
-        }
+            } else if (this.checkCanMove(this.level(), blockPos)) {
+                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
+            } else {
+                if (!this.level().isClientSide) {
+                    BlockState blockState = this.level().getBlockState(blockPos);
+                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
+                    if (!blockState.is(Blocks.MOVING_PISTON)) {
+                        if (!this.cancelDrop) {
+                            boolean canBeReplaced = blockState.canBeReplaced(new DirectionalPlaceContext(
+                                this.level(),
+                                blockPos,
+                                Direction.DOWN,
+                                ItemStack.EMPTY,
+                                Direction.UP
+                            ));
+                            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
+                            if (canBeReplaced && canSurvive) {
+                                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED) && this.level()
+                                                                                                         .getFluidState(blockPos)
+                                                                                                         .getType() == Fluids.WATER) {
+                                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
+                                }
 
-        this.discard();
-        if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-            this.callOnBrokenAfterFall(block, pos);
-            this.spawnAtLocation(block);
+                                if (this.level().setBlock(blockPos, this.blockState, 3)) {
+                                    ((ServerLevel) this.level()).getChunkSource().chunkMap.broadcast(
+                                        this,
+                                        new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos))
+                                    );
+                                    this.discard();
+                                    if (block instanceof Fallable) {
+                                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
+                                    }
+                                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                    this.discard();
+                                    this.callOnBrokenAfterFall(block, blockPos);
+                                    this.spawnAtLocation(block);
+                                }
+                            } else {
+                                this.discard();
+                                if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                    this.callOnBrokenAfterFall(block, blockPos);
+                                    this.spawnAtLocation(block);
+                                }
+                            }
+                        } else {
+                            this.discard();
+                            this.callOnBrokenAfterFall(block, blockPos);
+                        }
+                    }
+                }
+            }
+            this.move(MoverType.SELF, this.getDeltaMovement());
+            this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
@@ -63,62 +64,71 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
     @Override
     public void tick() {
         this.setNoGravity(true);
+
         if (this.blockState.isAir()) {
             this.discard();
-        } else {
-            Block block = this.blockState.getBlock();
-            ++this.time;
-            BlockPos blockPos = this.blockPosition();
-            if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
-                this.discard();
-            } else if (this.checkCanMove(this.level(), blockPos)) {
-                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
-            } else {
-                if (!this.level().isClientSide) {
-                    BlockState blockState = this.level().getBlockState(blockPos);
-                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-                    if (!blockState.is(Blocks.MOVING_PISTON)) {
-                        if (!this.cancelDrop) {
-                            boolean canBeReplaced = blockState.canBeReplaced(
-                                new DirectionalPlaceContext(this.level(), blockPos, Direction.DOWN, ItemStack.EMPTY, Direction.UP)
-                            );
-                            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
-                            if (canBeReplaced && canSurvive) {
-                                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                                    && this.level().getFluidState(blockPos).getType() == Fluids.WATER) {
-                                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-                                }
+            return;
+        }
 
-                                if (this.level().setBlock(blockPos, this.blockState, 3)) {
-                                    ((ServerLevel) this.level())
-                                        .getChunkSource()
-                                        .chunkMap
-                                        .broadcast(this, new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos)));
-                                    this.discard();
-                                    if (block instanceof Fallable) {
-                                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
-                                    }
-                                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                    this.discard();
-                                    this.callOnBrokenAfterFall(block, blockPos);
-                                    this.spawnAtLocation(block);
-                                }
-                            } else {
-                                this.discard();
-                                if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                    this.callOnBrokenAfterFall(block, blockPos);
-                                    this.spawnAtLocation(block);
-                                }
-                            }
-                        } else {
-                            this.discard();
-                            this.callOnBrokenAfterFall(block, blockPos);
-                        }
-                    }
+        Block block = this.blockState.getBlock();
+        ++this.time;
+        BlockPos blockPos = this.blockPosition();
+        int y = blockPos.getY();
+
+        if (y <= this.level().getMinBuildHeight() || y > this.level().getMaxBuildHeight() + 64) {
+            this.discard();
+            return;
+        }
+
+        Vec3 movement = GravityManager.applyGravity(this, this.getDeltaMovement());
+
+        if (this.checkCanMove(this.level(), blockPos)) {
+            this.setDeltaMovement(movement.add(0.0, 0.04, 0.0));
+        } else if (!this.level().isClientSide) {
+            BlockState blockState = this.level().getBlockState(blockPos);
+            this.setDeltaMovement(movement.multiply(0.7, -0.5, 0.7));
+
+            if (!blockState.is(Blocks.MOVING_PISTON)) {
+                if (this.cancelDrop) {
+                    this.discard();
+                    this.callOnBrokenAfterFall(block, blockPos);
+                } else {
+                    handleBlockPlacementOrDrop(block, blockPos, blockState);
                 }
             }
-            this.move(MoverType.SELF, this.getDeltaMovement());
-            this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
+        }
+
+        this.move(MoverType.SELF, this.getDeltaMovement());
+        this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
+    }
+
+    private void handleBlockPlacementOrDrop(Block block, BlockPos pos, BlockState currentState) {
+        boolean canBeReplaced = currentState.canBeReplaced(
+            new DirectionalPlaceContext(this.level(), pos, Direction.DOWN, ItemStack.EMPTY, Direction.UP)
+        );
+        boolean canSurvive = this.blockState.canSurvive(this.level(), pos);
+
+        if (canBeReplaced && canSurvive) {
+            if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
+                && this.level().getFluidState(pos).getType() == Fluids.WATER) {
+                this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
+            }
+
+            if (this.level().setBlock(pos, this.blockState, 3)) {
+                ((ServerLevel) this.level()).getChunkSource().chunkMap
+                    .broadcast(this, new ClientboundBlockUpdatePacket(pos, this.level().getBlockState(pos)));
+                this.discard();
+                if (block instanceof Fallable fallable) {
+                    fallable.onLand(this.level(), pos, this.blockState, currentState, this);
+                }
+                return;
+            }
+        }
+
+        this.discard();
+        if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+            this.callOnBrokenAfterFall(block, pos);
+            this.spawnAtLocation(block);
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -2,20 +2,33 @@ package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MoverType;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.FallingBlockEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.DirectionalPlaceContext;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
+import org.jetbrains.annotations.NotNull;
 
 public class LevitatingBlockEntity extends FallingBlockEntity {
-
     public LevitatingBlockEntity(EntityType<? extends FallingBlockEntity> entityType, Level level) {
         super(entityType, level);
-        this.setNoGravity(false);
+        this.setNoGravity(true);
         this.refreshDimensions();
     }
 
@@ -31,15 +44,17 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
         this.setStartPos(this.blockPosition());
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public static LevitatingBlockEntity levitate(Level level, BlockPos pos, BlockState blockState) {
         LevitatingBlockEntity levitating = new LevitatingBlockEntity(
             level,
-            (double) pos.getX() + 0.5D,
+            (double) pos.getX() + 0.5,
             pos.getY(),
-            (double) pos.getZ() + 0.5D,
-            blockState
+            (double) pos.getZ() + 0.5,
+            blockState.hasProperty(BlockStateProperties.WATERLOGGED)
+                ? blockState.setValue(BlockStateProperties.WATERLOGGED, false)
+                : blockState
         );
-        // 设置原位置为空气
         level.setBlock(pos, blockState.getFluidState().createLegacyBlock(), 3);
         level.addFreshEntity(levitating);
         return levitating;
@@ -47,9 +62,82 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
 
     @Override
     public void tick() {
-        super.tick();
-        if (this.blockPosition().getY() > this.level().getMaxBuildHeight() + 64) {
+        this.setNoGravity(true);
+        if (this.blockState.isAir()) {
             this.discard();
+        } else {
+            Block block = this.blockState.getBlock();
+            ++this.time;
+            BlockPos blockPos = this.blockPosition();
+            if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
+                this.discard();
+            } else if (this.checkCanMove(this.level(), blockPos)) {
+                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
+            } else {
+                if (!this.level().isClientSide) {
+                    BlockState blockState = this.level().getBlockState(blockPos);
+                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
+                    if (!blockState.is(Blocks.MOVING_PISTON)) {
+                        if (!this.cancelDrop) {
+                            boolean canBeReplaced = blockState.canBeReplaced(
+                                new DirectionalPlaceContext(this.level(), blockPos, Direction.DOWN, ItemStack.EMPTY, Direction.UP)
+                            );
+                            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
+                            if (canBeReplaced && canSurvive) {
+                                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
+                                    && this.level().getFluidState(blockPos).getType() == Fluids.WATER) {
+                                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
+                                }
+
+                                if (this.level().setBlock(blockPos, this.blockState, 3)) {
+                                    ((ServerLevel) this.level())
+                                        .getChunkSource()
+                                        .chunkMap
+                                        .broadcast(this, new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos)));
+                                    this.discard();
+                                    if (block instanceof Fallable) {
+                                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
+                                    }
+                                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                    this.discard();
+                                    this.callOnBrokenAfterFall(block, blockPos);
+                                    this.spawnAtLocation(block);
+                                }
+                            } else {
+                                this.discard();
+                                if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                    this.callOnBrokenAfterFall(block, blockPos);
+                                    this.spawnAtLocation(block);
+                                }
+                            }
+                        } else {
+                            this.discard();
+                            this.callOnBrokenAfterFall(block, blockPos);
+                        }
+                    }
+                }
+            }
+            this.move(MoverType.SELF, this.getDeltaMovement());
+            this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
         }
+    }
+
+    private boolean checkCanMove(Level level, BlockPos pos) {
+        if (this.time > 1 && this.getDeltaMovement().equals(Vec3.ZERO)) return false;
+        if (level.getBlockState(pos.above()).isAir()) return true;
+        if (level.getBlockState(pos.above()).liquid()) return true;
+        if (level.getBlockState(pos.above()).getCollisionShape(this.level(), pos.above()).equals(Shapes.empty())) return true;
+        if (level.getBlockState(pos).getBlock() instanceof Fallable) return true;
+        if (level.getBlockState(pos.above()).getBlock() instanceof Fallable) return true;
+        return !this.level().getEntitiesOfClass(
+            FallingBlockEntity.class,
+            new AABB(this.position(), this.position()).expandTowards(-0.2, 0, -0.2).expandTowards(0.2, 1.7, 0.2),
+            entity -> !entity.equals(this) && entity.getBlockState().getBlock() instanceof Fallable
+        ).isEmpty();
+    }
+
+    @Override
+    public @NotNull EntityDimensions getDimensions(@NotNull Pose pose) {
+        return EntityDimensions.scalable(0.98f, 0.98f);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -1,37 +1,18 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
-import dev.dubhe.anvilcraft.util.GravityManager;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.MoverType;
-import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.DirectionalPlaceContext;
-import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.Shapes;
-import org.jetbrains.annotations.NotNull;
 
 public class LevitatingBlockEntity extends FallingBlockEntity {
+
     public LevitatingBlockEntity(EntityType<? extends FallingBlockEntity> entityType, Level level) {
         super(entityType, level);
-        // 1. 移除 setNoGravity(true)，让物理系统接管 (虽然 FallingBlock 不走标准 tick，但保持状态一致是好的)
         this.setNoGravity(false);
-        this.refreshDimensions();
     }
 
     private LevitatingBlockEntity(Level level, double x, double y, double z, BlockState state) {
@@ -46,138 +27,25 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
         this.setStartPos(this.blockPosition());
     }
 
-    @SuppressWarnings("UnusedReturnValue")
     public static LevitatingBlockEntity levitate(Level level, BlockPos pos, BlockState blockState) {
         LevitatingBlockEntity levitating = new LevitatingBlockEntity(
             level,
-            (double) pos.getX() + 0.5,
+            (double) pos.getX() + 0.5D,
             pos.getY(),
-            (double) pos.getZ() + 0.5,
-            blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-            ? blockState.setValue(BlockStateProperties.WATERLOGGED, false)
-            : blockState
+            (double) pos.getZ() + 0.5D,
+            blockState
         );
+        // 设置原位置为空气
         level.setBlock(pos, blockState.getFluidState().createLegacyBlock(), 3);
         level.addFreshEntity(levitating);
         return levitating;
     }
-
+    
     @Override
     public void tick() {
-
-        if (this.blockState.isAir()) {
+        super.tick();
+        if (this.blockPosition().getY() > this.level().getMaxBuildHeight() + 64) {
             this.discard();
-        } else {
-            Block block = this.blockState.getBlock();
-            ++this.time;
-            Vec3 externalGravity = GravityManager.getGravityVector(this);
-
-            Vec3 naturalBuoyancy = new Vec3(0, 0.04, 0);
-
-            Vec3 finalAcceleration = naturalBuoyancy.add(externalGravity);
-
-            this.setDeltaMovement(this.getDeltaMovement().add(finalAcceleration));
-
-            this.move(MoverType.SELF, this.getDeltaMovement());
-
-            BlockPos blockPos = this.blockPosition();
-
-            boolean landed = this.onGround() || (this.verticalCollision && this.getDeltaMovement().y > 0);
-
-            if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
-                this.discard();
-            } else {
-                if (!landed && this.checkCanMove(this.level(), blockPos)) {
-                } else {
-                    if (!this.level().isClientSide) {
-                        BlockState blockState = this.level().getBlockState(blockPos);
-
-                        this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-
-                        if (!blockState.is(Blocks.MOVING_PISTON)) {
-                            if (!this.cancelDrop) {
-
-                                Direction placeDirection = this.getDeltaMovement().y > 0 ? Direction.DOWN : Direction.UP;
-
-                                boolean canBeReplaced = blockState.canBeReplaced(new DirectionalPlaceContext(
-                                    this.level(),
-                                    blockPos,
-                                    placeDirection,
-                                    ItemStack.EMPTY,
-                                    placeDirection.getOpposite()
-                                ));
-                                boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
-
-                                if (canBeReplaced && canSurvive) {
-                                    if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED) && this.level()
-                                                                                                             .getFluidState(blockPos)
-                                                                                                             .getType() == Fluids.WATER) {
-                                        this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-                                    }
-
-                                    if (this.level().setBlock(blockPos, this.blockState, 3)) {
-                                        ((ServerLevel) this.level()).getChunkSource().chunkMap.broadcast(
-                                            this,
-                                            new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos))
-                                        );
-                                        this.discard();
-                                        if (block instanceof Fallable) {
-                                            ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
-                                        }
-                                    } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                        this.discard();
-                                        this.callOnBrokenAfterFall(block, blockPos);
-                                        this.spawnAtLocation(block);
-                                    }
-                                } else {
-                                    this.discard();
-                                    if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                        this.callOnBrokenAfterFall(block, blockPos);
-                                        this.spawnAtLocation(block);
-                                    }
-                                }
-                            } else {
-                                this.discard();
-                                this.callOnBrokenAfterFall(block, blockPos);
-                            }
-                        }
-                    }
-                }
-            }
-
-            // 5. 空气阻力 (原版是 0.98)
-            this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
         }
-    }
-
-    private boolean checkCanMove(Level level, BlockPos pos) {
-        // 这里的逻辑主要是为了防止方块实体在生成时如果卡在方块里，给它一点时间移出去，或者判定是否有路可走
-        // 针对漂浮粉，我们主要关心上方
-
-        if (this.time > 1 && this.getDeltaMovement().equals(Vec3.ZERO)) return false;
-
-        // 简化的碰撞检查：
-        // 如果我们是向上飞的，检查上面
-        // 如果是向下掉的，检查下面 (原版逻辑)
-        // 这里保留原始逻辑作为一个宽泛的“是否被完全堵死”的检查
-
-        BlockPos checkPos = this.getDeltaMovement().y > 0 ? pos.above() : pos.below();
-
-        if (level.getBlockState(checkPos).isAir()) return true;
-        if (level.getBlockState(checkPos).liquid()) return true;
-        if (level.getBlockState(checkPos).getCollisionShape(this.level(), checkPos).equals(Shapes.empty())) return true;
-        if (level.getBlockState(pos).getBlock() instanceof Fallable) return true; // 自己占的位置
-
-        // 检查路径上是否有其他下落方块
-        return !this.level().getEntitiesOfClass(
-            FallingBlockEntity.class,
-            new AABB(this.position(), this.position()).inflate(0.2, 0.2, 0.2), // 稍微扩大一点检测范围
-            entity -> !entity.equals(this) && entity.getBlockState().getBlock() instanceof Fallable
-        ).isEmpty();
-    }
-
-    @Override
-    public @NotNull EntityDimensions getDimensions(@NotNull Pose pose) {
-        return EntityDimensions.scalable(0.98f, 0.98f);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
@@ -69,11 +70,11 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
             Block block = this.blockState.getBlock();
             ++this.time;
             BlockPos blockPos = this.blockPosition();
-
+            double g = GravityManager.getGravity(this);
             if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
                 this.discard();
             } else if (this.checkCanMove(this.level(), blockPos)) {
-                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
+                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * g, 0.0));
             } else {
                 if (!this.level().isClientSide) {
                     BlockState blockState = this.level().getBlockState(blockPos);

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
@@ -28,7 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public class LevitatingBlockEntity extends FallingBlockEntity {
     public LevitatingBlockEntity(EntityType<? extends FallingBlockEntity> entityType, Level level) {
         super(entityType, level);
-        this.setNoGravity(true);
+        // 1. 移除 setNoGravity(true)，让物理系统接管 (虽然 FallingBlock 不走标准 tick，但保持状态一致是好的)
+        this.setNoGravity(false);
         this.refreshDimensions();
     }
 
@@ -62,82 +64,114 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
 
     @Override
     public void tick() {
-        this.setNoGravity(true);
+
         if (this.blockState.isAir()) {
             this.discard();
         } else {
             Block block = this.blockState.getBlock();
             ++this.time;
+            Vec3 externalGravity = GravityManager.getGravityVector(this);
+
+            Vec3 naturalBuoyancy = new Vec3(0, 0.04, 0);
+
+            Vec3 finalAcceleration = naturalBuoyancy.add(externalGravity);
+
+            this.setDeltaMovement(this.getDeltaMovement().add(finalAcceleration));
+
+            this.move(MoverType.SELF, this.getDeltaMovement());
+
             BlockPos blockPos = this.blockPosition();
+
+            boolean landed = this.onGround() || (this.verticalCollision && this.getDeltaMovement().y > 0);
 
             if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
                 this.discard();
-            } else if (this.checkCanMove(this.level(), blockPos)) {
-                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
             } else {
-                if (!this.level().isClientSide) {
-                    BlockState blockState = this.level().getBlockState(blockPos);
-                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-                    if (!blockState.is(Blocks.MOVING_PISTON)) {
-                        if (!this.cancelDrop) {
-                            boolean canBeReplaced = blockState.canBeReplaced(new DirectionalPlaceContext(
-                                this.level(),
-                                blockPos,
-                                Direction.DOWN,
-                                ItemStack.EMPTY,
-                                Direction.UP
-                            ));
-                            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
-                            if (canBeReplaced && canSurvive) {
-                                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED) && this.level()
-                                                                                                         .getFluidState(blockPos)
-                                                                                                         .getType() == Fluids.WATER) {
-                                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-                                }
+                if (!landed && this.checkCanMove(this.level(), blockPos)) {
+                } else {
+                    if (!this.level().isClientSide) {
+                        BlockState blockState = this.level().getBlockState(blockPos);
 
-                                if (this.level().setBlock(blockPos, this.blockState, 3)) {
-                                    ((ServerLevel) this.level()).getChunkSource().chunkMap.broadcast(
-                                        this,
-                                        new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos))
-                                    );
-                                    this.discard();
-                                    if (block instanceof Fallable) {
-                                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
+                        this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
+
+                        if (!blockState.is(Blocks.MOVING_PISTON)) {
+                            if (!this.cancelDrop) {
+
+                                Direction placeDirection = this.getDeltaMovement().y > 0 ? Direction.DOWN : Direction.UP;
+
+                                boolean canBeReplaced = blockState.canBeReplaced(new DirectionalPlaceContext(
+                                    this.level(),
+                                    blockPos,
+                                    placeDirection,
+                                    ItemStack.EMPTY,
+                                    placeDirection.getOpposite()
+                                ));
+                                boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
+
+                                if (canBeReplaced && canSurvive) {
+                                    if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED) && this.level()
+                                                                                                             .getFluidState(blockPos)
+                                                                                                             .getType() == Fluids.WATER) {
+                                        this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
                                     }
-                                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+
+                                    if (this.level().setBlock(blockPos, this.blockState, 3)) {
+                                        ((ServerLevel) this.level()).getChunkSource().chunkMap.broadcast(
+                                            this,
+                                            new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos))
+                                        );
+                                        this.discard();
+                                        if (block instanceof Fallable) {
+                                            ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
+                                        }
+                                    } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                        this.discard();
+                                        this.callOnBrokenAfterFall(block, blockPos);
+                                        this.spawnAtLocation(block);
+                                    }
+                                } else {
                                     this.discard();
-                                    this.callOnBrokenAfterFall(block, blockPos);
-                                    this.spawnAtLocation(block);
+                                    if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+                                        this.callOnBrokenAfterFall(block, blockPos);
+                                        this.spawnAtLocation(block);
+                                    }
                                 }
                             } else {
                                 this.discard();
-                                if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                    this.callOnBrokenAfterFall(block, blockPos);
-                                    this.spawnAtLocation(block);
-                                }
+                                this.callOnBrokenAfterFall(block, blockPos);
                             }
-                        } else {
-                            this.discard();
-                            this.callOnBrokenAfterFall(block, blockPos);
                         }
                     }
                 }
             }
-            this.move(MoverType.SELF, this.getDeltaMovement());
+
+            // 5. 空气阻力 (原版是 0.98)
             this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
         }
     }
 
     private boolean checkCanMove(Level level, BlockPos pos) {
+        // 这里的逻辑主要是为了防止方块实体在生成时如果卡在方块里，给它一点时间移出去，或者判定是否有路可走
+        // 针对漂浮粉，我们主要关心上方
+
         if (this.time > 1 && this.getDeltaMovement().equals(Vec3.ZERO)) return false;
-        if (level.getBlockState(pos.above()).isAir()) return true;
-        if (level.getBlockState(pos.above()).liquid()) return true;
-        if (level.getBlockState(pos.above()).getCollisionShape(this.level(), pos.above()).equals(Shapes.empty())) return true;
-        if (level.getBlockState(pos).getBlock() instanceof Fallable) return true;
-        if (level.getBlockState(pos.above()).getBlock() instanceof Fallable) return true;
+
+        // 简化的碰撞检查：
+        // 如果我们是向上飞的，检查上面
+        // 如果是向下掉的，检查下面 (原版逻辑)
+        // 这里保留原始逻辑作为一个宽泛的“是否被完全堵死”的检查
+
+        BlockPos checkPos = this.getDeltaMovement().y > 0 ? pos.above() : pos.below();
+
+        if (level.getBlockState(checkPos).isAir()) return true;
+        if (level.getBlockState(checkPos).liquid()) return true;
+        if (level.getBlockState(checkPos).getCollisionShape(this.level(), checkPos).equals(Shapes.empty())) return true;
+        if (level.getBlockState(pos).getBlock() instanceof Fallable) return true; // 自己占的位置
+
+        // 检查路径上是否有其他下落方块
         return !this.level().getEntitiesOfClass(
             FallingBlockEntity.class,
-            new AABB(this.position(), this.position()).expandTowards(-0.2, 0, -0.2).expandTowards(0.2, 1.7, 0.2),
+            new AABB(this.position(), this.position()).inflate(0.2, 0.2, 0.2), // 稍微扩大一点检测范围
             entity -> !entity.equals(this) && entity.getBlockState().getBlock() instanceof Fallable
         ).isEmpty();
     }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/LevitatingBlockEntity.java
@@ -1,35 +1,21 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
-import dev.dubhe.anvilcraft.util.GravityManager;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.MoverType;
-import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.DirectionalPlaceContext;
-import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
-import org.jetbrains.annotations.NotNull;
 
 public class LevitatingBlockEntity extends FallingBlockEntity {
+
     public LevitatingBlockEntity(EntityType<? extends FallingBlockEntity> entityType, Level level) {
         super(entityType, level);
-        this.setNoGravity(true);
+        this.setNoGravity(false);
         this.refreshDimensions();
     }
 
@@ -45,17 +31,15 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
         this.setStartPos(this.blockPosition());
     }
 
-    @SuppressWarnings("UnusedReturnValue")
     public static LevitatingBlockEntity levitate(Level level, BlockPos pos, BlockState blockState) {
         LevitatingBlockEntity levitating = new LevitatingBlockEntity(
             level,
-            (double) pos.getX() + 0.5,
+            (double) pos.getX() + 0.5D,
             pos.getY(),
-            (double) pos.getZ() + 0.5,
-            blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                ? blockState.setValue(BlockStateProperties.WATERLOGGED, false)
-                : blockState
+            (double) pos.getZ() + 0.5D,
+            blockState
         );
+        // 设置原位置为空气
         level.setBlock(pos, blockState.getFluidState().createLegacyBlock(), 3);
         level.addFreshEntity(levitating);
         return levitating;
@@ -63,83 +47,9 @@ public class LevitatingBlockEntity extends FallingBlockEntity {
 
     @Override
     public void tick() {
-        this.setNoGravity(true);
-        if (this.blockState.isAir()) {
+        super.tick();
+        if (this.blockPosition().getY() > this.level().getMaxBuildHeight() + 64) {
             this.discard();
-        } else {
-            Block block = this.blockState.getBlock();
-            ++this.time;
-            BlockPos blockPos = this.blockPosition();
-            double g = GravityManager.getGravity(this);
-            if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
-                this.discard();
-            } else if (this.checkCanMove(this.level(), blockPos)) {
-                this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * g, 0.0));
-            } else {
-                if (!this.level().isClientSide) {
-                    BlockState blockState = this.level().getBlockState(blockPos);
-                    this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-                    if (!blockState.is(Blocks.MOVING_PISTON)) {
-                        if (!this.cancelDrop) {
-                            boolean canBeReplaced = blockState.canBeReplaced(
-                                new DirectionalPlaceContext(this.level(), blockPos, Direction.DOWN, ItemStack.EMPTY, Direction.UP)
-                            );
-                            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
-                            if (canBeReplaced && canSurvive) {
-                                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                                    && this.level().getFluidState(blockPos).getType() == Fluids.WATER) {
-                                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-                                }
-
-                                if (this.level().setBlock(blockPos, this.blockState, 3)) {
-                                    ((ServerLevel) this.level())
-                                        .getChunkSource()
-                                        .chunkMap
-                                        .broadcast(this, new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos)));
-                                    this.discard();
-                                    if (block instanceof Fallable) {
-                                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
-                                    }
-                                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                    this.discard();
-                                    this.callOnBrokenAfterFall(block, blockPos);
-                                    this.spawnAtLocation(block);
-                                }
-                            } else {
-                                this.discard();
-                                if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                                    this.callOnBrokenAfterFall(block, blockPos);
-                                    this.spawnAtLocation(block);
-                                }
-                            }
-                        } else {
-                            this.discard();
-                            this.callOnBrokenAfterFall(block, blockPos);
-                        }
-                    }
-                }
-            }
-            this.move(MoverType.SELF, this.getDeltaMovement());
-            this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
         }
-    }
-
-    private boolean checkCanMove(Level level, BlockPos pos) {
-        if (this.time > 1 && this.getDeltaMovement().equals(Vec3.ZERO)) return false;
-        if (level.getBlockState(pos.above()).isAir()) return true;
-        if (level.getBlockState(pos.above()).liquid()) return true;
-        if (level.getBlockState(pos.above()).getCollisionShape(this.level(), pos.above()).equals(Shapes.empty())) return true;
-        if (level.getBlockState(pos).getBlock() instanceof Fallable) return true;
-        if (level.getBlockState(pos.above()).getBlock() instanceof Fallable) return true;
-        return !this.level().getEntitiesOfClass(
-            FallingBlockEntity.class,
-            new AABB(this.position(), this.position()).expandTowards(-0.2, 0, -0.2).expandTowards(0.2, 1.7, 0.2),
-            entity -> !entity.equals(this) && entity.getBlockState().getBlock() instanceof Fallable
-        ).isEmpty();
-    }
-
-    @Override
-    public @NotNull EntityDimensions getDimensions(@NotNull Pose pose) {
-        return EntityDimensions.scalable(0.98f, 0.98f);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/entity/StandableFallingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/StandableFallingBlockEntity.java
@@ -3,9 +3,6 @@ package dev.dubhe.anvilcraft.entity;
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntitySelector;
@@ -13,17 +10,10 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.DirectionalPlaceContext;
-import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
 import org.jetbrains.annotations.NotNull;
@@ -33,7 +23,7 @@ import java.util.List;
 public class StandableFallingBlockEntity extends FallingBlockEntity {
     public StandableFallingBlockEntity(EntityType<? extends FallingBlockEntity> entityType, Level level) {
         super(entityType, level);
-        this.setNoGravity(true);
+        this.setNoGravity(false);
         this.refreshDimensions();
     }
 
@@ -67,67 +57,7 @@ public class StandableFallingBlockEntity extends FallingBlockEntity {
 
     @Override
     public void tick() {
-        this.setNoGravity(true);
-        if (this.blockState.isAir()) {
-            this.discard();
-            return;
-        }
-        Block block = this.blockState.getBlock();
-        ++this.time;
-        BlockPos blockPos = this.blockPosition();
-
-        whenStop:
-        if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
-            this.discard();
-        } else if (
-            (this.time <= 1 || !this.getDeltaMovement().equals(Vec3.ZERO))
-                && isFree(this.level(), new BlockPos(
-                this.getBlockX(), (int) Math.floor(blockPos.getBottomCenter().y - 0.04), this.getBlockZ()))
-        ) {
-            this.setDeltaMovement(this.getDeltaMovement().add(0.0, -0.04, 0.0));
-        } else {
-            if (this.level().isClientSide) break whenStop;
-            BlockState blockState = this.level().getBlockState(blockPos);
-            this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-            if (blockState.is(Blocks.MOVING_PISTON)) break whenStop;
-
-            if (this.cancelDrop) {
-                this.discard();
-                this.callOnBrokenAfterFall(block, blockPos);
-                break whenStop;
-            }
-            boolean canBeReplaced = blockState.canBeReplaced(
-                new DirectionalPlaceContext(this.level(), blockPos, Direction.DOWN, ItemStack.EMPTY, Direction.UP));
-            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
-            if (canBeReplaced && canSurvive) {
-                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                    && this.level().getFluidState(blockPos).getType() == Fluids.WATER) {
-                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-                }
-
-                if (this.level().setBlock(blockPos, this.blockState, 3)) {
-                    ((ServerLevel) this.level())
-                        .getChunkSource()
-                        .chunkMap
-                        .broadcast(this, new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos)));
-                    this.discard();
-                    if (block instanceof Fallable) {
-                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
-                    }
-                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                    this.discard();
-                    this.callOnBrokenAfterFall(block, blockPos);
-                    this.spawnAtLocation(block);
-                }
-            } else {
-                this.discard();
-                if (!this.dropItem || !this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) break whenStop;
-                this.callOnBrokenAfterFall(block, blockPos);
-                this.spawnAtLocation(block);
-            }
-        }
-        this.move(MoverType.SELF, this.getDeltaMovement());
-        this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
+        super.tick();
     }
 
     @Override
@@ -184,7 +114,7 @@ public class StandableFallingBlockEntity extends FallingBlockEntity {
     }
 
     @Override
-    public @NotNull EntityDimensions getDimensions(@NotNull Pose pose) {
+    public EntityDimensions getDimensions(Pose pose) {
         return EntityDimensions.scalable(0.98f, 0.98f);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/entity/StandableLevitatingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/StandableLevitatingBlockEntity.java
@@ -3,24 +3,14 @@ package dev.dubhe.anvilcraft.entity;
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.DirectionalPlaceContext;
-import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.List;
@@ -60,68 +50,7 @@ public class StandableLevitatingBlockEntity extends LevitatingBlockEntity {
 
     @Override
     public void tick() {
-        this.setNoGravity(true);
-        if (this.blockState.isAir()) {
-            this.discard();
-            return;
-        }
-        Block block = this.blockState.getBlock();
-        ++this.time;
-        BlockPos blockPos = this.blockPosition();
-
-        whenStop:
-        if (blockPos.getY() <= this.level().getMinBuildHeight() || blockPos.getY() > this.level().getMaxBuildHeight() + 64) {
-            this.discard();
-        } else if (
-            (this.time <= 1 || !this.getDeltaMovement().equals(Vec3.ZERO))
-                && StandableFallingBlockEntity.isFree(
-                this.level(), new BlockPos(
-                    this.getBlockX(), (int) Math.floor(blockPos.getCenter().y + 0.54), this.getBlockZ()))
-        ) {
-            this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04, 0.0));
-        } else {
-            if (this.level().isClientSide) break whenStop;
-            BlockState blockState = this.level().getBlockState(blockPos);
-            this.setDeltaMovement(this.getDeltaMovement().multiply(0.7, -0.5, 0.7));
-            if (blockState.is(Blocks.MOVING_PISTON)) break whenStop;
-
-            if (this.cancelDrop) {
-                this.discard();
-                this.callOnBrokenAfterFall(block, blockPos);
-                break whenStop;
-            }
-            boolean canBeReplaced = blockState.canBeReplaced(
-                new DirectionalPlaceContext(this.level(), blockPos, Direction.DOWN, ItemStack.EMPTY, Direction.UP));
-            boolean canSurvive = this.blockState.canSurvive(this.level(), blockPos);
-            if (canBeReplaced && canSurvive) {
-                if (this.blockState.hasProperty(BlockStateProperties.WATERLOGGED)
-                    && this.level().getFluidState(blockPos).getType() == Fluids.WATER) {
-                    this.blockState = this.blockState.setValue(BlockStateProperties.WATERLOGGED, true);
-                }
-
-                if (this.level().setBlock(blockPos, this.blockState, 3)) {
-                    ((ServerLevel) this.level())
-                        .getChunkSource()
-                        .chunkMap
-                        .broadcast(this, new ClientboundBlockUpdatePacket(blockPos, this.level().getBlockState(blockPos)));
-                    this.discard();
-                    if (block instanceof Fallable) {
-                        ((Fallable) block).onLand(this.level(), blockPos, this.blockState, blockState, this);
-                    }
-                } else if (this.dropItem && this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-                    this.discard();
-                    this.callOnBrokenAfterFall(block, blockPos);
-                    this.spawnAtLocation(block);
-                }
-            } else {
-                this.discard();
-                if (!this.dropItem || !this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) break whenStop;
-                this.callOnBrokenAfterFall(block, blockPos);
-                this.spawnAtLocation(block);
-            }
-        }
-        this.move(MoverType.SELF, this.getDeltaMovement());
-        this.setDeltaMovement(this.getDeltaMovement().scale(0.98));
+        super.tick();
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
@@ -7,6 +7,7 @@ import dev.dubhe.anvilcraft.block.item.ResinBlockItem;
 import dev.dubhe.anvilcraft.entity.MagnetizedNodeEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
+import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.item.DragonRodItem;
 import dev.dubhe.anvilcraft.item.MultitoolItem;
@@ -28,7 +29,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 import net.neoforged.neoforge.event.entity.living.LivingUseTotemEvent;
@@ -70,11 +70,11 @@ public class PlayerEventListener {
         if (
             item.is(ModItems.MAGNET)
             || (item.is(ModItems.MULTITOOL_ITEM) && MultitoolItem.getMode(item) == MultitoolItem.MAGNET_MODE)
-            || item.is(Tags.Items.BUCKETS)
+            || item.is(ModItemTags.ANVIL_HAMMER)
         ) {
             return;
         }
-        if (player.isShiftKeyDown() || entities.isEmpty()) {
+        if (!player.isShiftKeyDown() || entities.isEmpty()) {
             return;
         }
         MagnetizedNodeEntity node = entities.getFirst();

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockEntities.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockEntities.java
@@ -6,6 +6,7 @@ import dev.dubhe.anvilcraft.block.entity.ActivatorSlidingRailBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.ActiveSilencerBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.AdvancedComparatorBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.BatchCrafterBlockEntity;
+import dev.dubhe.anvilcraft.block.entity.BlackHoleBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.ChargeCollectorBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.ChargerBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.ChuteBlockEntity;
@@ -200,6 +201,11 @@ public class ModBlockEntities {
         "space_overcompressor",
         SpaceOvercompressorBlockEntity::createBlockEntity
     ).validBlocks(ModBlocks.SPACE_OVERCOMPRESSOR).register();
+
+    public static final BlockEntityEntry<BlackHoleBlockEntity> BLACK_HOLE = REGISTRATE.blockEntity(
+        "black_hole",
+        BlackHoleBlockEntity::createBlockEntity
+    ).validBlocks(ModBlocks.BLACK_HOLE).register();
 
     public static final BlockEntityEntry<TimeCountedPressurePlateBlockEntity> TIME_COUNTED_PRESSURE_PLATE = REGISTRATE.blockEntity(
         "time_counted_pressure_plate",

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -13,6 +13,7 @@ import dev.dubhe.anvilcraft.block.ArrowBlock;
 import dev.dubhe.anvilcraft.block.BatchCrafterBlock;
 import dev.dubhe.anvilcraft.block.BerryCakeBlock;
 import dev.dubhe.anvilcraft.block.BerryCreamBlock;
+import dev.dubhe.anvilcraft.block.BlackHoleBlock;
 import dev.dubhe.anvilcraft.block.BlockComparatorBlock;
 import dev.dubhe.anvilcraft.block.BlockDevourerBlock;
 import dev.dubhe.anvilcraft.block.BlockPlacerBlock;
@@ -380,7 +381,7 @@ public class ModBlocks {
                 .pattern("NIN")
                 .pattern("NVN")
                 .pattern("BBB")
-                .define('I', ModItems.NEUTRONIUM_INGOT)
+                .define('I', ModItemTags.UNCHARGED_NEUTRONIUM_INGOTS)
                 .define('N', ModItems.NEGATIVE_MATTER)
                 .define('B', ModBlocks.NEGATIVE_MATTER_BLOCK)
                 .define('V', ModItems.VOID_MATTER)
@@ -4747,6 +4748,14 @@ public class ModBlocks {
         PlayerHungerPressurePlateBlock::new,
         ModItemTags.BRONZE_INGOTS
     );
+
+    public static final BlockEntry<BlackHoleBlock> BLACK_HOLE = REGISTRATE.block("black_hole", BlackHoleBlock::new)
+        .initialProperties(() -> Blocks.OBSIDIAN)
+        .properties(p -> p.strength(10000.0F, 10000.0F))
+        .blockstate((ctx, provider) -> {
+        })
+        .simpleItem()
+        .register();
 
     public static void register() {
     }

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -375,7 +375,7 @@ public class ModBlocks {
     public static final BlockEntry<? extends Block> NEUTRON_IRRADIATOR = REGISTRATE.block("neutron_irradiator", NeutronIrradiatorBlock::new)
         .initialProperties(() -> Blocks.IRON_BLOCK)
         .blockstate(DataGenUtil::noExtraModelOrState)
-        .properties(p -> p.strength(50.0f, 1200f))
+        .properties(p -> p.strength(50.0f, 1200f).lightLevel(state -> 7).emissiveRendering(ModBlocks::always))
         .recipe((ctx, provider) -> {
             ShapedRecipeBuilder.shaped(RecipeCategory.MISC, ctx.get())
                 .pattern("NIN")
@@ -4751,7 +4751,7 @@ public class ModBlocks {
 
     public static final BlockEntry<BlackHoleBlock> BLACK_HOLE = REGISTRATE.block("black_hole", BlackHoleBlock::new)
         .initialProperties(() -> Blocks.OBSIDIAN)
-        .properties(p -> p.strength(10000.0F, 10000.0F))
+        .properties(p -> p.strength(10000.0F, 10000.0F).lightLevel(state -> 15).emissiveRendering(ModBlocks::always))
         .blockstate((ctx, provider) -> {
         })
         .simpleItem()

--- a/src/main/java/dev/dubhe/anvilcraft/init/entity/ModEntities.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/entity/ModEntities.java
@@ -60,11 +60,13 @@ public class ModEntities {
 
     public static final EntityEntry<? extends StandableFallingBlockEntity> STANDABLE_FALLING_BLOCK = AnvilCraft.REGISTRATE
         .entity("standable_falling_block", StandableFallingBlockEntity::new, MobCategory.MISC)
+        .properties(builder -> builder.sized(0.98f, 0.98f))
         .renderer(() -> FallingBlockRenderer::new)
         .register();
 
     public static final EntityEntry<? extends StandableLevitatingBlockEntity> STANDABLE_LEVITATING_BLOCK = AnvilCraft.REGISTRATE
         .entity("standable_levitating_block", StandableLevitatingBlockEntity::new, MobCategory.MISC)
+        .properties(builder -> builder.sized(0.98f, 0.98f))
         .renderer(() -> FallingBlockRenderer::new)
         .register();
 

--- a/src/main/java/dev/dubhe/anvilcraft/init/entity/ModEntities.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/entity/ModEntities.java
@@ -54,6 +54,7 @@ public class ModEntities {
 
     public static final EntityEntry<? extends LevitatingBlockEntity> LEVITATING_BLOCK = AnvilCraft.REGISTRATE
         .entity("levitating_block", LevitatingBlockEntity::new, MobCategory.MISC)
+        .properties(builder -> builder.sized(0.98f, 0.98f))
         .renderer(() -> FallingBlockRenderer::new)
         .register();
 

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -152,7 +152,10 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         this.repairMaterial = repairMaterialSlotItem.getItem();
         ItemStack result = repairTool.copy();
         this.currentRecipe = REPAIR_COST_RECIPES.getOrDefault(repairMaterialSlotItem.getItem(), null);
-        if (!resultMaterialSlotItem.isEmpty() && this.currentRecipe != null && resultMaterialSlotItem.getItem() != this.currentRecipe.item) {
+        if (!resultMaterialSlotItem.isEmpty()
+            && this.currentRecipe != null
+            && resultMaterialSlotItem.getItem() != this.currentRecipe.item
+        ) {
             this.usedGold = 0;
             return ItemStack.EMPTY;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -24,7 +24,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -101,21 +100,21 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         };
         this.access = access;
         this.addSlot(new Slot(this.repairToolSlots, 0, 25, 34) {
-            public boolean mayPlace(@NotNull ItemStack stack) {
+            public boolean mayPlace(ItemStack stack) {
                 return stack.isDamageableItem() || stack.is(Items.ENCHANTED_BOOK) || stack.isEnchanted();
             }
         });
         this.addSlot(new Slot(this.repairMaterialSlots, 0, 89, 22) {
-            public boolean mayPlace(@NotNull ItemStack stack) {
+            public boolean mayPlace(ItemStack stack) {
                 return isRepairMaterial(stack);
             }
         });
         this.addSlot(new Slot(this.resultToolSlots, 2, 145, 34) {
-            public boolean mayPlace(@NotNull ItemStack stack) {
+            public boolean mayPlace(ItemStack stack) {
                 return false;
             }
 
-            public void onTake(@NotNull Player player, @NotNull ItemStack stack) {
+            public void onTake(Player player, ItemStack stack) {
                 player.playSound(SoundEvents.GRINDSTONE_USE);
                 if (currentRecipe != null) {
                     resultMaterialSlots.setItem(2, new ItemStack(currentRecipe.item, usedGold + resultMaterialSlots.getItem(2).getCount()));
@@ -125,7 +124,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
             }
         });
         this.addSlot(new Slot(this.resultMaterialSlots, 2, 89, 47) {
-            public boolean mayPlace(@NotNull ItemStack stack) {
+            public boolean mayPlace(ItemStack stack) {
                 return false;
             }
         });
@@ -150,7 +149,6 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         final ItemStack repairMaterialSlotItem = repairMaterialSlots.getItem(0);
         final ItemStack resultMaterialSlotItem = resultMaterialSlots.getItem(0);
         this.repairMaterial = repairMaterialSlotItem.getItem();
-        ItemStack result = repairTool.copy();
         this.currentRecipe = REPAIR_COST_RECIPES.getOrDefault(repairMaterialSlotItem.getItem(), null);
         if (!resultMaterialSlotItem.isEmpty()
             && this.currentRecipe != null
@@ -161,6 +159,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         }
         int repairCost = repairTool.getOrDefault(DataComponents.REPAIR_COST, 0);
         this.totalRepairCost = repairCost;
+        ItemStack result = repairTool.copy();
         DataComponentType<ItemEnchantments> enchantmentComponent = result.is(Items.ENCHANTED_BOOK)
             ? DataComponents.STORED_ENCHANTMENTS
             : DataComponents.ENCHANTMENTS;
@@ -212,7 +211,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
     }
 
     @Override
-    public @NotNull ItemStack quickMoveStack(@NotNull Player player, int index) {
+    public ItemStack quickMoveStack(Player player, int index) {
         ItemStack itemStack;
         Slot slot = this.slots.get(index);
         if (slot.hasItem()) {
@@ -265,12 +264,12 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
     }
 
     @Override
-    public boolean stillValid(@NotNull Player player) {
+    public boolean stillValid(Player player) {
         return stillValid(this.access, player, ModBlocks.ROYAL_GRINDSTONE.get());
     }
 
     @Override
-    public void slotsChanged(@NotNull Container container) {
+    public void slotsChanged(Container container) {
         super.slotsChanged(container);
         if (container.equals(this.repairMaterialSlots)
             || container.equals(this.repairToolSlots)) resultToolSlots.setItem(2, createResult());
@@ -281,7 +280,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
      *
      * @param player 玩家
      */
-    public void removed(@NotNull Player player) {
+    public void removed(Player player) {
         super.removed(player);
         this.access.execute((level, blockPos) -> {
             this.clearContainer(player, this.repairToolSlots);
@@ -290,7 +289,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         });
     }
 
-    protected void clearContainer(Player player, @NotNull Container container) {
+    protected void clearContainer(Player player, Container container) {
         int i;
         if (!player.isAlive() || player instanceof ServerPlayer && ((ServerPlayer) player).hasDisconnected()) {
             for (i = 0; i < container.getContainerSize(); ++i) {

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalGrindstoneMenu.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -100,21 +101,21 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         };
         this.access = access;
         this.addSlot(new Slot(this.repairToolSlots, 0, 25, 34) {
-            public boolean mayPlace(ItemStack stack) {
+            public boolean mayPlace(@NotNull ItemStack stack) {
                 return stack.isDamageableItem() || stack.is(Items.ENCHANTED_BOOK) || stack.isEnchanted();
             }
         });
         this.addSlot(new Slot(this.repairMaterialSlots, 0, 89, 22) {
-            public boolean mayPlace(ItemStack stack) {
+            public boolean mayPlace(@NotNull ItemStack stack) {
                 return isRepairMaterial(stack);
             }
         });
         this.addSlot(new Slot(this.resultToolSlots, 2, 145, 34) {
-            public boolean mayPlace(ItemStack stack) {
+            public boolean mayPlace(@NotNull ItemStack stack) {
                 return false;
             }
 
-            public void onTake(Player player, ItemStack stack) {
+            public void onTake(@NotNull Player player, @NotNull ItemStack stack) {
                 player.playSound(SoundEvents.GRINDSTONE_USE);
                 if (currentRecipe != null) {
                     resultMaterialSlots.setItem(2, new ItemStack(currentRecipe.item, usedGold + resultMaterialSlots.getItem(2).getCount()));
@@ -124,7 +125,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
             }
         });
         this.addSlot(new Slot(this.resultMaterialSlots, 2, 89, 47) {
-            public boolean mayPlace(ItemStack stack) {
+            public boolean mayPlace(@NotNull ItemStack stack) {
                 return false;
             }
         });
@@ -149,18 +150,14 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         final ItemStack repairMaterialSlotItem = repairMaterialSlots.getItem(0);
         final ItemStack resultMaterialSlotItem = resultMaterialSlots.getItem(0);
         this.repairMaterial = repairMaterialSlotItem.getItem();
+        ItemStack result = repairTool.copy();
         this.currentRecipe = REPAIR_COST_RECIPES.getOrDefault(repairMaterialSlotItem.getItem(), null);
-        if (
-            !resultMaterialSlotItem.isEmpty()
-            && this.currentRecipe != null
-            && resultMaterialSlotItem.getItem() != this.currentRecipe.item
-        ) {
+        if (!resultMaterialSlotItem.isEmpty() && this.currentRecipe != null && resultMaterialSlotItem.getItem() != this.currentRecipe.item) {
             this.usedGold = 0;
             return ItemStack.EMPTY;
         }
         int repairCost = repairTool.getOrDefault(DataComponents.REPAIR_COST, 0);
         this.totalRepairCost = repairCost;
-        ItemStack result = repairTool.copy();
         DataComponentType<ItemEnchantments> enchantmentComponent = result.is(Items.ENCHANTED_BOOK)
             ? DataComponents.STORED_ENCHANTMENTS
             : DataComponents.ENCHANTMENTS;
@@ -212,7 +209,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
     }
 
     @Override
-    public ItemStack quickMoveStack(Player player, int index) {
+    public @NotNull ItemStack quickMoveStack(@NotNull Player player, int index) {
         ItemStack itemStack;
         Slot slot = this.slots.get(index);
         if (slot.hasItem()) {
@@ -265,12 +262,12 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
     }
 
     @Override
-    public boolean stillValid(Player player) {
+    public boolean stillValid(@NotNull Player player) {
         return stillValid(this.access, player, ModBlocks.ROYAL_GRINDSTONE.get());
     }
 
     @Override
-    public void slotsChanged(Container container) {
+    public void slotsChanged(@NotNull Container container) {
         super.slotsChanged(container);
         if (container.equals(this.repairMaterialSlots)
             || container.equals(this.repairToolSlots)) resultToolSlots.setItem(2, createResult());
@@ -281,7 +278,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
      *
      * @param player 玩家
      */
-    public void removed(Player player) {
+    public void removed(@NotNull Player player) {
         super.removed(player);
         this.access.execute((level, blockPos) -> {
             this.clearContainer(player, this.repairToolSlots);
@@ -290,7 +287,7 @@ public class RoyalGrindstoneMenu extends AbstractContainerMenu {
         });
     }
 
-    protected void clearContainer(Player player, Container container) {
+    protected void clearContainer(Player player, @NotNull Container container) {
         int i;
         if (!player.isAlive() || player instanceof ServerPlayer && ((ServerPlayer) player).hasDisconnected()) {
             for (i = 0; i < container.getContainerSize(); ++i) {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -33,7 +33,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -98,9 +97,12 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
-        value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V", ordinal = 1
-    )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V",
+            ordinal = 1
+        )
     )
     public void anvilcraft$fixFallingBlockEntity(
         Entity instance,
@@ -159,20 +161,36 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
-        value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z", ordinal = 0
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/Mth;equal(DD)Z",
+            ordinal = 0
+        )
     )
-    )
-    public boolean anvilcraft$cancelCollision1(double x, double y, Operation<Boolean> original, @Share("isFixed") LocalBooleanRef isFixed) {
+    public boolean anvilcraft$cancelCollision1(
+        double x,
+        double y,
+        Operation<Boolean> original,
+        @Share("isFixed") LocalBooleanRef isFixed
+    ) {
         return isFixed.get() || original.call(x, y);
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
-        value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z", ordinal = 1
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/Mth;equal(DD)Z",
+            ordinal = 1
+        )
     )
-    )
-    public boolean anvilcraft$cancelCollision2(double x, double y, Operation<Boolean> original, @Share("isFixed") LocalBooleanRef isFixed) {
+    public boolean anvilcraft$cancelCollision2(
+        double x,
+        double y,
+        Operation<Boolean> original,
+        @Share("isFixed") LocalBooleanRef isFixed
+    ) {
         return isFixed.get() || original.call(x, y);
     }
 
@@ -217,38 +235,36 @@ public abstract class EntityMixin implements IEntityExtension {
 
     @Inject(method = "move", at = @At("HEAD"))
     public void anvil$recordMovement(
-        MoverType type,
-        Vec3 pos,
-        CallbackInfo ci,
-        @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
+        MoverType type, Vec3 pos, CallbackInfo ci, @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
     ) {
         beforeBoundingMovement.set(this.getDeltaMovement());
     }
 
     @Inject(method = "move", at = @At("RETURN"))
     public void anvil$collisionCraft(
-        MoverType type,
-        Vec3 pos,
-        CallbackInfo ci,
-        @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
+        MoverType type, Vec3 pos, CallbackInfo ci, @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
     ) {
         Optional<FallingBlockEntity> entityOp = Util.castSafely(this, FallingBlockEntity.class);
         if (entityOp.isEmpty() || !this.horizontalCollision) return;
         FallingBlockEntity self = entityOp.get();
-        BlockPos blockPos = BlockPos.containing(this.position.add(beforeBoundingMovement.get()
-            .scale(0.55 / beforeBoundingMovement.get().length())
-            .multiply(1, 0, 1)));
+        BlockPos blockPos = BlockPos.containing(
+            this.position.add(
+                beforeBoundingMovement.get()
+                    .scale(0.55 / beforeBoundingMovement.get().length())
+                    .multiply(1, 0, 1)
+            )
+        );
         NeoForge.EVENT_BUS.post(new AnvilEvent.CollisionBlock(level, blockPos, self, beforeBoundingMovement.get().length()));
     }
 
     @Inject(
-        method = "handlePortal", at = @At(
-        value = "INVOKE",
-        target = "Lnet/minecraft/world/entity/Entity;changeDimension("
-                 + "Lnet/minecraft/world/level/portal/DimensionTransition;"
-                 + ")"
-                 + "Lnet/minecraft/world/entity/Entity;"
-    )
+        method = "handlePortal",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/Entity;changeDimension("
+                     + "Lnet/minecraft/world/level/portal/DimensionTransition;"
+                     + ")Lnet/minecraft/world/entity/Entity;"
+        )
     )
     private void handlePortal(CallbackInfo ci) {
         // noinspection ConstantValue
@@ -270,49 +286,17 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @Inject(
-        method = "getGravity", at = @At("RETURN"), cancellable = true
+        method = "tick",
+        at = @At("TAIL")
     )
-    private void anvilcraft$ApplyGravity(CallbackInfoReturnable<Double> cir) {
-        Entity entity = (Entity) (Object) this;
-        Level level = entity.level();
+    private void anvilcraft$Gravity(CallbackInfo ci) {
+        Entity e = (Entity) (Object) this;
 
-        // 获取基础重力
-        double baseGravity = cir.getReturnValue();
+        // 如果是无重力实体则返回
+        if (e.isNoGravity()) return;
 
-        // 应用物质特殊属性
-        GravityManager.GravityType type = GravityManager.getGravityType(entity);
-        switch (type) {
-            case ANTI_GRAVITY -> baseGravity *= -1;
-            case MICRO_ANTI_GRAVITY -> baseGravity *= -0.005;
-            default -> {
-            }
-        }
-
-        // 维度重力 = 基础重力 * 维度系数
-        double dimensionGravity = baseGravity * GravityManager.getDimensionGravity(level);
-
-        // 实际重力 = 维度重力 - 引力向量.y
-        double newGravity = dimensionGravity - GravityManager.getGravityVector(entity).y;
-
-        // 返回实际重力
-        cir.setReturnValue(newGravity);
-    }
-
-    @Inject(
-        method = "tick", at = @At("TAIL")
-    )
-    private void anvilcraft$ApplyHorizontalGravity(CallbackInfo ci) {
-        Entity entity = (Entity) (Object) this;
-
-        // 排除无重力实体和创造飞行玩家
-        if (entity.isNoGravity() || (entity instanceof Player player && player.getAbilities().flying)) {
-            return;
-        }
-
-        // 应用引力向量的水平分量
-        Vec3 finalForce = GravityManager.getGravityVector(entity);
-        if (finalForce.x != 0 || finalForce.z != 0) {
-            entity.setDeltaMovement(entity.getDeltaMovement().add(finalForce.x, 0, finalForce.z));
-        }
+        // 获取重力常数并应用
+        double g = GravityManager.getGravity(e);
+        e.setDeltaMovement(this.getDeltaMovement().add(0.0, 1 - g, 0.0));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -10,6 +10,7 @@ import dev.dubhe.anvilcraft.api.injection.entity.IEntityExtension;
 import dev.dubhe.anvilcraft.block.entity.DeflectionRingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.SpectralAnvilConversionUtil;
 import dev.dubhe.anvilcraft.util.Util;
 import it.unimi.dsi.fastutil.Pair;
@@ -22,7 +23,6 @@ import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Portal;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -282,6 +282,24 @@ public abstract class EntityMixin implements IEntityExtension {
                 }
             }
             fallingBlockEntity.blockState = newState;
+        }
+    }
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void anvilcraft$Gravity(CallbackInfo ci) {
+        Entity entity = (Entity) (Object) this;
+
+        // 如果是无重力实体则返回
+        if (entity.isNoGravity()) return;
+
+        // 获取运动向量和重力因子
+        Vec3 v = entity.getDeltaMovement();
+        double g = GravityManager.getGravity(entity);
+
+        if (v.y < 0) { // 下落的实体
+            entity.setDeltaMovement(this.getDeltaMovement().add(0.0, g - 1.0, 0.0));
+        } else if (v.y > 0) { // 上升的实体
+            entity.setDeltaMovement(this.getDeltaMovement().add(0.0, -g - 1.0, 0.0));
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -244,7 +244,10 @@ public abstract class EntityMixin implements IEntityExtension {
     @Inject(
         method = "handlePortal", at = @At(
         value = "INVOKE",
-        target = "Lnet/minecraft/world/entity/Entity;changeDimension(" + "Lnet/minecraft/world/level/portal/DimensionTransition;" + ")Lnet/minecraft/world/entity/Entity;"
+        target = "Lnet/minecraft/world/entity/Entity;changeDimension("
+                 + "Lnet/minecraft/world/level/portal/DimensionTransition;"
+                 + ")"
+                 + "Lnet/minecraft/world/entity/Entity;"
     )
     )
     private void handlePortal(CallbackInfo ci) {
@@ -281,7 +284,7 @@ public abstract class EntityMixin implements IEntityExtension {
         switch (type) {
             case ANTI_GRAVITY -> baseGravity *= -1;
             case MICRO_ANTI_GRAVITY -> baseGravity *= -0.005;
-            case NORMAL -> {
+            default -> {
             }
         }
 

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -98,12 +98,9 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V",
-            ordinal = 1
-        )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
+        value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V", ordinal = 1
+    )
     )
     public void anvilcraft$fixFallingBlockEntity(
         Entity instance,
@@ -162,36 +159,20 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/util/Mth;equal(DD)Z",
-            ordinal = 0
-        )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
+        value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z", ordinal = 0
     )
-    public boolean anvilcraft$cancelCollision1(
-        double x,
-        double y,
-        Operation<Boolean> original,
-        @Share("isFixed") LocalBooleanRef isFixed
-    ) {
+    )
+    public boolean anvilcraft$cancelCollision1(double x, double y, Operation<Boolean> original, @Share("isFixed") LocalBooleanRef isFixed) {
         return isFixed.get() || original.call(x, y);
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/util/Mth;equal(DD)Z",
-            ordinal = 1
-        )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
+        value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z", ordinal = 1
     )
-    public boolean anvilcraft$cancelCollision2(
-        double x,
-        double y,
-        Operation<Boolean> original,
-        @Share("isFixed") LocalBooleanRef isFixed
-    ) {
+    )
+    public boolean anvilcraft$cancelCollision2(double x, double y, Operation<Boolean> original, @Share("isFixed") LocalBooleanRef isFixed) {
         return isFixed.get() || original.call(x, y);
     }
 
@@ -236,36 +217,35 @@ public abstract class EntityMixin implements IEntityExtension {
 
     @Inject(method = "move", at = @At("HEAD"))
     public void anvil$recordMovement(
-        MoverType type, Vec3 pos, CallbackInfo ci, @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
+        MoverType type,
+        Vec3 pos,
+        CallbackInfo ci,
+        @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
     ) {
         beforeBoundingMovement.set(this.getDeltaMovement());
     }
 
     @Inject(method = "move", at = @At("RETURN"))
     public void anvil$collisionCraft(
-        MoverType type, Vec3 pos, CallbackInfo ci, @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
+        MoverType type,
+        Vec3 pos,
+        CallbackInfo ci,
+        @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
     ) {
         Optional<FallingBlockEntity> entityOp = Util.castSafely(this, FallingBlockEntity.class);
         if (entityOp.isEmpty() || !this.horizontalCollision) return;
         FallingBlockEntity self = entityOp.get();
-        BlockPos blockPos = BlockPos.containing(
-            this.position.add(
-                beforeBoundingMovement.get()
-                    .scale(0.55 / beforeBoundingMovement.get().length())
-                    .multiply(1, 0, 1)
-            )
-        );
+        BlockPos blockPos = BlockPos.containing(this.position.add(beforeBoundingMovement.get()
+            .scale(0.55 / beforeBoundingMovement.get().length())
+            .multiply(1, 0, 1)));
         NeoForge.EVENT_BUS.post(new AnvilEvent.CollisionBlock(level, blockPos, self, beforeBoundingMovement.get().length()));
     }
 
     @Inject(
-        method = "handlePortal",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/Entity;changeDimension("
-                     + "Lnet/minecraft/world/level/portal/DimensionTransition;"
-                     + ")Lnet/minecraft/world/entity/Entity;"
-        )
+        method = "handlePortal", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/entity/Entity;changeDimension(" + "Lnet/minecraft/world/level/portal/DimensionTransition;" + ")Lnet/minecraft/world/entity/Entity;"
+    )
     )
     private void handlePortal(CallbackInfo ci) {
         // noinspection ConstantValue
@@ -287,34 +267,36 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @Inject(
-        method = "getGravity",
-        at = @At("RETURN"),
-        cancellable = true
+        method = "getGravity", at = @At("RETURN"), cancellable = true
     )
-    private void anvilcraft$ModifyGravity(CallbackInfoReturnable<Double> cir) {
+    private void anvilcraft$ApplyGravity(CallbackInfoReturnable<Double> cir) {
         Entity entity = (Entity) (Object) this;
         Level level = entity.level();
 
         // 获取基础重力
         double baseGravity = cir.getReturnValue();
+
         // 应用物质特殊属性
         GravityManager.GravityType type = GravityManager.getGravityType(entity);
         switch (type) {
             case ANTI_GRAVITY -> baseGravity *= -1;
             case MICRO_ANTI_GRAVITY -> baseGravity *= -0.005;
-            case NORMAL -> {}
+            case NORMAL -> {
+            }
         }
+
         // 维度重力 = 基础重力 * 维度系数
         double dimensionGravity = baseGravity * GravityManager.getDimensionGravity(level);
+
         // 实际重力 = 维度重力 - 引力向量.y
         double newGravity = dimensionGravity - GravityManager.getGravityVector(entity).y;
+
         // 返回实际重力
         cir.setReturnValue(newGravity);
     }
 
     @Inject(
-        method = "tick",
-        at = @At("TAIL")
+        method = "tick", at = @At("TAIL")
     )
     private void anvilcraft$ApplyHorizontalGravity(CallbackInfo ci) {
         Entity entity = (Entity) (Object) this;

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -296,7 +296,6 @@ public abstract class EntityMixin implements IEntityExtension {
             return;
         }
         // 根据重力方向调整移动向量
-        Vec3 movement = GravityManager.applyGravity(entity, this.getDeltaMovement());
-        entity.setDeltaMovement(movement);
+        entity.setDeltaMovement(GravityManager.applyGravity(entity, this.getDeltaMovement()));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -286,16 +287,47 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @Inject(
+        method = "getGravity",
+        at = @At("RETURN"),
+        cancellable = true
+    )
+    private void anvilcraft$ModifyGravity(CallbackInfoReturnable<Double> cir) {
+        Entity entity = (Entity) (Object) this;
+        Level level = entity.level();
+
+        // 获取基础重力
+        double baseGravity = cir.getReturnValue();
+        // 应用物质特殊属性
+        GravityManager.GravityType type = GravityManager.getGravityType(entity);
+        switch (type) {
+            case ANTI_GRAVITY -> baseGravity *= -1;
+            case MICRO_ANTI_GRAVITY -> baseGravity *= -0.005;
+            case NORMAL -> {}
+        }
+        // 维度重力 = 基础重力 * 维度系数
+        double dimensionGravity = baseGravity * GravityManager.getDimensionGravity(level);
+        // 实际重力 = 维度重力 - 引力向量.y
+        double newGravity = dimensionGravity - GravityManager.getGravityVector(entity).y;
+        // 返回实际重力
+        cir.setReturnValue(newGravity);
+    }
+
+    @Inject(
         method = "tick",
         at = @At("TAIL")
     )
-    private void anvilcraft$Gravity(CallbackInfo ci) {
+    private void anvilcraft$ApplyHorizontalGravity(CallbackInfo ci) {
         Entity entity = (Entity) (Object) this;
-        // 如果是无重力实体或创造飞行玩家则返回
+
+        // 排除无重力实体和创造飞行玩家
         if (entity.isNoGravity() || (entity instanceof Player player && player.getAbilities().flying)) {
             return;
         }
-        // 根据重力方向调整移动向量
-        entity.setDeltaMovement(GravityManager.applyGravity(entity, this.getDeltaMovement()));
+
+        // 应用引力向量的水平分量
+        Vec3 finalForce = GravityManager.getGravityVector(entity);
+        if (finalForce.x != 0 || finalForce.z != 0) {
+            entity.setDeltaMovement(entity.getDeltaMovement().add(finalForce.x, 0, finalForce.z));
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -290,13 +290,13 @@ public abstract class EntityMixin implements IEntityExtension {
         at = @At("TAIL")
     )
     private void anvilcraft$Gravity(CallbackInfo ci) {
-        Entity e = (Entity) (Object) this;
-
-        // 如果是无重力实体则返回
-        if (e.isNoGravity()) return;
-
-        // 获取重力常数并应用
-        double g = GravityManager.getGravity(e);
-        e.setDeltaMovement(this.getDeltaMovement().add(0.0, 1 - g, 0.0));
+        Entity entity = (Entity) (Object) this;
+        // 如果是无重力实体或创造飞行玩家则返回
+        if (entity.isNoGravity() || (entity instanceof Player player && player.getAbilities().flying)) {
+            return;
+        }
+        // 根据重力方向调整移动向量
+        Vec3 movement = GravityManager.applyGravity(entity, this.getDeltaMovement());
+        entity.setDeltaMovement(movement);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -284,6 +284,7 @@ public abstract class EntityMixin implements IEntityExtension {
         switch (type) {
             case ANTI_GRAVITY -> baseGravity *= -1;
             case MICRO_ANTI_GRAVITY -> baseGravity *= -0.005;
+            case LOW_GRAVITY -> baseGravity *= 0.5;
             default -> {
             }
         }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -97,12 +98,9 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V",
-            ordinal = 1
-        )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
+        value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setPos(DDD)V", ordinal = 1
+    )
     )
     public void anvilcraft$fixFallingBlockEntity(
         Entity instance,
@@ -161,36 +159,20 @@ public abstract class EntityMixin implements IEntityExtension {
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/util/Mth;equal(DD)Z",
-            ordinal = 0
-        )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
+        value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z", ordinal = 0
     )
-    public boolean anvilcraft$cancelCollision1(
-        double x,
-        double y,
-        Operation<Boolean> original,
-        @Share("isFixed") LocalBooleanRef isFixed
-    ) {
+    )
+    public boolean anvilcraft$cancelCollision1(double x, double y, Operation<Boolean> original, @Share("isFixed") LocalBooleanRef isFixed) {
         return isFixed.get() || original.call(x, y);
     }
 
     @WrapOperation(
-        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/util/Mth;equal(DD)Z",
-            ordinal = 1
-        )
+        method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At(
+        value = "INVOKE", target = "Lnet/minecraft/util/Mth;equal(DD)Z", ordinal = 1
     )
-    public boolean anvilcraft$cancelCollision2(
-        double x,
-        double y,
-        Operation<Boolean> original,
-        @Share("isFixed") LocalBooleanRef isFixed
-    ) {
+    )
+    public boolean anvilcraft$cancelCollision2(double x, double y, Operation<Boolean> original, @Share("isFixed") LocalBooleanRef isFixed) {
         return isFixed.get() || original.call(x, y);
     }
 
@@ -235,36 +217,38 @@ public abstract class EntityMixin implements IEntityExtension {
 
     @Inject(method = "move", at = @At("HEAD"))
     public void anvil$recordMovement(
-        MoverType type, Vec3 pos, CallbackInfo ci, @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
+        MoverType type,
+        Vec3 pos,
+        CallbackInfo ci,
+        @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
     ) {
         beforeBoundingMovement.set(this.getDeltaMovement());
     }
 
     @Inject(method = "move", at = @At("RETURN"))
     public void anvil$collisionCraft(
-        MoverType type, Vec3 pos, CallbackInfo ci, @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
+        MoverType type,
+        Vec3 pos,
+        CallbackInfo ci,
+        @Share("beforeBoundingMovement") LocalRef<Vec3> beforeBoundingMovement
     ) {
         Optional<FallingBlockEntity> entityOp = Util.castSafely(this, FallingBlockEntity.class);
         if (entityOp.isEmpty() || !this.horizontalCollision) return;
         FallingBlockEntity self = entityOp.get();
-        BlockPos blockPos = BlockPos.containing(
-            this.position.add(
-                beforeBoundingMovement.get()
-                    .scale(0.55 / beforeBoundingMovement.get().length())
-                    .multiply(1, 0, 1)
-            )
-        );
+        BlockPos blockPos = BlockPos.containing(this.position.add(beforeBoundingMovement.get()
+            .scale(0.55 / beforeBoundingMovement.get().length())
+            .multiply(1, 0, 1)));
         NeoForge.EVENT_BUS.post(new AnvilEvent.CollisionBlock(level, blockPos, self, beforeBoundingMovement.get().length()));
     }
 
     @Inject(
-        method = "handlePortal",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/Entity;changeDimension("
-                     + "Lnet/minecraft/world/level/portal/DimensionTransition;"
-                     + ")Lnet/minecraft/world/entity/Entity;"
-        )
+        method = "handlePortal", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/entity/Entity;changeDimension("
+                 + "Lnet/minecraft/world/level/portal/DimensionTransition;"
+                 + ")"
+                 + "Lnet/minecraft/world/entity/Entity;"
+    )
     )
     private void handlePortal(CallbackInfo ci) {
         // noinspection ConstantValue
@@ -285,21 +269,50 @@ public abstract class EntityMixin implements IEntityExtension {
         }
     }
 
-    @Inject(method = "tick", at = @At("TAIL"))
-    private void anvilcraft$Gravity(CallbackInfo ci) {
+    @Inject(
+        method = "getGravity", at = @At("RETURN"), cancellable = true
+    )
+    private void anvilcraft$ApplyGravity(CallbackInfoReturnable<Double> cir) {
+        Entity entity = (Entity) (Object) this;
+        Level level = entity.level();
+
+        // 获取基础重力
+        double baseGravity = cir.getReturnValue();
+
+        // 应用物质特殊属性
+        GravityManager.GravityType type = GravityManager.getGravityType(entity);
+        switch (type) {
+            case ANTI_GRAVITY -> baseGravity *= -1;
+            case MICRO_ANTI_GRAVITY -> baseGravity *= -0.005;
+            default -> {
+            }
+        }
+
+        // 维度重力 = 基础重力 * 维度系数
+        double dimensionGravity = baseGravity * GravityManager.getDimensionGravity(level);
+
+        // 实际重力 = 维度重力 - 引力向量.y
+        double newGravity = dimensionGravity - GravityManager.getGravityVector(entity).y;
+
+        // 返回实际重力
+        cir.setReturnValue(newGravity);
+    }
+
+    @Inject(
+        method = "tick", at = @At("TAIL")
+    )
+    private void anvilcraft$ApplyHorizontalGravity(CallbackInfo ci) {
         Entity entity = (Entity) (Object) this;
 
-        // 如果是无重力实体则返回
-        if (entity.isNoGravity()) return;
+        // 排除无重力实体和创造飞行玩家
+        if (entity.isNoGravity() || (entity instanceof Player player && player.getAbilities().flying)) {
+            return;
+        }
 
-        // 获取运动向量和重力因子
-        Vec3 v = entity.getDeltaMovement();
-        double g = GravityManager.getGravity(entity);
-
-        if (v.y < 0) { // 下落的实体
-            entity.setDeltaMovement(this.getDeltaMovement().add(0.0, g - 1.0, 0.0));
-        } else if (v.y > 0) { // 上升的实体
-            entity.setDeltaMovement(this.getDeltaMovement().add(0.0, -g - 1.0, 0.0));
+        // 应用引力向量的水平分量
+        Vec3 finalForce = GravityManager.getGravityVector(entity);
+        if (finalForce.x != 0 || finalForce.z != 0) {
+            entity.setDeltaMovement(entity.getDeltaMovement().add(finalForce.x, 0, finalForce.z));
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -1,7 +1,5 @@
 package dev.dubhe.anvilcraft.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IFallingBlockEntityExtension;
@@ -9,7 +7,6 @@ import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
@@ -18,15 +15,11 @@ import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
-import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
-import net.minecraft.world.phys.Vec3;
-import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -49,225 +42,26 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @Shadow
     public boolean cancelDrop;
-    @Shadow
-    public boolean dropItem;
+
     @Shadow
     private float fallDamagePerDistance;
     @Shadow
     private int fallDamageMax;
     @Unique
     private float anvilcraft$fallDistance;
-    @Unique
-    private BlockPos anvilcraft$cachedSupportPos;
 
     public FallingBlockEntityMixin(EntityType<?> entityType, Level level) {
         super(entityType, level);
     }
 
-    // 重定义下落方块的下方
-    @WrapOperation(
-        method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;below()Lnet/minecraft/core/BlockPos;")
-    )
-    private BlockPos anvilcraft$redirectBelowInTick(BlockPos instance, Operation<BlockPos> original) {
-        Vec3 netGravityVector = GravityManager.getNetGravityVectorForFallingBlock(this);
-        // 如果重力向下且没有显著水平分量，使用原版逻辑
-        if (netGravityVector.y < -0.01 && Math.abs(netGravityVector.x) < 0.1 && Math.abs(netGravityVector.z) < 0.1) {
-            return original.call(instance);
-        }
-        // 卡在方块里则当前坐标是下方
-        if (!FallingBlock.isFree(this.level().getBlockState(instance))) {
-            return instance;
-        }
-        // 总重力向量的方向是下落方块的下方
-        Direction gravityDirection = Direction.getNearest(netGravityVector.x, netGravityVector.y, netGravityVector.z);
-        return instance.relative(gravityDirection);
-    }
-
-    /**
-     * 拦截原版的 onGround() 检查，接管方块是否应该变成实体的逻辑。
-     * 主逻辑 ↓
-     */
-    @WrapOperation(
-        method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;onGround()Z")
-    )
-    private boolean anvilcraft$overrideOnGround(FallingBlockEntity instance, Operation<Boolean> original) {
-        Vec3 gravityVec = GravityManager.getNetGravityVectorForFallingBlock(instance);
-
-        // 0. 平衡环境保持实体状态（大概也许可能可以叫拉格朗日点？）
-        if (gravityVec.lengthSqr() < 1.0E-5) return false;
-
-        Direction gravityDir = Direction.getNearest(gravityVec.x, gravityVec.y, gravityVec.z);
-
-        // 1. 物理碰撞检测
-        if (!this.anvilcraft$checkCollision(instance, gravityDir, original)) {
-            return false;
-        }
-
-        // 准备上下文数据
-        Level level = instance.level();
-        BlockPos pos = BlockPos.containing(instance.position());
-        BlockPos supportPos = pos.relative(gravityDir);
-        BlockState supportState = level.getBlockState(supportPos);
-
-        // 2. 摩擦力与滑行检查
-        float friction = supportState.isAir() ? 0.6F : supportState.getFriction(level, supportPos, instance);
-        boolean isMovingSlowly = instance.getDeltaMovement().lengthSqr() < 0.04;
-
-        // 如果速度慢且被摩擦力抓住 -> 着陆，否则 -> 滑行
-        boolean heldByFriction = isMovingSlowly && this.anvilcraft$isHeldByFriction(gravityVec, gravityDir, friction);
-
-        // 如果没被摩擦力抓住 且 有路可走 -> 滑行
-        if (!heldByFriction && this.anvilcraft$hasSlidingPath(level, pos, gravityVec, gravityDir)) {
-            return false;
-        }
-
-        // 3. 稳定性预判
-        // 模拟变成方块后的受力，防止变成方块后立刻又变成实体
-        if (!this.anvilcraft$predictStability(instance, pos)) {
-            return false;
-        }
-
-        // 4. 不完整方块检查
-        if (!supportState.isFaceSturdy(level, supportPos, gravityDir.getOpposite())) {
-            // 如果面不完整，检查碰撞箱
-            VoxelShape shape = supportState.getCollisionShape(level, supportPos);
-            boolean isFullHeight;
-
-            // 根据重力方向判断检查最大值还是最小值
-            if (gravityDir.getAxisDirection() == Direction.AxisDirection.NEGATIVE) {
-                // 向下落撞击顶面，检查 shape.max(axis) 是否接近 1.0
-                isFullHeight = shape.max(gravityDir.getAxis()) >= 1.0 - 1.0E-5;
-            } else {
-                // 向上飞撞击底面，检查 shape.min(axis) 是否接近 0.0
-                isFullHeight = shape.min(gravityDir.getAxis()) <= 1.0E-5;
-            }
-
-            if (!isFullHeight) {
-                this.anvilcraft$breakEntity(instance);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * 辅助方法：检查特定方向是否发生了碰撞
-     */
-    @Unique
-    private boolean anvilcraft$checkCollision(FallingBlockEntity entity, Direction gravityDir, Operation<Boolean> original) {
-        if (gravityDir == Direction.DOWN) {
-            return original.call(entity);
-        } else if (gravityDir == Direction.UP) {
-            return entity.verticalCollision && !original.call(entity);
-        } else {
-            return entity.horizontalCollision;
-        }
-    }
-
-    /**
-     * 辅助方法：计算切向力与摩擦力，判断是否能稳住
-     */
-    @Unique
-    private boolean anvilcraft$isHeldByFriction(Vec3 gravity, Direction gravityDir, float friction) {
-        double totalGravitySq = gravity.lengthSqr();
-        double normalForce = Math.abs(gravity.get(gravityDir.getAxis()));
-        // 切向力 = sqrt(总力^2 - 法向力^2)
-        double tangentialForce = Math.sqrt(Math.max(0, totalGravitySq - normalForce * normalForce));
-        double grip = 1.0 - friction;
-
-        // 判定阈值：切向力 < 最大静摩擦力
-        return tangentialForce < normalForce * grip * 2.0;
-    }
-
-    /**
-     * 辅助方法：检查三个轴向上是否存在可以滑行的空位
-     */
-    @Unique
-    private boolean anvilcraft$hasSlidingPath(Level level, BlockPos currentPos, Vec3 gravity, Direction primaryDir) {
-        if (this.anvilcraft$checkAxisSlide(level, currentPos, gravity.x, Direction.EAST, Direction.WEST, primaryDir)) return true;
-        if (this.anvilcraft$checkAxisSlide(level, currentPos, gravity.y, Direction.UP, Direction.DOWN, primaryDir)) return true;
-        return this.anvilcraft$checkAxisSlide(level, currentPos, gravity.z, Direction.SOUTH, Direction.NORTH, primaryDir);
-    }
-
-    /**
-     * 单轴滑行检查
-     */
-    @Unique
-    private boolean anvilcraft$checkAxisSlide(
-        Level level,
-        BlockPos pos,
-        double component,
-        Direction posDir,
-        Direction negDir,
-        Direction forbiddenDir
-    ) {
-        if (Math.abs(component) <= 1.0E-5) return false;
-
-        Direction targetDir = component > 0 ? posDir : negDir;
-        // 不能向地板滑行
-        if (targetDir == forbiddenDir) return false;
-
-        return FallingBlock.isFree(level.getBlockState(pos.relative(targetDir)));
-    }
-
-    /**
-     * 辅助方法：预测变成方块后的稳定性
-     *
-     * @return true 表示稳定（可以着陆），false 表示不稳定（应该保持实体）
-     */
-    @Unique
-    private boolean anvilcraft$predictStability(FallingBlockEntity instance, BlockPos pos) {
-        // 如果在方块里直接稳定
-        if (!FallingBlock.isFree(instance.level().getBlockState(pos))) {
-            return true;
-        }
-
-        Vec3 blockGravity = GravityManager.getNetGravityVectorForFallingBlock(
-            instance.level(),
-            Vec3.atCenterOf(pos),
-            GravityManager.getFallingBlockGravityType(instance.blockState.getBlock())
-        );
-
-        // 如果方块位置无重力，认为是稳定的
-        if (blockGravity.lengthSqr() <= 1.0E-5) return true;
-
-        Direction dir = Direction.getNearest(blockGravity.x, blockGravity.y, blockGravity.z);
-        BlockPos targetPos = pos.relative(dir);
-        BlockState targetState = instance.level().getBlockState(targetPos);
-
-        // 主方向是空的 -> 不稳定
-        if (FallingBlock.isFree(targetState)) return false;
-
-        // 主方向有方块，检查摩擦力
-        float friction = targetState.getFriction(instance.level(), targetPos, null);
-
-        // 被摩擦力抓住则稳定，没被抓住则不稳定
-        boolean heldByFriction = this.anvilcraft$isHeldByFriction(blockGravity, dir, friction);
-
-        if (!heldByFriction && this.anvilcraft$hasSlidingPath(instance.level(), pos, blockGravity, dir)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * 辅助方法：碎裂掉落逻辑
-     */
-    @Unique
-    private void anvilcraft$breakEntity(FallingBlockEntity instance) {
-        if (this.dropItem && instance.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
-            instance.spawnAtLocation(instance.getBlockState().getBlock());
-        }
-        instance.discard();
-    }
-
     @Inject(
-        method = "tick", at = @At(
-        value = "INVOKE",
-        ordinal = 0,
-        target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;level()Lnet/minecraft/world/level/Level;"
-    )
+        method = "tick",
+        at =
+        @At(
+            value = "INVOKE",
+            ordinal = 0,
+            target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;level()Lnet/minecraft/world/level/Level;"
+        )
     )
     private void anvilPerFallOnGround(CallbackInfo ci) {
         if (this.level().isClientSide()) return;
@@ -282,17 +76,19 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @SuppressWarnings("UnreachableCode")
     @Inject(
-        method = "tick", at = @At(
-        value = "INVOKE",
-        target = "Lnet/minecraft/world/level/block/Fallable;"
-                 + "onLand("
-                 + "Lnet/minecraft/world/level/Level;"
-                 + "Lnet/minecraft/core/BlockPos;"
-                 + "Lnet/minecraft/world/level/block/state/BlockState;"
-                 + "Lnet/minecraft/world/level/block/state/BlockState;"
-                 + "Lnet/minecraft/world/entity/item/FallingBlockEntity;"
-                 + ")V"
-    )
+        method = "tick",
+        at =
+        @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/block/Fallable;"
+                     + "onLand("
+                     + "Lnet/minecraft/world/level/Level;"
+                     + "Lnet/minecraft/core/BlockPos;"
+                     + "Lnet/minecraft/world/level/block/state/BlockState;"
+                     + "Lnet/minecraft/world/level/block/state/BlockState;"
+                     + "Lnet/minecraft/world/entity/item/FallingBlockEntity;"
+                     + ")V"
+        )
     )
     private void anvilFallOnGround(CallbackInfo ci, @Local BlockPos blockPos) {
         if (this.level().isClientSide()) return;
@@ -301,7 +97,9 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, entity, this.anvilcraft$fallDistance);
         NeoForge.EVENT_BUS.post(event);
         if (event.isAnvilDamage()) {
-            BlockState state = this.blockState.is(ModBlocks.ROYAL_ANVIL.get()) ? this.blockState : AnvilBlock.damage(this.blockState);
+            BlockState state = this.blockState.is(ModBlocks.ROYAL_ANVIL.get())
+                               ? this.blockState
+                               : AnvilBlock.damage(this.blockState);
             if (state != null) {
                 this.level().setBlockAndUpdate(blockPos, state);
             } else {
@@ -314,17 +112,24 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @SuppressWarnings("UnreachableCode")
     @Inject(
-        method = "causeFallDamage", at = @At(
-        value = "INVOKE",
-        target = "Lnet/minecraft/world/level/Level;"
-                 + "getEntities("
-                 + "Lnet/minecraft/world/entity/Entity;"
-                 + "Lnet/minecraft/world/phys/AABB;"
-                 + "Ljava/util/function/Predicate;"
-                 + ")Ljava/util/List;"
+        method = "causeFallDamage",
+        at =
+        @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/level/Level;"
+                     + "getEntities("
+                     + "Lnet/minecraft/world/entity/Entity;"
+                     + "Lnet/minecraft/world/phys/AABB;"
+                     + "Ljava/util/function/Predicate;"
+                     + ")Ljava/util/List;"
+        )
     )
-    )
-    private void anvilHurtEntity(float fallDistance, float multiplier, DamageSource source, CallbackInfoReturnable<Boolean> cir) {
+    private void anvilHurtEntity(
+        float fallDistance,
+        float multiplier,
+        DamageSource source,
+        CallbackInfoReturnable<Boolean> cir
+    ) {
         Level level = this.level();
         FallingBlockEntity fallingBlockEntity = Util.cast(this);
         Predicate<Entity> predicate = EntitySelector.NO_CREATIVE_OR_SPECTATOR.and(EntitySelector.LIVING_ENTITY_STILL_ALIVE);
@@ -339,27 +144,38 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     }
 
     @Inject(
-        method = "tick", at = @At(
-        value = "INVOKE",
-        target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V",
-        ordinal = 1
-    )
+        method = "tick",
+        at =
+        @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V",
+            ordinal = 1
+        )
     )
     private void hurtEntity(CallbackInfo ci) {
-        if (this.getDeltaMovement().multiply(1, 0, 1).length() < 0.75 && this.getDeltaMovement().y < 2.5) {
+        if (
+            this.getDeltaMovement().multiply(1, 0, 1).length() < 0.75
+            && this.getDeltaMovement().y < 2.5
+        ) {
             return;
         }
         if (!this.blockState.is(BlockTags.ANVIL)) return;
         EntityHitResult hitResult = ProjectileUtil.getEntityHitResult(
             this.level(),
             this,
-            this.position()
-                .subtract(0, 0.5, 0)
-                .subtract(this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()),
-            this.position().subtract(0, 0.5, 0),
-            this.getBoundingBox().expandTowards((
+            this.position().subtract(0, 0.5, 0).subtract(
                 this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()
-            ).multiply(-1, -1, -1)).inflate(1.0),
+            ),
+            this.position().subtract(0, 0.5, 0),
+            this.getBoundingBox()
+                .expandTowards(
+                    (
+                        this.anvilcraft$isDeflected()
+                        ? this.anvilcraft$getFixedDeltaMovement()
+                        : this.getDeltaMovement()
+                    ).multiply(-1, -1, -1)
+                )
+                .inflate(1.0),
             Entity::isAttackable
         );
         if (hitResult == null) return;
@@ -369,13 +185,16 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     }
 
     @Inject(
-        method = "tick", at = @At("TAIL")
+        method = "tick",
+        at = @At("TAIL")
     )
-    private void anvilcraft$ApplyFallingBlockGravity(CallbackInfo ci) {
+    private void anvilcraft$FallingBlockGravity(CallbackInfo ci) {
+
         // 如果是无重力实体则返回
         if (this.isNoGravity()) return;
-        // 应用引力向量的水平分量
-        Vec3 gravityVector = GravityManager.getGravityVector(this);
-        this.setDeltaMovement(this.getDeltaMovement().add(gravityVector.x, 0, gravityVector.z));
+
+        // 获取重力常数并应用
+        double g = GravityManager.getGravity(this);
+        this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * (1 - g), 0.0));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -284,7 +284,14 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     @Inject(
         method = "tick", at = @At(
         value = "INVOKE",
-        target = "Lnet/minecraft/world/level/block/Fallable;" + "onLand(" + "Lnet/minecraft/world/level/Level;" + "Lnet/minecraft/core/BlockPos;" + "Lnet/minecraft/world/level/block/state/BlockState;" + "Lnet/minecraft/world/level/block/state/BlockState;" + "Lnet/minecraft/world/entity/item/FallingBlockEntity;" + ")V"
+        target = "Lnet/minecraft/world/level/block/Fallable;"
+                 + "onLand("
+                 + "Lnet/minecraft/world/level/Level;"
+                 + "Lnet/minecraft/core/BlockPos;"
+                 + "Lnet/minecraft/world/level/block/state/BlockState;"
+                 + "Lnet/minecraft/world/level/block/state/BlockState;"
+                 + "Lnet/minecraft/world/entity/item/FallingBlockEntity;"
+                 + ")V"
     )
     )
     private void anvilFallOnGround(CallbackInfo ci, @Local BlockPos blockPos) {
@@ -309,7 +316,12 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     @Inject(
         method = "causeFallDamage", at = @At(
         value = "INVOKE",
-        target = "Lnet/minecraft/world/level/Level;" + "getEntities(" + "Lnet/minecraft/world/entity/Entity;" + "Lnet/minecraft/world/phys/AABB;" + "Ljava/util/function/Predicate;" + ")Ljava/util/List;"
+        target = "Lnet/minecraft/world/level/Level;"
+                 + "getEntities("
+                 + "Lnet/minecraft/world/entity/Entity;"
+                 + "Lnet/minecraft/world/phys/AABB;"
+                 + "Ljava/util/function/Predicate;"
+                 + ")Ljava/util/List;"
     )
     )
     private void anvilHurtEntity(float fallDistance, float multiplier, DamageSource source, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IFallingBlockEntityExtension;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.BlockTags;
@@ -19,6 +20,7 @@ import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -181,5 +183,22 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         if (hitResult.getType() != EntityHitResult.Type.ENTITY) return;
         float hurtAmount = (float) (this.getDeltaMovement().length() * DAMAGE_FACTOR);
         hitResult.getEntity().hurt(damageSources().anvil(this), hurtAmount);
+    }
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void anvilcraft$FallingBlockGravity(CallbackInfo ci) {
+
+        // 如果是无重力实体则返回
+        if (this.isNoGravity()) return;
+
+        // 获取运动向量和重力因子
+        Vec3 v = this.getDeltaMovement();
+        double g = GravityManager.getGravity(this);
+
+        if (v.y < 0) { // 下落的重力方块
+            this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * g, 0.0));
+        } else if (v.y > 0) { // 上升的重力方块
+            this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * -g, 0.0));
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -225,7 +225,7 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         Vec3 blockGravity = GravityManager.getNetGravityVectorForFallingBlock(
             instance.level(),
             Vec3.atCenterOf(pos),
-            GravityManager.getFallingBlockGravityType(instance.blockState.getBlock())
+            GravityManager.getGravityType(instance)
         );
 
         // 如果方块位置无重力，认为是稳定的

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
-import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -193,7 +192,6 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         // 如果是无重力实体则返回
         if (this.isNoGravity()) return;
         // 根据重力方向调整移动向量
-        Vec3 movement = GravityManager.applyGravity(this, this.getDeltaMovement());
-        this.setDeltaMovement(movement);
+        this.setDeltaMovement(GravityManager.applyGravity(this, this.getDeltaMovement()));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -1,5 +1,7 @@
 package dev.dubhe.anvilcraft.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IFallingBlockEntityExtension;
@@ -7,6 +9,7 @@ import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
@@ -15,12 +18,15 @@ import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -43,16 +49,217 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @Shadow
     public boolean cancelDrop;
-
+    @Shadow
+    public boolean dropItem;
     @Shadow
     private float fallDamagePerDistance;
     @Shadow
     private int fallDamageMax;
     @Unique
     private float anvilcraft$fallDistance;
+    @Unique
+    private BlockPos anvilcraft$cachedSupportPos;
 
     public FallingBlockEntityMixin(EntityType<?> entityType, Level level) {
         super(entityType, level);
+    }
+
+    // 重定义下落方块的下方
+    @WrapOperation(
+        method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;below()Lnet/minecraft/core/BlockPos;")
+    )
+    private BlockPos anvilcraft$redirectBelowInTick(BlockPos instance, Operation<BlockPos> original) {
+        Vec3 netGravityVector = GravityManager.getNetGravityVectorForFallingBlock(this);
+        // 如果重力向下且没有显著水平分量，使用原版逻辑
+        if (netGravityVector.y < -0.01 && Math.abs(netGravityVector.x) < 0.1 && Math.abs(netGravityVector.z) < 0.1) {
+            return original.call(instance);
+        }
+        // 卡在方块里则当前坐标是下方
+        if (!FallingBlock.isFree(this.level().getBlockState(instance))) {
+            return instance;
+        }
+        // 总重力向量的方向是下落方块的下方
+        Direction gravityDirection = Direction.getNearest(netGravityVector.x, netGravityVector.y, netGravityVector.z);
+        return instance.relative(gravityDirection);
+    }
+
+    /**
+     * 拦截原版的 onGround() 检查，接管方块是否应该变成实体的逻辑。
+     * 主逻辑 ↓
+     */
+    @WrapOperation(
+        method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;onGround()Z")
+    )
+    private boolean anvilcraft$overrideOnGround(FallingBlockEntity instance, Operation<Boolean> original) {
+        Vec3 gravityVec = GravityManager.getNetGravityVectorForFallingBlock(instance);
+
+        // 0. 平衡环境保持实体状态（大概也许可能可以叫拉格朗日点？）
+        if (gravityVec.lengthSqr() < 1.0E-5) return false;
+
+        Direction gravityDir = Direction.getNearest(gravityVec.x, gravityVec.y, gravityVec.z);
+
+        // 1. 物理碰撞检测
+        if (!this.anvilcraft$checkCollision(instance, gravityDir, original)) {
+            return false;
+        }
+
+        // 准备上下文数据
+        Level level = instance.level();
+        BlockPos pos = BlockPos.containing(instance.position());
+        BlockPos supportPos = pos.relative(gravityDir);
+        BlockState supportState = level.getBlockState(supportPos);
+
+        // 2. 摩擦力与滑行检查
+        float friction = supportState.isAir() ? 0.6F : supportState.getFriction(level, supportPos, instance);
+        boolean isMovingSlowly = instance.getDeltaMovement().lengthSqr() < 0.04;
+
+        // 如果速度慢且被摩擦力抓住 -> 着陆，否则 -> 滑行
+        boolean heldByFriction = isMovingSlowly && this.anvilcraft$isHeldByFriction(gravityVec, gravityDir, friction);
+
+        // 如果没被摩擦力抓住 且 有路可走 -> 滑行
+        if (!heldByFriction && this.anvilcraft$hasSlidingPath(level, pos, gravityVec, gravityDir)) {
+            return false;
+        }
+
+        // 3. 稳定性预判
+        // 模拟变成方块后的受力，防止变成方块后立刻又变成实体
+        if (!this.anvilcraft$predictStability(instance, pos)) {
+            return false;
+        }
+
+        // 4. 不完整方块检查
+        if (!supportState.isFaceSturdy(level, supportPos, gravityDir.getOpposite())) {
+            // 如果面不完整，检查碰撞箱
+            VoxelShape shape = supportState.getCollisionShape(level, supportPos);
+            boolean isFullHeight;
+
+            // 根据重力方向判断检查最大值还是最小值
+            if (gravityDir.getAxisDirection() == Direction.AxisDirection.NEGATIVE) {
+                // 向下落撞击顶面，检查 shape.max(axis) 是否接近 1.0
+                isFullHeight = shape.max(gravityDir.getAxis()) >= 1.0 - 1.0E-5;
+            } else {
+                // 向上飞撞击底面，检查 shape.min(axis) 是否接近 0.0
+                isFullHeight = shape.min(gravityDir.getAxis()) <= 1.0E-5;
+            }
+
+            if (!isFullHeight) {
+                this.anvilcraft$breakEntity(instance);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 辅助方法：检查特定方向是否发生了碰撞
+     */
+    @Unique
+    private boolean anvilcraft$checkCollision(FallingBlockEntity entity, Direction gravityDir, Operation<Boolean> original) {
+        if (gravityDir == Direction.DOWN) {
+            return original.call(entity);
+        } else if (gravityDir == Direction.UP) {
+            return entity.verticalCollision && !original.call(entity);
+        } else {
+            return entity.horizontalCollision;
+        }
+    }
+
+    /**
+     * 辅助方法：计算切向力与摩擦力，判断是否能稳住
+     */
+    @Unique
+    private boolean anvilcraft$isHeldByFriction(Vec3 gravity, Direction gravityDir, float friction) {
+        double totalGravitySq = gravity.lengthSqr();
+        double normalForce = Math.abs(gravity.get(gravityDir.getAxis()));
+        // 切向力 = sqrt(总力^2 - 法向力^2)
+        double tangentialForce = Math.sqrt(Math.max(0, totalGravitySq - normalForce * normalForce));
+        double grip = 1.0 - friction;
+
+        // 判定阈值：切向力 < 最大静摩擦力
+        return tangentialForce < normalForce * grip * 2.0;
+    }
+
+    /**
+     * 辅助方法：检查三个轴向上是否存在可以滑行的空位
+     */
+    @Unique
+    private boolean anvilcraft$hasSlidingPath(Level level, BlockPos currentPos, Vec3 gravity, Direction primaryDir) {
+        if (this.anvilcraft$checkAxisSlide(level, currentPos, gravity.x, Direction.EAST, Direction.WEST, primaryDir)) return true;
+        if (this.anvilcraft$checkAxisSlide(level, currentPos, gravity.y, Direction.UP, Direction.DOWN, primaryDir)) return true;
+        return this.anvilcraft$checkAxisSlide(level, currentPos, gravity.z, Direction.SOUTH, Direction.NORTH, primaryDir);
+    }
+
+    /**
+     * 单轴滑行检查
+     */
+    @Unique
+    private boolean anvilcraft$checkAxisSlide(
+        Level level,
+        BlockPos pos,
+        double component,
+        Direction posDir,
+        Direction negDir,
+        Direction forbiddenDir
+    ) {
+        if (Math.abs(component) <= 1.0E-5) return false;
+
+        Direction targetDir = component > 0 ? posDir : negDir;
+        // 不能向地板滑行
+        if (targetDir == forbiddenDir) return false;
+
+        return FallingBlock.isFree(level.getBlockState(pos.relative(targetDir)));
+    }
+
+    /**
+     * 辅助方法：预测变成方块后的稳定性
+     *
+     * @return true 表示稳定（可以着陆），false 表示不稳定（应该保持实体）
+     */
+    @Unique
+    private boolean anvilcraft$predictStability(FallingBlockEntity instance, BlockPos pos) {
+        // 如果在方块里直接稳定
+        if (!FallingBlock.isFree(instance.level().getBlockState(pos))) {
+            return true;
+        }
+
+        Vec3 blockGravity = GravityManager.getNetGravityVectorForFallingBlock(
+            instance.level(),
+            Vec3.atCenterOf(pos),
+            GravityManager.getFallingBlockGravityType(instance.blockState.getBlock())
+        );
+
+        // 如果方块位置无重力，认为是稳定的
+        if (blockGravity.lengthSqr() <= 1.0E-5) return true;
+
+        Direction dir = Direction.getNearest(blockGravity.x, blockGravity.y, blockGravity.z);
+        BlockPos targetPos = pos.relative(dir);
+        BlockState targetState = instance.level().getBlockState(targetPos);
+
+        // 主方向是空的 -> 不稳定
+        if (FallingBlock.isFree(targetState)) return false;
+
+        // 主方向有方块，检查摩擦力
+        float friction = targetState.getFriction(instance.level(), targetPos, null);
+
+        // 被摩擦力抓住则稳定，没被抓住则不稳定
+        boolean heldByFriction = this.anvilcraft$isHeldByFriction(blockGravity, dir, friction);
+
+        if (!heldByFriction && this.anvilcraft$hasSlidingPath(instance.level(), pos, blockGravity, dir)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 辅助方法：碎裂掉落逻辑
+     */
+    @Unique
+    private void anvilcraft$breakEntity(FallingBlockEntity instance) {
+        if (this.dropItem && instance.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+            instance.spawnAtLocation(instance.getBlockState().getBlock());
+        }
+        instance.discard();
     }
 
     @Inject(
@@ -105,12 +312,7 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         target = "Lnet/minecraft/world/level/Level;" + "getEntities(" + "Lnet/minecraft/world/entity/Entity;" + "Lnet/minecraft/world/phys/AABB;" + "Ljava/util/function/Predicate;" + ")Ljava/util/List;"
     )
     )
-    private void anvilHurtEntity(
-        float fallDistance,
-        float multiplier,
-        DamageSource source,
-        CallbackInfoReturnable<Boolean> cir
-    ) {
+    private void anvilHurtEntity(float fallDistance, float multiplier, DamageSource source, CallbackInfoReturnable<Boolean> cir) {
         Level level = this.level();
         FallingBlockEntity fallingBlockEntity = Util.cast(this);
         Predicate<Entity> predicate = EntitySelector.NO_CREATIVE_OR_SPECTATOR.and(EntitySelector.LIVING_ENTITY_STILL_ALIVE);
@@ -155,8 +357,7 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     }
 
     @Inject(
-        method = "tick",
-        at = @At("TAIL")
+        method = "tick", at = @At("TAIL")
     )
     private void anvilcraft$ApplyFallingBlockGravity(CallbackInfo ci) {
         // 如果是无重力实体则返回

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -189,12 +190,10 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         at = @At("TAIL")
     )
     private void anvilcraft$FallingBlockGravity(CallbackInfo ci) {
-
         // 如果是无重力实体则返回
         if (this.isNoGravity()) return;
-
-        // 获取重力常数并应用
-        double g = GravityManager.getGravity(this);
-        this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * (1 - g), 0.0));
+        // 根据重力方向调整移动向量
+        Vec3 movement = GravityManager.applyGravity(this, this.getDeltaMovement());
+        this.setDeltaMovement(movement);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -1,5 +1,7 @@
 package dev.dubhe.anvilcraft.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IFallingBlockEntityExtension;
@@ -7,6 +9,7 @@ import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
@@ -15,12 +18,15 @@ import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -43,26 +49,225 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @Shadow
     public boolean cancelDrop;
-
+    @Shadow
+    public boolean dropItem;
     @Shadow
     private float fallDamagePerDistance;
     @Shadow
     private int fallDamageMax;
     @Unique
     private float anvilcraft$fallDistance;
+    @Unique
+    private BlockPos anvilcraft$cachedSupportPos;
 
     public FallingBlockEntityMixin(EntityType<?> entityType, Level level) {
         super(entityType, level);
     }
 
+    // 重定义下落方块的下方
+    @WrapOperation(
+        method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;below()Lnet/minecraft/core/BlockPos;")
+    )
+    private BlockPos anvilcraft$redirectBelowInTick(BlockPos instance, Operation<BlockPos> original) {
+        Vec3 netGravityVector = GravityManager.getNetGravityVectorForFallingBlock(this);
+        // 如果重力向下且没有显著水平分量，使用原版逻辑
+        if (netGravityVector.y < -0.01 && Math.abs(netGravityVector.x) < 0.1 && Math.abs(netGravityVector.z) < 0.1) {
+            return original.call(instance);
+        }
+        // 卡在方块里则当前坐标是下方
+        if (!FallingBlock.isFree(this.level().getBlockState(instance))) {
+            return instance;
+        }
+        // 总重力向量的方向是下落方块的下方
+        Direction gravityDirection = Direction.getNearest(netGravityVector.x, netGravityVector.y, netGravityVector.z);
+        return instance.relative(gravityDirection);
+    }
+
+    /**
+     * 拦截原版的 onGround() 检查，接管方块是否应该变成实体的逻辑。
+     * 主逻辑 ↓
+     */
+    @WrapOperation(
+        method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;onGround()Z")
+    )
+    private boolean anvilcraft$overrideOnGround(FallingBlockEntity instance, Operation<Boolean> original) {
+        Vec3 gravityVec = GravityManager.getNetGravityVectorForFallingBlock(instance);
+
+        // 0. 平衡环境保持实体状态（大概也许可能可以叫拉格朗日点？）
+        if (gravityVec.lengthSqr() < 1.0E-5) return false;
+
+        Direction gravityDir = Direction.getNearest(gravityVec.x, gravityVec.y, gravityVec.z);
+
+        // 1. 物理碰撞检测
+        if (!this.anvilcraft$checkCollision(instance, gravityDir, original)) {
+            return false;
+        }
+
+        // 准备上下文数据
+        Level level = instance.level();
+        BlockPos pos = BlockPos.containing(instance.position());
+        BlockPos supportPos = pos.relative(gravityDir);
+        BlockState supportState = level.getBlockState(supportPos);
+
+        // 2. 摩擦力与滑行检查
+        float friction = supportState.isAir() ? 0.6F : supportState.getFriction(level, supportPos, instance);
+        boolean isMovingSlowly = instance.getDeltaMovement().lengthSqr() < 0.04;
+
+        // 如果速度慢且被摩擦力抓住 -> 着陆，否则 -> 滑行
+        boolean heldByFriction = isMovingSlowly && this.anvilcraft$isHeldByFriction(gravityVec, gravityDir, friction);
+
+        // 如果没被摩擦力抓住 且 有路可走 -> 滑行
+        if (!heldByFriction && this.anvilcraft$hasSlidingPath(level, pos, gravityVec, gravityDir)) {
+            return false;
+        }
+
+        // 3. 稳定性预判
+        // 模拟变成方块后的受力，防止变成方块后立刻又变成实体
+        if (!this.anvilcraft$predictStability(instance, pos)) {
+            return false;
+        }
+
+        // 4. 不完整方块检查
+        if (!supportState.isFaceSturdy(level, supportPos, gravityDir.getOpposite())) {
+            // 如果面不完整，检查碰撞箱
+            VoxelShape shape = supportState.getCollisionShape(level, supportPos);
+            boolean isFullHeight;
+
+            // 根据重力方向判断检查最大值还是最小值
+            if (gravityDir.getAxisDirection() == Direction.AxisDirection.NEGATIVE) {
+                // 向下落撞击顶面，检查 shape.max(axis) 是否接近 1.0
+                isFullHeight = shape.max(gravityDir.getAxis()) >= 1.0 - 1.0E-5;
+            } else {
+                // 向上飞撞击底面，检查 shape.min(axis) 是否接近 0.0
+                isFullHeight = shape.min(gravityDir.getAxis()) <= 1.0E-5;
+            }
+
+            if (!isFullHeight) {
+                this.anvilcraft$breakEntity(instance);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 辅助方法：检查特定方向是否发生了碰撞
+     */
+    @Unique
+    private boolean anvilcraft$checkCollision(FallingBlockEntity entity, Direction gravityDir, Operation<Boolean> original) {
+        if (gravityDir == Direction.DOWN) {
+            return original.call(entity);
+        } else if (gravityDir == Direction.UP) {
+            return entity.verticalCollision && !original.call(entity);
+        } else {
+            return entity.horizontalCollision;
+        }
+    }
+
+    /**
+     * 辅助方法：计算切向力与摩擦力，判断是否能稳住
+     */
+    @Unique
+    private boolean anvilcraft$isHeldByFriction(Vec3 gravity, Direction gravityDir, float friction) {
+        double totalGravitySq = gravity.lengthSqr();
+        double normalForce = Math.abs(gravity.get(gravityDir.getAxis()));
+        // 切向力 = sqrt(总力^2 - 法向力^2)
+        double tangentialForce = Math.sqrt(Math.max(0, totalGravitySq - normalForce * normalForce));
+        double grip = 1.0 - friction;
+
+        // 判定阈值：切向力 < 最大静摩擦力
+        return tangentialForce < normalForce * grip * 2.0;
+    }
+
+    /**
+     * 辅助方法：检查三个轴向上是否存在可以滑行的空位
+     */
+    @Unique
+    private boolean anvilcraft$hasSlidingPath(Level level, BlockPos currentPos, Vec3 gravity, Direction primaryDir) {
+        if (this.anvilcraft$checkAxisSlide(level, currentPos, gravity.x, Direction.EAST, Direction.WEST, primaryDir)) return true;
+        if (this.anvilcraft$checkAxisSlide(level, currentPos, gravity.y, Direction.UP, Direction.DOWN, primaryDir)) return true;
+        return this.anvilcraft$checkAxisSlide(level, currentPos, gravity.z, Direction.SOUTH, Direction.NORTH, primaryDir);
+    }
+
+    /**
+     * 单轴滑行检查
+     */
+    @Unique
+    private boolean anvilcraft$checkAxisSlide(
+        Level level,
+        BlockPos pos,
+        double component,
+        Direction posDir,
+        Direction negDir,
+        Direction forbiddenDir
+    ) {
+        if (Math.abs(component) <= 1.0E-5) return false;
+
+        Direction targetDir = component > 0 ? posDir : negDir;
+        // 不能向地板滑行
+        if (targetDir == forbiddenDir) return false;
+
+        return FallingBlock.isFree(level.getBlockState(pos.relative(targetDir)));
+    }
+
+    /**
+     * 辅助方法：预测变成方块后的稳定性
+     *
+     * @return true 表示稳定（可以着陆），false 表示不稳定（应该保持实体）
+     */
+    @Unique
+    private boolean anvilcraft$predictStability(FallingBlockEntity instance, BlockPos pos) {
+        // 如果在方块里直接稳定
+        if (!FallingBlock.isFree(instance.level().getBlockState(pos))) {
+            return true;
+        }
+
+        Vec3 blockGravity = GravityManager.getNetGravityVectorForFallingBlock(
+            instance.level(),
+            Vec3.atCenterOf(pos),
+            GravityManager.getFallingBlockGravityType(instance.blockState.getBlock())
+        );
+
+        // 如果方块位置无重力，认为是稳定的
+        if (blockGravity.lengthSqr() <= 1.0E-5) return true;
+
+        Direction dir = Direction.getNearest(blockGravity.x, blockGravity.y, blockGravity.z);
+        BlockPos targetPos = pos.relative(dir);
+        BlockState targetState = instance.level().getBlockState(targetPos);
+
+        // 主方向是空的 -> 不稳定
+        if (FallingBlock.isFree(targetState)) return false;
+
+        // 主方向有方块，检查摩擦力
+        float friction = targetState.getFriction(instance.level(), targetPos, null);
+
+        // 被摩擦力抓住则稳定，没被抓住则不稳定
+        boolean heldByFriction = this.anvilcraft$isHeldByFriction(blockGravity, dir, friction);
+
+        if (!heldByFriction && this.anvilcraft$hasSlidingPath(instance.level(), pos, blockGravity, dir)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 辅助方法：碎裂掉落逻辑
+     */
+    @Unique
+    private void anvilcraft$breakEntity(FallingBlockEntity instance) {
+        if (this.dropItem && instance.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
+            instance.spawnAtLocation(instance.getBlockState().getBlock());
+        }
+        instance.discard();
+    }
+
     @Inject(
-        method = "tick",
-        at =
-        @At(
-            value = "INVOKE",
-            ordinal = 0,
-            target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;level()Lnet/minecraft/world/level/Level;"
-        )
+        method = "tick", at = @At(
+        value = "INVOKE",
+        ordinal = 0,
+        target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;level()Lnet/minecraft/world/level/Level;"
+    )
     )
     private void anvilPerFallOnGround(CallbackInfo ci) {
         if (this.level().isClientSide()) return;
@@ -77,19 +282,17 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @SuppressWarnings("UnreachableCode")
     @Inject(
-        method = "tick",
-        at =
-        @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/Fallable;"
-                     + "onLand("
-                     + "Lnet/minecraft/world/level/Level;"
-                     + "Lnet/minecraft/core/BlockPos;"
-                     + "Lnet/minecraft/world/level/block/state/BlockState;"
-                     + "Lnet/minecraft/world/level/block/state/BlockState;"
-                     + "Lnet/minecraft/world/entity/item/FallingBlockEntity;"
-                     + ")V"
-        )
+        method = "tick", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/level/block/Fallable;"
+                 + "onLand("
+                 + "Lnet/minecraft/world/level/Level;"
+                 + "Lnet/minecraft/core/BlockPos;"
+                 + "Lnet/minecraft/world/level/block/state/BlockState;"
+                 + "Lnet/minecraft/world/level/block/state/BlockState;"
+                 + "Lnet/minecraft/world/entity/item/FallingBlockEntity;"
+                 + ")V"
+    )
     )
     private void anvilFallOnGround(CallbackInfo ci, @Local BlockPos blockPos) {
         if (this.level().isClientSide()) return;
@@ -98,9 +301,7 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, entity, this.anvilcraft$fallDistance);
         NeoForge.EVENT_BUS.post(event);
         if (event.isAnvilDamage()) {
-            BlockState state = this.blockState.is(ModBlocks.ROYAL_ANVIL.get())
-                               ? this.blockState
-                               : AnvilBlock.damage(this.blockState);
+            BlockState state = this.blockState.is(ModBlocks.ROYAL_ANVIL.get()) ? this.blockState : AnvilBlock.damage(this.blockState);
             if (state != null) {
                 this.level().setBlockAndUpdate(blockPos, state);
             } else {
@@ -113,24 +314,17 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @SuppressWarnings("UnreachableCode")
     @Inject(
-        method = "causeFallDamage",
-        at =
-        @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/Level;"
-                     + "getEntities("
-                     + "Lnet/minecraft/world/entity/Entity;"
-                     + "Lnet/minecraft/world/phys/AABB;"
-                     + "Ljava/util/function/Predicate;"
-                     + ")Ljava/util/List;"
-        )
+        method = "causeFallDamage", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/level/Level;"
+                 + "getEntities("
+                 + "Lnet/minecraft/world/entity/Entity;"
+                 + "Lnet/minecraft/world/phys/AABB;"
+                 + "Ljava/util/function/Predicate;"
+                 + ")Ljava/util/List;"
     )
-    private void anvilHurtEntity(
-        float fallDistance,
-        float multiplier,
-        DamageSource source,
-        CallbackInfoReturnable<Boolean> cir
-    ) {
+    )
+    private void anvilHurtEntity(float fallDistance, float multiplier, DamageSource source, CallbackInfoReturnable<Boolean> cir) {
         Level level = this.level();
         FallingBlockEntity fallingBlockEntity = Util.cast(this);
         Predicate<Entity> predicate = EntitySelector.NO_CREATIVE_OR_SPECTATOR.and(EntitySelector.LIVING_ENTITY_STILL_ALIVE);
@@ -145,38 +339,27 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     }
 
     @Inject(
-        method = "tick",
-        at =
-        @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V",
-            ordinal = 1
-        )
+        method = "tick", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V",
+        ordinal = 1
+    )
     )
     private void hurtEntity(CallbackInfo ci) {
-        if (
-            this.getDeltaMovement().multiply(1, 0, 1).length() < 0.75
-            && this.getDeltaMovement().y < 2.5
-        ) {
+        if (this.getDeltaMovement().multiply(1, 0, 1).length() < 0.75 && this.getDeltaMovement().y < 2.5) {
             return;
         }
         if (!this.blockState.is(BlockTags.ANVIL)) return;
         EntityHitResult hitResult = ProjectileUtil.getEntityHitResult(
             this.level(),
             this,
-            this.position().subtract(0, 0.5, 0).subtract(
-                this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()
-            ),
+            this.position()
+                .subtract(0, 0.5, 0)
+                .subtract(this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()),
             this.position().subtract(0, 0.5, 0),
-            this.getBoundingBox()
-                .expandTowards(
-                    (
-                        this.anvilcraft$isDeflected()
-                        ? this.anvilcraft$getFixedDeltaMovement()
-                        : this.getDeltaMovement()
-                    ).multiply(-1, -1, -1)
-                )
-                .inflate(1.0),
+            this.getBoundingBox().expandTowards((
+                this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()
+            ).multiply(-1, -1, -1)).inflate(1.0),
             Entity::isAttackable
         );
         if (hitResult == null) return;
@@ -185,20 +368,14 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         hitResult.getEntity().hurt(damageSources().anvil(this), hurtAmount);
     }
 
-    @Inject(method = "tick", at = @At("TAIL"))
-    private void anvilcraft$FallingBlockGravity(CallbackInfo ci) {
-
+    @Inject(
+        method = "tick", at = @At("TAIL")
+    )
+    private void anvilcraft$ApplyFallingBlockGravity(CallbackInfo ci) {
         // 如果是无重力实体则返回
         if (this.isNoGravity()) return;
-
-        // 获取运动向量和重力因子
-        Vec3 v = this.getDeltaMovement();
-        double g = GravityManager.getGravity(this);
-
-        if (v.y < 0) { // 下落的重力方块
-            this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * g, 0.0));
-        } else if (v.y > 0) { // 上升的重力方块
-            this.setDeltaMovement(this.getDeltaMovement().add(0.0, 0.04 * -g, 0.0));
-        }
+        // 应用引力向量的水平分量
+        Vec3 gravityVector = GravityManager.getGravityVector(this);
+        this.setDeltaMovement(this.getDeltaMovement().add(gravityVector.x, 0, gravityVector.z));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -192,6 +192,6 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         // 如果是无重力实体则返回
         if (this.isNoGravity()) return;
         // 根据重力方向调整移动向量
-        this.setDeltaMovement(GravityManager.applyGravity(this, this.getDeltaMovement()));
+        this.setDeltaMovement(GravityManager.getGravityVector(this));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockEntityMixin.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -55,13 +56,11 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     }
 
     @Inject(
-        method = "tick",
-        at =
-        @At(
-            value = "INVOKE",
-            ordinal = 0,
-            target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;level()Lnet/minecraft/world/level/Level;"
-        )
+        method = "tick", at = @At(
+        value = "INVOKE",
+        ordinal = 0,
+        target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;level()Lnet/minecraft/world/level/Level;"
+    )
     )
     private void anvilPerFallOnGround(CallbackInfo ci) {
         if (this.level().isClientSide()) return;
@@ -76,19 +75,10 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @SuppressWarnings("UnreachableCode")
     @Inject(
-        method = "tick",
-        at =
-        @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/Fallable;"
-                     + "onLand("
-                     + "Lnet/minecraft/world/level/Level;"
-                     + "Lnet/minecraft/core/BlockPos;"
-                     + "Lnet/minecraft/world/level/block/state/BlockState;"
-                     + "Lnet/minecraft/world/level/block/state/BlockState;"
-                     + "Lnet/minecraft/world/entity/item/FallingBlockEntity;"
-                     + ")V"
-        )
+        method = "tick", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/level/block/Fallable;" + "onLand(" + "Lnet/minecraft/world/level/Level;" + "Lnet/minecraft/core/BlockPos;" + "Lnet/minecraft/world/level/block/state/BlockState;" + "Lnet/minecraft/world/level/block/state/BlockState;" + "Lnet/minecraft/world/entity/item/FallingBlockEntity;" + ")V"
+    )
     )
     private void anvilFallOnGround(CallbackInfo ci, @Local BlockPos blockPos) {
         if (this.level().isClientSide()) return;
@@ -97,9 +87,7 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         AnvilEvent.OnLand event = new AnvilEvent.OnLand(this.level(), blockPos, entity, this.anvilcraft$fallDistance);
         NeoForge.EVENT_BUS.post(event);
         if (event.isAnvilDamage()) {
-            BlockState state = this.blockState.is(ModBlocks.ROYAL_ANVIL.get())
-                               ? this.blockState
-                               : AnvilBlock.damage(this.blockState);
+            BlockState state = this.blockState.is(ModBlocks.ROYAL_ANVIL.get()) ? this.blockState : AnvilBlock.damage(this.blockState);
             if (state != null) {
                 this.level().setBlockAndUpdate(blockPos, state);
             } else {
@@ -112,17 +100,10 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
 
     @SuppressWarnings("UnreachableCode")
     @Inject(
-        method = "causeFallDamage",
-        at =
-        @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/Level;"
-                     + "getEntities("
-                     + "Lnet/minecraft/world/entity/Entity;"
-                     + "Lnet/minecraft/world/phys/AABB;"
-                     + "Ljava/util/function/Predicate;"
-                     + ")Ljava/util/List;"
-        )
+        method = "causeFallDamage", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/level/Level;" + "getEntities(" + "Lnet/minecraft/world/entity/Entity;" + "Lnet/minecraft/world/phys/AABB;" + "Ljava/util/function/Predicate;" + ")Ljava/util/List;"
+    )
     )
     private void anvilHurtEntity(
         float fallDistance,
@@ -144,38 +125,27 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
     }
 
     @Inject(
-        method = "tick",
-        at =
-        @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V",
-            ordinal = 1
-        )
+        method = "tick", at = @At(
+        value = "INVOKE",
+        target = "Lnet/minecraft/world/entity/item/FallingBlockEntity;setDeltaMovement(Lnet/minecraft/world/phys/Vec3;)V",
+        ordinal = 1
+    )
     )
     private void hurtEntity(CallbackInfo ci) {
-        if (
-            this.getDeltaMovement().multiply(1, 0, 1).length() < 0.75
-            && this.getDeltaMovement().y < 2.5
-        ) {
+        if (this.getDeltaMovement().multiply(1, 0, 1).length() < 0.75 && this.getDeltaMovement().y < 2.5) {
             return;
         }
         if (!this.blockState.is(BlockTags.ANVIL)) return;
         EntityHitResult hitResult = ProjectileUtil.getEntityHitResult(
             this.level(),
             this,
-            this.position().subtract(0, 0.5, 0).subtract(
-                this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()
-            ),
+            this.position()
+                .subtract(0, 0.5, 0)
+                .subtract(this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()),
             this.position().subtract(0, 0.5, 0),
-            this.getBoundingBox()
-                .expandTowards(
-                    (
-                        this.anvilcraft$isDeflected()
-                        ? this.anvilcraft$getFixedDeltaMovement()
-                        : this.getDeltaMovement()
-                    ).multiply(-1, -1, -1)
-                )
-                .inflate(1.0),
+            this.getBoundingBox().expandTowards((
+                this.anvilcraft$isDeflected() ? this.anvilcraft$getFixedDeltaMovement() : this.getDeltaMovement()
+            ).multiply(-1, -1, -1)).inflate(1.0),
             Entity::isAttackable
         );
         if (hitResult == null) return;
@@ -188,10 +158,11 @@ abstract class FallingBlockEntityMixin extends Entity implements IFallingBlockEn
         method = "tick",
         at = @At("TAIL")
     )
-    private void anvilcraft$FallingBlockGravity(CallbackInfo ci) {
+    private void anvilcraft$ApplyFallingBlockGravity(CallbackInfo ci) {
         // 如果是无重力实体则返回
         if (this.isNoGravity()) return;
-        // 根据重力方向调整移动向量
-        this.setDeltaMovement(GravityManager.getGravityVector(this));
+        // 应用引力向量的水平分量
+        Vec3 gravityVector = GravityManager.getGravityVector(this);
+        this.setDeltaMovement(this.getDeltaMovement().add(gravityVector.x, 0, gravityVector.z));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
@@ -35,28 +35,65 @@ public abstract class FallingBlockMixin extends Block {
         at = @At("HEAD"),
         cancellable = true
     )
-    private void anvilcraft$SmartFallingLogic(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
-        // 获取重力方向和大小
+    private void anvilcraft$FallingLogic(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
+        // 1. 计算净重力
         GravityManager.GravityType gravityType = GravityManager.getFallingBlockGravityType(state.getBlock());
-        double gravity = (gravityType == GravityManager.GravityType.ANTI_GRAVITY) ? 0.04 : -0.04;
+        Vec3 netGravity = GravityManager.getNetGravityVectorForFallingBlock(level, Vec3.atCenterOf(pos), gravityType);
+        double gravitySq = netGravity.lengthSqr();
 
-        // G取0.04计算重力大小
-        Vec3 gravityVector = GravityManager.GravitySourceManager.calculateGravityVector(level, Vec3.atCenterOf(pos), 0.04);
-
-        // 漂浮粉块反向重力
-        if (gravityType == GravityManager.GravityType.ANTI_GRAVITY) {
-            gravityVector = gravityVector.reverse();
+        // 如果受力极小，忽略
+        if (gravitySq < 1.0E-5) {
+            return;
         }
 
-        // 计算合力 Y 分量
-        double gravityVectorY = gravity + gravityVector.y;
+        // 2. 寻找主受力方向
+        Direction primaryDir = Direction.getNearest(netGravity.x, netGravity.y, netGravity.z);
+        BlockPos targetPos = pos.relative(primaryDir);
+        BlockState targetState = level.getBlockState(targetPos);
 
-        // 如果合力向上，检查上方是否为空；如果合力向下，检查下方是否为空
-        Direction direction = gravityVectorY > 0 ? Direction.UP : Direction.DOWN;
-        BlockPos blockPos = pos.relative(direction);
+        // 3. 判断是否可以直接移动
+        boolean canMove = false;
 
-        // 检查目标位置是否可以让方块移动
-        if (isFree(level.getBlockState(blockPos))) {
+        if (isFree(targetState)) {
+            // 主方向是空的，直接起飞
+            canMove = true;
+        } else {
+            // 主方向被阻挡，检查是否可以克服摩擦力滑行
+            double normalForce = Math.abs(netGravity.get(primaryDir.getAxis()));
+            double tangentialForce = Math.sqrt(Math.max(0, gravitySq - normalForce * normalForce));
+
+            // 获取阻挡方块的摩擦系数
+            float friction = targetState.getFriction(level, targetPos, null);
+            double grip = 1.0 - friction;
+
+            // 只有切向力足够大，才能克服摩擦力开始滑动
+            if (tangentialForce > normalForce * grip * 2.0) {
+                // 摩擦力无法束缚，检查滑动方向是否有空位
+                // 遍历其它轴寻找出路
+
+                // 检查 X 轴
+                if (!canMove && Math.abs(netGravity.x) > 1.0E-5) {
+                    Direction dir = netGravity.x > 0 ? Direction.EAST : Direction.WEST;
+                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
+                }
+                // 检查 Y 轴
+                if (!canMove && Math.abs(netGravity.y) > 1.0E-5) {
+                    Direction dir = netGravity.y > 0 ? Direction.UP : Direction.DOWN;
+                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
+                }
+                // 检查 Z 轴
+                if (!canMove && Math.abs(netGravity.z) > 1.0E-5) {
+                    Direction dir = netGravity.z > 0 ? Direction.SOUTH : Direction.NORTH;
+                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
+                }
+            } else {
+                // 摩擦力太大，被死死按在墙上/地板上/天花板上
+                canMove = false;
+            }
+        }
+
+        // 5. 执行转换
+        if (canMove) {
             if (state.is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
                 LevitatingBlockEntity.levitate(level, pos, state);
             } else {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.item.FallingBlockEntity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -31,11 +32,9 @@ public abstract class FallingBlockMixin extends Block {
     }
 
     @Inject(
-        method = "tick",
-        at = @At("HEAD"),
-        cancellable = true
+        method = "tick", at = @At("HEAD"), cancellable = true
     )
-    private void anvilcraft$FallingLogic(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
+    private void anvilcraft$fall(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
         // 1. 计算净重力
         GravityManager.GravityType gravityType = GravityManager.getFallingBlockGravityType(state.getBlock());
         Vec3 netGravity = GravityManager.getNetGravityVectorForFallingBlock(level, Vec3.atCenterOf(pos), gravityType);
@@ -51,7 +50,7 @@ public abstract class FallingBlockMixin extends Block {
         BlockPos targetPos = pos.relative(primaryDir);
         BlockState targetState = level.getBlockState(targetPos);
 
-        // 3. 判断是否可以直接移动
+        // 3. 判断是否可以移动
         boolean canMove = false;
 
         if (isFree(targetState)) {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -32,67 +31,32 @@ public abstract class FallingBlockMixin extends Block {
     }
 
     @Inject(
-        method = "tick", at = @At("HEAD"), cancellable = true
+        method = "tick",
+        at = @At("HEAD"),
+        cancellable = true
     )
-    private void anvilcraft$fall(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
-        // 1. 计算净重力
+    private void anvilcraft$SmartFallingLogic(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
+        // 获取重力方向和大小
         GravityManager.GravityType gravityType = GravityManager.getFallingBlockGravityType(state.getBlock());
-        Vec3 netGravity = GravityManager.getNetGravityVectorForFallingBlock(level, Vec3.atCenterOf(pos), gravityType);
-        double gravitySq = netGravity.lengthSqr();
+        double gravity = (gravityType == GravityManager.GravityType.ANTI_GRAVITY) ? 0.04 : -0.04;
 
-        // 如果受力极小，忽略
-        if (gravitySq < 1.0E-5) {
-            return;
+        // G取0.04计算重力大小
+        Vec3 gravityVector = GravityManager.GravitySourceManager.calculateGravityVector(level, Vec3.atCenterOf(pos), 0.04);
+
+        // 漂浮粉块反向重力
+        if (gravityType == GravityManager.GravityType.ANTI_GRAVITY) {
+            gravityVector = gravityVector.reverse();
         }
 
-        // 2. 寻找主受力方向
-        Direction primaryDir = Direction.getNearest(netGravity.x, netGravity.y, netGravity.z);
-        BlockPos targetPos = pos.relative(primaryDir);
-        BlockState targetState = level.getBlockState(targetPos);
+        // 计算合力 Y 分量
+        double gravityVectorY = gravity + gravityVector.y;
 
-        // 3. 判断是否可以移动
-        boolean canMove = false;
+        // 如果合力向上，检查上方是否为空；如果合力向下，检查下方是否为空
+        Direction direction = gravityVectorY > 0 ? Direction.UP : Direction.DOWN;
+        BlockPos blockPos = pos.relative(direction);
 
-        if (isFree(targetState)) {
-            // 主方向是空的，直接起飞
-            canMove = true;
-        } else {
-            // 主方向被阻挡，检查是否可以克服摩擦力滑行
-            double normalForce = Math.abs(netGravity.get(primaryDir.getAxis()));
-            double tangentialForce = Math.sqrt(Math.max(0, gravitySq - normalForce * normalForce));
-
-            // 获取阻挡方块的摩擦系数
-            float friction = targetState.getFriction(level, targetPos, null);
-            double grip = 1.0 - friction;
-
-            // 只有切向力足够大，才能克服摩擦力开始滑动
-            if (tangentialForce > normalForce * grip * 2.0) {
-                // 摩擦力无法束缚，检查滑动方向是否有空位
-                // 遍历其它轴寻找出路
-
-                // 检查 X 轴
-                if (!canMove && Math.abs(netGravity.x) > 1.0E-5) {
-                    Direction dir = netGravity.x > 0 ? Direction.EAST : Direction.WEST;
-                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
-                }
-                // 检查 Y 轴
-                if (!canMove && Math.abs(netGravity.y) > 1.0E-5) {
-                    Direction dir = netGravity.y > 0 ? Direction.UP : Direction.DOWN;
-                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
-                }
-                // 检查 Z 轴
-                if (!canMove && Math.abs(netGravity.z) > 1.0E-5) {
-                    Direction dir = netGravity.z > 0 ? Direction.SOUTH : Direction.NORTH;
-                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
-                }
-            } else {
-                // 摩擦力太大，被死死按在墙上/地板上/天花板上
-                canMove = false;
-            }
-        }
-
-        // 5. 执行转换
-        if (canMove) {
+        // 检查目标位置是否可以让方块移动
+        if (isFree(level.getBlockState(blockPos))) {
             if (state.is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
                 LevitatingBlockEntity.levitate(level, pos, state);
             } else {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
@@ -1,0 +1,106 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.util.GravityManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.item.FallingBlockEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FallingBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(FallingBlock.class)
+public abstract class FallingBlockMixin extends Block {
+
+    public FallingBlockMixin(Properties properties) {
+        super(properties);
+    }
+
+    @Shadow
+    public static boolean isFree(BlockState state) {
+        throw new AssertionError();
+    }
+
+    @Inject(
+        method = "tick", at = @At("HEAD"), cancellable = true
+    )
+    private void anvilcraft$fall(BlockState state, ServerLevel level, BlockPos pos, RandomSource random, CallbackInfo ci) {
+        // 1. 计算净重力
+        GravityManager.GravityType gravityType = GravityManager.getFallingBlockGravityType(state.getBlock());
+        Vec3 netGravity = GravityManager.getNetGravityVectorForFallingBlock(level, Vec3.atCenterOf(pos), gravityType);
+        double gravitySq = netGravity.lengthSqr();
+
+        // 如果受力极小，忽略
+        if (gravitySq < 1.0E-5) {
+            return;
+        }
+
+        // 2. 寻找主受力方向
+        Direction primaryDir = Direction.getNearest(netGravity.x, netGravity.y, netGravity.z);
+        BlockPos targetPos = pos.relative(primaryDir);
+        BlockState targetState = level.getBlockState(targetPos);
+
+        // 3. 判断是否可以移动
+        boolean canMove = false;
+
+        if (isFree(targetState)) {
+            // 主方向是空的，直接起飞
+            canMove = true;
+        } else {
+            // 主方向被阻挡，检查是否可以克服摩擦力滑行
+            double normalForce = Math.abs(netGravity.get(primaryDir.getAxis()));
+            double tangentialForce = Math.sqrt(Math.max(0, gravitySq - normalForce * normalForce));
+
+            // 获取阻挡方块的摩擦系数
+            float friction = targetState.getFriction(level, targetPos, null);
+            double grip = 1.0 - friction;
+
+            // 只有切向力足够大，才能克服摩擦力开始滑动
+            if (tangentialForce > normalForce * grip * 2.0) {
+                // 摩擦力无法束缚，检查滑动方向是否有空位
+                // 遍历其它轴寻找出路
+
+                // 检查 X 轴
+                if (!canMove && Math.abs(netGravity.x) > 1.0E-5) {
+                    Direction dir = netGravity.x > 0 ? Direction.EAST : Direction.WEST;
+                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
+                }
+                // 检查 Y 轴
+                if (!canMove && Math.abs(netGravity.y) > 1.0E-5) {
+                    Direction dir = netGravity.y > 0 ? Direction.UP : Direction.DOWN;
+                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
+                }
+                // 检查 Z 轴
+                if (!canMove && Math.abs(netGravity.z) > 1.0E-5) {
+                    Direction dir = netGravity.z > 0 ? Direction.SOUTH : Direction.NORTH;
+                    if (dir != primaryDir && isFree(level.getBlockState(pos.relative(dir)))) canMove = true;
+                }
+            } else {
+                // 摩擦力太大，被死死按在墙上/地板上/天花板上
+                canMove = false;
+            }
+        }
+
+        // 5. 执行转换
+        if (canMove) {
+            if (state.is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+                LevitatingBlockEntity.levitate(level, pos, state);
+            } else {
+                FallingBlockEntity.fall(level, pos, state);
+            }
+            ci.cancel();
+        } else {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -7,11 +7,9 @@ import dev.dubhe.anvilcraft.api.injection.entity.IItemEntityExtension;
 import dev.dubhe.anvilcraft.block.ItemCollectorBlock;
 import dev.dubhe.anvilcraft.block.entity.ItemCollectorBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
-import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -98,30 +96,6 @@ abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
             ));
         }
         this.anvilcraft$blockPos = blockPos;
-    }
-
-    @WrapOperation(
-        method = "tick",
-        at = @At(
-            value = "INVOKE",
-            target =
-                "Lnet/minecraft/world/entity/item/ItemEntity;"
-                + "getDeltaMovement()Lnet/minecraft/world/phys/Vec3;"
-        )
-    )
-    private Vec3 anomalousGravity(ItemEntity instance, Operation<Vec3> original) {
-        Vec3 vec3 = original.call(instance);
-        vec3 = GravityManager.applyGravity(instance, vec3);
-        double dy = 1;
-        if (this.getItem().is(ModItemTags.LEVITATIONALS)) dy *= -0.005;
-        if (this.getItem().is(ModItems.NEGATIVE_MATTER_NUGGET)
-            || this.getItem().is(ModItems.NEGATIVE_MATTER)
-            || this.getItem().is(ModBlocks.NEGATIVE_MATTER_BLOCK.asItem())) {
-            if (this.position().y <= this.level().getMaxBuildHeight()) {
-                if (vec3.y < 0) dy *= -1;
-            }
-        }
-        return new Vec3(vec3.x, vec3.y * dy, vec3.z);
     }
 
     @Inject(method = "tick", at = @At(value = "HEAD"))

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -7,9 +7,11 @@ import dev.dubhe.anvilcraft.api.injection.entity.IItemEntityExtension;
 import dev.dubhe.anvilcraft.block.ItemCollectorBlock;
 import dev.dubhe.anvilcraft.block.entity.ItemCollectorBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -96,6 +98,30 @@ abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
             ));
         }
         this.anvilcraft$blockPos = blockPos;
+    }
+
+    @WrapOperation(
+        method = "tick",
+        at = @At(
+            value = "INVOKE",
+            target =
+                "Lnet/minecraft/world/entity/item/ItemEntity;"
+                + "getDeltaMovement()Lnet/minecraft/world/phys/Vec3;"
+        )
+    )
+    private Vec3 anomalousGravity(ItemEntity instance, Operation<Vec3> original) {
+        Vec3 vec3 = original.call(instance);
+        vec3 = GravityManager.applyGravity(instance, vec3);
+        double dy = 1;
+        if (this.getItem().is(ModItemTags.LEVITATIONALS)) dy *= -0.005;
+        if (this.getItem().is(ModItems.NEGATIVE_MATTER_NUGGET)
+            || this.getItem().is(ModItems.NEGATIVE_MATTER)
+            || this.getItem().is(ModBlocks.NEGATIVE_MATTER_BLOCK.asItem())) {
+            if (this.position().y <= this.level().getMaxBuildHeight()) {
+                if (vec3.y < 0) dy *= -1;
+            }
+        }
+        return new Vec3(vec3.x, vec3.y * dy, vec3.z);
     }
 
     @Inject(method = "tick", at = @At(value = "HEAD"))

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -11,6 +11,7 @@ import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -108,9 +109,9 @@ abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
                 + "getDeltaMovement()Lnet/minecraft/world/phys/Vec3;"
         )
     )
-    private Vec3 slowDown(ItemEntity instance, Operation<Vec3> original) {
+    private Vec3 anomalousGravity(ItemEntity instance, Operation<Vec3> original) {
         Vec3 vec3 = original.call(instance);
-        double dy = 1;
+        double dy = GravityManager.getGravity(this);
         if (this.getItem().is(ModItemTags.LEVITATIONALS)) dy *= -0.005;
         if (this.level().getBlockState(this.blockPosition()).is(ModBlocks.HOLLOW_MAGNET_BLOCK)) dy *= 0.2;
         if (this.getItem().is(ModItems.NEGATIVE_MATTER_NUGGET)

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -7,11 +7,9 @@ import dev.dubhe.anvilcraft.api.injection.entity.IItemEntityExtension;
 import dev.dubhe.anvilcraft.block.ItemCollectorBlock;
 import dev.dubhe.anvilcraft.block.entity.ItemCollectorBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
-import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -98,30 +96,6 @@ abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
             ));
         }
         this.anvilcraft$blockPos = blockPos;
-    }
-
-    @WrapOperation(
-        method = "tick",
-        at = @At(
-            value = "INVOKE",
-            target =
-                "Lnet/minecraft/world/entity/item/ItemEntity;"
-                + "getDeltaMovement()Lnet/minecraft/world/phys/Vec3;"
-        )
-    )
-    private Vec3 anomalousGravity(ItemEntity instance, Operation<Vec3> original) {
-        Vec3 vec3 = original.call(instance);
-        double dy = GravityManager.getGravity(this);
-        if (this.getItem().is(ModItemTags.LEVITATIONALS)) dy *= -0.005;
-        if (this.level().getBlockState(this.blockPosition()).is(ModBlocks.HOLLOW_MAGNET_BLOCK)) dy *= 0.2;
-        if (this.getItem().is(ModItems.NEGATIVE_MATTER_NUGGET)
-            || this.getItem().is(ModItems.NEGATIVE_MATTER)
-            || this.getItem().is(ModBlocks.NEGATIVE_MATTER_BLOCK.asItem())) {
-            if (this.position().y <= this.level().getMaxBuildHeight()) {
-                if (vec3.y < 0) dy *= -1;
-            }
-        }
-        return new Vec3(vec3.x, vec3.y * dy, vec3.z);
     }
 
     @Inject(method = "tick", at = @At(value = "HEAD"))

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -50,8 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity.isInNeutronIrradiatorRange;
-
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity {
     @Unique
@@ -238,17 +236,6 @@ public abstract class LivingEntityMixin extends Entity {
             if (!source.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
                 cir.setReturnValue(false);
             }
-        }
-    }
-
-    @Inject(
-        method = "jumpFromGround",
-        at = @At("HEAD"),
-        cancellable = true
-    )
-    private void onJumpFromGround(CallbackInfo ci) {
-        if (isInNeutronIrradiatorRange(level(), blockPosition())) {
-           ci.cancel();
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -10,7 +10,6 @@ import dev.dubhe.anvilcraft.api.totem.TotemManager;
 import dev.dubhe.anvilcraft.api.totem.handler.TotemHandler;
 import dev.dubhe.anvilcraft.block.EmberAnvilBlock;
 import dev.dubhe.anvilcraft.block.TranscendenceAnvilBlock;
-import dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity;
 import dev.dubhe.anvilcraft.init.ModMobEffects;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
@@ -237,17 +236,6 @@ public abstract class LivingEntityMixin extends Entity {
             if (!source.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
                 cir.setReturnValue(false);
             }
-        }
-    }
-
-    @Inject(
-        method = "jumpFromGround",
-        at = @At("HEAD"),
-        cancellable = true
-    )
-    private void onJumpFromGround(CallbackInfo ci) {
-        if (NeutronIrradiatorBlockEntity.isInIrradiatorRange(level(), blockPosition())) {
-            ci.cancel();
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity.isInNeutronIrradiatorRange;
+
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity {
     @Unique
@@ -239,14 +241,14 @@ public abstract class LivingEntityMixin extends Entity {
         }
     }
 
-//    @Inject(
-//        method = "jumpFromGround",
-//        at = @At("HEAD"),
-//        cancellable = true
-//    )
-//    private void onJumpFromGround(CallbackInfo ci) {
-//        if (GravityManager.isInNeutronIrradiatorRange(level(), blockPosition())) {
-//           ci.cancel();
-//        }
-//    }
+    @Inject(
+        method = "jumpFromGround",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void onJumpFromGround(CallbackInfo ci) {
+        if (isInNeutronIrradiatorRange(level(), blockPosition())) {
+           ci.cancel();
+        }
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -15,7 +15,6 @@ import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.init.loot.ModLootTables;
 import dev.dubhe.anvilcraft.item.property.component.BoxContents;
-import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
@@ -240,14 +239,14 @@ public abstract class LivingEntityMixin extends Entity {
         }
     }
 
-    @Inject(
-        method = "jumpFromGround",
-        at = @At("HEAD"),
-        cancellable = true
-    )
-    private void onJumpFromGround(CallbackInfo ci) {
-        if (GravityManager.isInNeutronIrradiatorRange(level(), blockPosition())) {
-            ci.cancel();
-        }
-    }
+//    @Inject(
+//        method = "jumpFromGround",
+//        at = @At("HEAD"),
+//        cancellable = true
+//    )
+//    private void onJumpFromGround(CallbackInfo ci) {
+//        if (GravityManager.isInNeutronIrradiatorRange(level(), blockPosition())) {
+//           ci.cancel();
+//        }
+//    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -15,6 +15,7 @@ import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.init.loot.ModLootTables;
 import dev.dubhe.anvilcraft.item.property.component.BoxContents;
+import dev.dubhe.anvilcraft.util.GravityManager;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
@@ -236,6 +237,17 @@ public abstract class LivingEntityMixin extends Entity {
             if (!source.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
                 cir.setReturnValue(false);
             }
+        }
+    }
+
+    @Inject(
+        method = "jumpFromGround",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void onJumpFromGround(CallbackInfo ci) {
+        if (GravityManager.isInNeutronIrradiatorRange(level(), blockPosition())) {
+            ci.cancel();
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -2,6 +2,8 @@ package dev.dubhe.anvilcraft.util;
 
 import dev.dubhe.anvilcraft.block.BlackHoleBlock;
 import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
+import dev.dubhe.anvilcraft.entity.StandableFallingBlockEntity;
+import dev.dubhe.anvilcraft.entity.StandableLevitatingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.core.BlockPos;
@@ -116,33 +118,42 @@ public class GravityManager {
 
     // 特殊物质定义不同引力类型
     public enum GravityType {
-        NORMAL, // 正常实体正常重力
-        ANTI_GRAVITY, // 负物质反转重力
-        MICRO_ANTI_GRAVITY // 漂浮粉略有失重感
+        NORMAL, // 正常重力 1
+        ANTI_GRAVITY, // 反转重力 -1
+        MICRO_ANTI_GRAVITY, // 略有失重感 -0.005
+        LOW_GRAVITY // 低重力 0.5
+
     }
 
     public static GravityType getGravityType(Entity entity) {
         if (entity instanceof ItemEntity itemEntity) {
             var item = itemEntity.getItem();
 
-            // 判断负物质
             boolean isNegativeMatter = item.is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || item.is(ModItems.NEGATIVE_MATTER.get()) || item.is(
                 ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
-            if (isNegativeMatter) return GravityType.ANTI_GRAVITY;
+            if (isNegativeMatter) return GravityType.ANTI_GRAVITY; // 负物质
 
-            // 判断漂浮粉
             boolean isLevitationPowder = item.is(ModItems.LEVITATION_POWDER.get()) || item.is(ModBlocks.LEVITATION_POWDER_BLOCK.get()
                 .asItem());
-            if (isLevitationPowder) return GravityType.MICRO_ANTI_GRAVITY;
+            if (isLevitationPowder) return GravityType.MICRO_ANTI_GRAVITY; // 漂浮粉
+
+            // 在这里注册物品的重力类型
         }
 
-        // 判断漂浮粉方块实体
-        if (entity instanceof LevitatingBlockEntity levitatingBlock && levitatingBlock.getBlockState()
-            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+        if (entity instanceof LevitatingBlockEntity) { // 漂浮粉块
             return GravityType.ANTI_GRAVITY;
         }
 
-        return GravityType.NORMAL;
+        if (entity instanceof StandableFallingBlockEntity) { // 下降的可控沙
+            return GravityType.LOW_GRAVITY;
+        }
+
+        if (entity instanceof StandableLevitatingBlockEntity) { // 上升的可控沙
+            return GravityType.ANTI_GRAVITY;
+        }
+        // 在这里注册下落方块的重力类型
+
+        return GravityType.NORMAL; // 默认
     }
 
     public static GravityType getFallingBlockGravityType(Block block) {
@@ -169,11 +180,12 @@ public class GravityManager {
         return switch (type) {
             case ANTI_GRAVITY -> gravityVector.reverse();
             case MICRO_ANTI_GRAVITY -> gravityVector.scale(-0.005);
+            case LOW_GRAVITY -> gravityVector.scale(0.5);
             default -> gravityVector;
         };
     }
 
-    // 得到含维度的总体重力向量（用于下落方块）
+    // 得到含维度的总体重力向量（仅用于下落方块方块）
     public static Vec3 getNetGravityVectorForFallingBlock(Level level, Vec3 pos, GravityType gravityType) {
         // 确定基础重力的大小和方向
         double baseGravity = 0.04 * getDimensionGravity(level);

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -48,8 +48,7 @@ public class GravityManager {
     public static void onChunkLoad(ChunkEvent.Load event) {
         if (event.getLevel() instanceof Level level && !level.isClientSide && event.getChunk() instanceof LevelChunk chunk) {
             for (BlockPos pos : chunk.getBlockEntitiesPos()) {
-                BlockState state = chunk.getBlockState(pos);
-                GravitySourceType type = GravitySourceManager.getType(state.getBlock());
+                GravitySourceType type = GravitySourceManager.getType(chunk.getBlockState(pos).getBlock());
                 if (type != null) {
                     GravitySourceManager.addSource(level, pos, type);
                 }
@@ -61,10 +60,9 @@ public class GravityManager {
     @SubscribeEvent
     public static void onChunkUnload(ChunkEvent.Unload event) {
         if (event.getLevel() instanceof Level level && !level.isClientSide) {
-            long chunkKey = event.getChunk().getPos().toLong();
             Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
             if (dimCache != null) {
-                dimCache.remove(chunkKey);
+                dimCache.remove(event.getChunk().getPos().toLong());
             }
         }
     }
@@ -81,19 +79,17 @@ public class GravityManager {
     @SubscribeEvent
     public static void onBlockPlace(BlockEvent.EntityPlaceEvent event) {
         if (event.getLevel() instanceof Level level && !level.isClientSide) {
+
             GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
             if (type != null) {
                 GravitySourceManager.addSource(level, event.getPos(), type);
                 int r = type.radius;
-                // 遍历黑洞影响范围内的方块
-                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r))
-                    .forEach(pos -> {
-                        BlockState state = level.getBlockState(pos);
-                        // 如果是下落方块，给计划刻让它更新
-                        if (state.getBlock() instanceof FallingBlock) {
-                            level.scheduleTick(pos, state.getBlock(), 2);
-                        }
-                    });
+                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r)).forEach(p -> {
+                    BlockState s = level.getBlockState(p);
+                    if (s.getBlock() instanceof FallingBlock) {
+                        level.scheduleTick(p, s.getBlock(), 2);
+                    }
+                });
             }
         }
     }
@@ -106,15 +102,11 @@ public class GravityManager {
             if (type != null) {
                 GravitySourceManager.removeSource(level, event.getPos());
                 int r = type.radius;
-                // 遍历黑洞影响范围内的方块
-                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r))
-                    .forEach(pos -> {
-                        BlockState state = level.getBlockState(pos);
-                        // 如果是下落方块，给计划刻让它更新
-                        if (state.getBlock() instanceof FallingBlock) {
-                            level.scheduleTick(pos, state.getBlock(), 2);
-                        }
-                    });
+                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r)).forEach(pos -> {
+                    if (level.getBlockState(pos).getBlock() instanceof FallingBlock) {
+                        level.scheduleTick(pos, level.getBlockState(pos).getBlock(), 2);
+                    }
+                });
             }
         }
     }
@@ -157,7 +149,7 @@ public class GravityManager {
         return GravityType.NORMAL; // 普通下落方块
     }
 
-    // 处理特殊实体，最终得到重力向量
+    // 得到重力向量
     public static Vec3 getGravityVector(Entity entity) {
         // 获取计算的引力
         Vec3 gravityVector = GravitySourceManager.calculateGravityVector(entity);
@@ -176,6 +168,31 @@ public class GravityManager {
             case MICRO_ANTI_GRAVITY -> gravityVector.scale(-0.005);
             default -> gravityVector;
         };
+    }
+
+    // 得到含维度的总体重力向量（用于下落方块）
+    public static Vec3 getNetGravityVectorForFallingBlock(Level level, Vec3 pos, GravityType gravityType) {
+        // 确定基础重力的大小和方向
+        double baseGravity = 0.04 * getDimensionGravity(level);
+
+        // 根据物质类型调整基础重力的方向
+        double baseGravityY = (gravityType == GravityType.ANTI_GRAVITY) ? baseGravity : -baseGravity;
+        Vec3 baseGravityVector = new Vec3(0, baseGravityY, 0);
+
+        // 计算局部重力源的引力
+        Vec3 localGravityVector = GravitySourceManager.calculateGravityVector(level, pos, Math.abs(baseGravity));
+
+        // 根据物质类型调整重力向量方向
+        if (gravityType == GravityType.ANTI_GRAVITY) {
+            localGravityVector = localGravityVector.reverse();
+        }
+
+        // 返回向量用于下落方块计算
+        return baseGravityVector.add(localGravityVector);
+    }
+
+    public static Vec3 getNetGravityVectorForFallingBlock(Entity entity) {
+        return getNetGravityVectorForFallingBlock(entity.level(), entity.getBoundingBox().getCenter(), getGravityType(entity));
     }
 
     // 应用维度重力

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,39 +1,323 @@
 package dev.dubhe.anvilcraft.util;
 
+import dev.dubhe.anvilcraft.block.BlackHoleBlock;
+import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FallingBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@EventBusSubscriber(modid = "anvilcraft", bus = EventBusSubscriber.Bus.GAME)
 public class GravityManager {
-    // 重力设置
-    public static final double DEFAULT_GRAVITY = 1.0;
-    public static final double NEUTRON_IRRADIATOR_GRAVITY = 3.0;
-    public static final double MUN_GRAVITY = 0.1663;
 
-    public static double getGravity(Entity entity) {
-        Level level = entity.level();
-        BlockPos pos = entity.blockPosition();
-        // 检查应该用什么重力
-        if (isInNeutronIrradiatorRange(level, pos)) {
-            return NEUTRON_IRRADIATOR_GRAVITY;
-        } if (isOnMun(level)) {
-            return MUN_GRAVITY;
-        } return DEFAULT_GRAVITY;
+    // 维度 -> 区块索引 -> 重力源列表
+    private static final Map<ResourceKey<Level>, Map<Long, List<GravitySource>>> GRAVITY_CACHE = new ConcurrentHashMap<>();
+
+    // 维度重力倍率表
+    private static final Map<ResourceKey<Level>, Double> DIMENSION_GRAVITY_MAP = new HashMap<>();
+
+    static {
+        GravitySourceManager.registerSourceType(BlackHoleBlock.class, 7, 10.0);
+        // 在这里注册更多重力源，strength -> 距离该重力源 1 格处的重力是主世界重力的 strength 倍
+
+        // registerDimensionGravity(Level.MUN, 0.1653061224489796);
+        // 在这里注册更多维度重力，gravity -> 该维度重力是主世界重力的 gravity 倍
     }
 
-    private static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
-        // 引用中子辐照器的检查方法
-        try {
-            Class<?> neutronIrradiatorClass = Class.forName("dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity");
-            java.lang.reflect.Method isInIrradiatorRangeMethod = neutronIrradiatorClass.getMethod(
-                "isInIrradiatorRange", Level.class, BlockPos.class);
-            return (boolean) isInIrradiatorRangeMethod.invoke(null, level, pos);
-        } catch (Exception e) {
-            return false;
+    // 区块加载事件，搜索BlockEntity添加重力源
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide && event.getChunk() instanceof LevelChunk chunk) {
+            for (BlockPos pos : chunk.getBlockEntitiesPos()) {
+                GravitySourceType type = GravitySourceManager.getType(chunk.getBlockState(pos).getBlock());
+                if (type != null) {
+                    GravitySourceManager.addSource(level, pos, type);
+                }
+            }
         }
     }
 
-    private static boolean isOnMun(Level level) {
-        return false;
+    // 区块卸载事件，移除记录的重力源
+    @SubscribeEvent
+    public static void onChunkUnload(ChunkEvent.Unload event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
+            if (dimCache != null) {
+                dimCache.remove(event.getChunk().getPos().toLong());
+            }
+        }
+    }
+
+    // 世界卸载事件，清除所有缓存
+    @SubscribeEvent
+    public static void onLevelUnload(LevelEvent.Unload event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            GRAVITY_CACHE.remove(level.dimension());
+        }
+    }
+
+    // 方块放置事件，添加重力源
+    @SubscribeEvent
+    public static void onBlockPlace(BlockEvent.EntityPlaceEvent event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+
+            GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
+            if (type != null) {
+                GravitySourceManager.addSource(level, event.getPos(), type);
+                int r = type.radius;
+                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r)).forEach(p -> {
+                    BlockState s = level.getBlockState(p);
+                    if (s.getBlock() instanceof FallingBlock) {
+                        level.scheduleTick(p, s.getBlock(), 2);
+                    }
+                });
+            }
+        }
+    }
+
+    // 方块破坏事件，移除重力源
+    @SubscribeEvent
+    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
+            if (type != null) {
+                GravitySourceManager.removeSource(level, event.getPos());
+                int r = type.radius;
+                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r)).forEach(pos -> {
+                    if (level.getBlockState(pos).getBlock() instanceof FallingBlock) {
+                        level.scheduleTick(pos, level.getBlockState(pos).getBlock(), 2);
+                    }
+                });
+            }
+        }
+    }
+
+    // 特殊物质定义不同引力类型
+    public enum GravityType {
+        NORMAL, // 正常实体正常重力
+        ANTI_GRAVITY, // 负物质反转重力
+        MICRO_ANTI_GRAVITY // 漂浮粉略有失重感
+    }
+
+    public static GravityType getGravityType(Entity entity) {
+        if (entity instanceof ItemEntity itemEntity) {
+            var item = itemEntity.getItem();
+
+            // 判断负物质
+            boolean isNegativeMatter = item.is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || item.is(ModItems.NEGATIVE_MATTER.get()) || item.is(
+                ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
+            if (isNegativeMatter) return GravityType.ANTI_GRAVITY;
+
+            // 判断漂浮粉
+            boolean isLevitationPowder = item.is(ModItems.LEVITATION_POWDER.get()) || item.is(ModBlocks.LEVITATION_POWDER_BLOCK.get()
+                .asItem());
+            if (isLevitationPowder) return GravityType.MICRO_ANTI_GRAVITY;
+        }
+
+        // 判断漂浮粉方块实体
+        if (entity instanceof LevitatingBlockEntity levitatingBlock && levitatingBlock.getBlockState()
+            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+            return GravityType.ANTI_GRAVITY;
+        }
+
+        return GravityType.NORMAL;
+    }
+
+    public static GravityType getFallingBlockGravityType(Block block) {
+        if (block.equals(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+            return GravityType.ANTI_GRAVITY; // 漂浮粉块
+        }
+        return GravityType.NORMAL; // 普通下落方块
+    }
+
+    // 得到重力向量
+    public static Vec3 getGravityVector(Entity entity) {
+        // 获取计算的引力
+        Vec3 gravityVector = GravitySourceManager.calculateGravityVector(entity);
+
+        // 如果没有受到引力，直接返回零
+        if (gravityVector.equals(Vec3.ZERO)) {
+            return Vec3.ZERO;
+        }
+
+        // 获取实体引力类型
+        GravityType type = getGravityType(entity);
+
+        // 根据类型修正向量方向/大小
+        return switch (type) {
+            case ANTI_GRAVITY -> gravityVector.reverse();
+            case MICRO_ANTI_GRAVITY -> gravityVector.scale(-0.005);
+            default -> gravityVector;
+        };
+    }
+
+    // 得到含维度的总体重力向量（用于下落方块）
+    public static Vec3 getNetGravityVectorForFallingBlock(Level level, Vec3 pos, GravityType gravityType) {
+        // 确定基础重力的大小和方向
+        double baseGravity = 0.04 * getDimensionGravity(level);
+
+        // 根据物质类型调整基础重力的方向
+        double baseGravityY = (gravityType == GravityType.ANTI_GRAVITY) ? baseGravity : -baseGravity;
+        Vec3 baseGravityVector = new Vec3(0, baseGravityY, 0);
+
+        // 计算局部重力源的引力
+        Vec3 localGravityVector = GravitySourceManager.calculateGravityVector(level, pos, Math.abs(baseGravity));
+
+        // 根据物质类型调整重力向量方向
+        if (gravityType == GravityType.ANTI_GRAVITY) {
+            localGravityVector = localGravityVector.reverse();
+        }
+
+        // 返回向量用于下落方块计算
+        return baseGravityVector.add(localGravityVector);
+    }
+
+    public static Vec3 getNetGravityVectorForFallingBlock(Entity entity) {
+        return getNetGravityVectorForFallingBlock(entity.level(), entity.getBoundingBox().getCenter(), getGravityType(entity));
+    }
+
+    // 应用维度重力
+    public static void registerDimensionGravity(ResourceKey<Level> dimension, double gravity) {
+        DIMENSION_GRAVITY_MAP.put(dimension, gravity);
+    }
+
+    public static double getDimensionGravity(Level level) {
+        return DIMENSION_GRAVITY_MAP.getOrDefault(level.dimension(), 1.0);
+    }
+
+    // 重力源定义与存储
+    public static class GravitySourceType {
+        final double strength;
+        final int radius;
+        final double radiusSqr;
+
+        public GravitySourceType(double strength, int radius) {
+            this.strength = strength;
+            this.radius = radius;
+            this.radiusSqr = radius * radius;
+        }
+    }
+
+    public static class GravitySource {
+        public final BlockPos pos;
+        public final GravitySourceType type;
+
+        public GravitySource(BlockPos pos, GravitySourceType type) {
+            this.pos = pos;
+            this.type = type;
+        }
+    }
+
+    // 重力源管理器
+    public static class GravitySourceManager {
+        private static final Map<Class<? extends Block>, GravitySourceType> REGISTRY = new HashMap<>();
+
+        public static void registerSourceType(Class<? extends Block> blockClass, int radius, double strength) {
+            REGISTRY.put(blockClass, new GravitySourceType(strength, radius));
+        }
+
+        public static GravitySourceType getType(Block block) {
+            return REGISTRY.get(block.getClass());
+        }
+
+        public static void addSource(Level level, BlockPos pos, GravitySourceType type) {
+            long chunkKey = ChunkPos.asLong(pos);
+            List<GravitySource> list = GRAVITY_CACHE.computeIfAbsent(level.dimension(), k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(chunkKey, k -> new ArrayList<>());
+
+            // 检查列表中是否已经有该坐标的重力源
+            boolean alreadyExists = false;
+            for (GravitySource s : list) {
+                if (s.pos.equals(pos)) {
+                    alreadyExists = true;
+                    break;
+                }
+            }
+
+            if (!alreadyExists) {
+                list.add(new GravitySource(pos, type));
+            }
+        }
+
+        public static void removeSource(Level level, BlockPos pos) {
+            long chunkKey = ChunkPos.asLong(pos);
+            Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
+            if (dimCache != null) {
+                List<GravitySource> sources = dimCache.get(chunkKey);
+                if (sources != null) {
+                    sources.removeIf(s -> s.pos.equals(pos));
+                    if (sources.isEmpty()) {
+                        dimCache.remove(chunkKey);
+                    }
+                }
+            }
+        }
+
+        private static double getEntityG(Entity entity) {
+            return switch (entity) {
+                case LivingEntity livingEntity -> 0.08;
+                case Projectile projectile -> 0.05;
+                default -> 0.04;
+            };
+        }
+
+        public static Vec3 calculateGravityVector(Level level, Vec3 p, double g) {
+            var cache = GRAVITY_CACHE.get(level.dimension());
+            if (cache == null) return Vec3.ZERO;
+
+            double fx = 0;
+            double fy = 0;
+            double fz = 0;
+            int cx = ((int) Math.floor(p.x)) >> 4;
+            int cz = ((int) Math.floor(p.z)) >> 4;
+
+            for (int x = -1; x <= 1; x++) {
+                for (int z = -1; z <= 1; z++) {
+                    var list = cache.get(ChunkPos.asLong(cx + x, cz + z));
+                    if (list == null) continue;
+                    for (var s : list) {
+                        double dx = s.pos.getX() + 0.5 - p.x;
+                        double dy = s.pos.getY() + 0.5 - p.y;
+                        double dz = s.pos.getZ() + 0.5 - p.z;
+                        double radiusSquare = dx * dx + dy * dy + dz * dz;
+
+                        if (radiusSquare <= s.type.radiusSqr) {
+                            // 使用传入的 g
+                            double f = (g * s.type.strength) / (Math.max(radiusSquare, 1.0) * Math.sqrt(radiusSquare));
+                            fx += dx * f;
+                            fy += dy * f;
+                            fz += dz * f;
+                        }
+                    }
+                }
+            }
+            return new Vec3(fx, fy, fz);
+        }
+
+        public static Vec3 calculateGravityVector(Entity entity) {
+            return calculateGravityVector(entity.level(), entity.getBoundingBox().getCenter(), getEntityG(entity));
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,58 +1,94 @@
 package dev.dubhe.anvilcraft.util;
 
 import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
+import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.FallingBlockEntity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static dev.dubhe.anvilcraft.util.GravityManager.GravitySourceManager.getGravityVector;
 
 public class GravityManager {
-    // 重力设置，默认重力1.0
-    public static final double NEUTRON_IRRADIATOR_GRAVITY = 10.0;
+    // 维度重力映射表
+    private static final Map<ResourceKey<Level>, Double> DIMENSION_GRAVITY_MAP = new HashMap<>();
 
     static {
-        GravitySourceManager.registerSource(NeutronIrradiatorBlock.class, 7, NEUTRON_IRRADIATOR_GRAVITY);
-        // 在这里注册更多重力源
+        GravitySourceManager.registerSource(NeutronIrradiatorBlock.class, 7, 10.0);
+        // 在这里注册更多重力源，strength -> 该重力源所在方块任意表面中心的重力是主世界重力的 strength 倍
+
+        registerDimensionGravity(Level.END, 0.5);
+        // 在这里注册更多维度重力，gravity -> 该维度重力是主世界重力的 gravity 倍
     }
 
-    private static boolean isNegativeMatterItem(ItemEntity itemEntity) {
-        return itemEntity.getItem().is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || itemEntity.getItem()
-            .is(ModItems.NEGATIVE_MATTER.get()) || itemEntity.getItem().is(ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
+    // 设置不同实体的重力系数
+    private static double getGravityFactor(Entity entity) {
+        return switch (entity) {
+            case FallingBlockEntity fallingBlockEntity -> -0.04; // 下落方块
+            case LivingEntity livingEntity -> -0.08; // 生物
+            case Projectile projectile -> -0.05; // 投掷物
+            case ItemEntity itemEntity -> -0.02; // 掉落物
+            default -> -0.08;
+        };
     }
-    private static boolean isLevitationPowder(ItemEntity itemEntity) {
-        return itemEntity.getItem().is(ModItems.LEVITATION_POWDER.get()) || itemEntity.getItem()
-            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get().asItem());
-    }
-    // 在这里添加反重力物质
 
-    // 根据移动方向和重力源方向调整速度
+    // 应用重力并处理特殊实体
     public static Vec3 applyGravity(Entity entity, Vec3 movement) {
         Level level = entity.level();
-        Vec3 entityPos = entity.position();
         BlockPos blockPos = entity.blockPosition();
-        // 反重力物质处理
+        Vec3 entityPos = entity.position();
+        Vec3 gravityVector = getGravityVector(level, blockPos, entityPos);
+
+        // 维度重力处理，恒定向下重力
+        if (getDimensionGravity(level) != 1.0) {
+            gravityVector = gravityVector.add(0, getGravityFactor(entity) * (getDimensionGravity(level) - 1.0), 0);
+        }
+
+        // 物品实体处理，负物质反转重力，漂浮粉略有失重感
         if (entity instanceof ItemEntity itemEntity) {
-            if (isNegativeMatterItem(itemEntity)) { // 负物质：反转重力
-                Vec3 gravityVector = getGravityVector(entity.level(), entity.blockPosition(), entity.position());
-                if (isLevitationPowder(itemEntity)) { // 漂浮粉：轻微失重感
-                    return movement.subtract(gravityVector.scale(0.005));
-                }
-                return movement.subtract(gravityVector);
+            var item = itemEntity.getItem();
+            boolean isNegativeMatter = item.is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || item.is(ModItems.NEGATIVE_MATTER.get()) || item.is(
+                ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
+
+            if (isNegativeMatter) {
+                boolean isLevitationPowder = item.is(ModItems.LEVITATION_POWDER.get()) || item.is(ModBlocks.LEVITATION_POWDER_BLOCK.get()
+                    .asItem());
+
+                return movement.subtract(isLevitationPowder ? gravityVector.scale(0.005) : gravityVector);
             }
         }
-        // 获取所有重力影响并应用到移动向量
-        Vec3 gravityForce = getGravityVector(level, blockPos, entityPos);
-        return movement.add(gravityForce);
+
+        // 漂浮粉块下落方块实体：反转重力
+        if (entity instanceof LevitatingBlockEntity levitatingBlock && levitatingBlock.getBlockState()
+            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+            return movement.subtract(gravityVector);
+        }
+
+        // 默认情况：正常加重力
+        return movement.add(gravityVector);
+    }
+
+    // 维度重力管理器
+    public static void registerDimensionGravity(ResourceKey<Level> dimension, double gravity) {
+        DIMENSION_GRAVITY_MAP.put(dimension, gravity);
+    }
+
+    public static double getDimensionGravity(Level level) {
+        return DIMENSION_GRAVITY_MAP.getOrDefault(level.dimension(), 1.0);
     }
 
     // 重力源类型定义
@@ -60,17 +96,21 @@ public class GravityManager {
         private final Class<? extends Block> blockClass;
         private final int radius;
         private final double strength;
+
         public GravitySourceType(Class<? extends Block> blockClass, int radius, double strength) {
             this.blockClass = blockClass;
             this.radius = radius;
             this.strength = strength;
         }
+
         public Class<? extends Block> getBlockClass() {
             return blockClass;
         }
+
         public int getRadius() {
             return radius;
         }
+
         public double getStrength() {
             return strength;
         }
@@ -80,6 +120,7 @@ public class GravityManager {
     public static class GravitySource {
         public final BlockPos pos;
         public final double strength;
+
         public GravitySource(BlockPos pos, double strength) {
             this.pos = pos;
             this.strength = strength;
@@ -89,9 +130,11 @@ public class GravityManager {
     // 重力源管理器
     public static class GravitySourceManager {
         private static final List<GravitySourceType> REGISTERED_SOURCES = new ArrayList<>();
+
         public static void registerSource(Class<? extends Block> blockClass, int radius, double strength) {
             REGISTERED_SOURCES.add(new GravitySourceType(blockClass, radius, strength));
         }
+
         // 计算实体所受的总重力（返回向量）
         public static Vec3 getGravityVector(Level level, BlockPos pos, Vec3 entityPos) {
             List<GravitySource> sources = new ArrayList<>();
@@ -103,6 +146,7 @@ public class GravityManager {
             }
             return gravityVector(sources, entityPos); // 否则计算合力
         }
+
         // 搜索重力源
         private static void findGravitySourcesInRange(Level level, BlockPos center, GravitySourceType type, List<GravitySource> sources) {
             int radius = type.getRadius(); // 读取重力源半径
@@ -120,13 +164,14 @@ public class GravityManager {
                 }
             }
         }
+
         // 计算来自所有重力源的合力
         public static Vec3 gravityVector(List<GravitySource> sources, Vec3 entityPosition) {
             double fx = 0, fy = 0, fz = 0;
             for (GravitySource source : sources) { // 遍历重力源累加引力
                 Vec3 direction = Vec3.atCenterOf(source.pos).subtract(entityPosition); // 每个重力源计算距离向量
                 double rSqr = direction.lengthSqr();
-                if (rSqr > 0.5) {
+                if (rSqr > 0.70710678) {
                     double r = Math.sqrt(rSqr); // 万有引力公式计算
                     double f = 0.0224964424376324 * source.strength / (rSqr); // 测量得 G 在0.0224964424376323和0.0224964424376324之间
                     fx += direction.x / r * f; // 累加各分量力返回总向量

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,43 +1,140 @@
 package dev.dubhe.anvilcraft.util;
 
 import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
+import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static dev.dubhe.anvilcraft.util.GravityManager.GravitySourceManager.getGravityVector;
 
 public class GravityManager {
-    // 重力设置
-    public static final double DEFAULT_GRAVITY = 1.0;
-    public static final double NEUTRON_IRRADIATOR_GRAVITY = 3.0;
-    public static final double MUN_GRAVITY = 0.1663;
+    // 重力设置，默认重力1.0
+    public static final double NEUTRON_IRRADIATOR_GRAVITY = 10.0;
 
-    public static double getGravity(Entity entity) {
-        Level level = entity.level();
-        BlockPos pos = entity.blockPosition();
-        // 检查应该用什么重力
-        if (isInNeutronIrradiatorRange(level, pos)) {
-            return NEUTRON_IRRADIATOR_GRAVITY;
-        }
-        if (isOnMun(level)) {
-            return MUN_GRAVITY;
-        }
-        return DEFAULT_GRAVITY;
+    static {
+        GravitySourceManager.registerSource(NeutronIrradiatorBlock.class, 7, NEUTRON_IRRADIATOR_GRAVITY);
+        // 在这里注册更多重力源
     }
 
-    public static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
-        for (int i = 0; i <= 7; i++) {
-            BlockPos belowPos = pos.below(i);
-            BlockState blockstate = level.getBlockState(belowPos);
+    private static boolean isNegativeMatterItem(ItemEntity itemEntity) {
+        return itemEntity.getItem().is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || itemEntity.getItem()
+            .is(ModItems.NEGATIVE_MATTER.get()) || itemEntity.getItem().is(ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
+    }
+    private static boolean isLevitationPowder(ItemEntity itemEntity) {
+        return itemEntity.getItem().is(ModItems.LEVITATION_POWDER.get()) || itemEntity.getItem()
+            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get().asItem());
+    }
+    // 在这里添加反重力物质
 
-            if (blockstate.getBlock() instanceof NeutronIrradiatorBlock) {
-                return true;
+    // 根据移动方向和重力源方向调整速度
+    public static Vec3 applyGravity(Entity entity, Vec3 movement) {
+        Level level = entity.level();
+        Vec3 entityPos = entity.position();
+        BlockPos blockPos = entity.blockPosition();
+        // 反重力物质处理
+        if (entity instanceof ItemEntity itemEntity) {
+            if (isNegativeMatterItem(itemEntity)) { // 负物质：反转重力
+                Vec3 gravityVector = getGravityVector(entity.level(), entity.blockPosition(), entity.position());
+                if (isLevitationPowder(itemEntity)) { // 漂浮粉：轻微失重感
+                    return movement.subtract(gravityVector.scale(0.005));
+                }
+                return movement.subtract(gravityVector);
             }
         }
-        return false;
+        // 获取所有重力影响并应用到移动向量
+        Vec3 gravityForce = getGravityVector(level, blockPos, entityPos);
+        return movement.add(gravityForce);
     }
 
-    private static boolean isOnMun(Level level) {
-        return false;
+    // 重力源类型定义
+    public static class GravitySourceType {
+        private final Class<? extends Block> blockClass;
+        private final int radius;
+        private final double strength;
+        public GravitySourceType(Class<? extends Block> blockClass, int radius, double strength) {
+            this.blockClass = blockClass;
+            this.radius = radius;
+            this.strength = strength;
+        }
+        public Class<? extends Block> getBlockClass() {
+            return blockClass;
+        }
+        public int getRadius() {
+            return radius;
+        }
+        public double getStrength() {
+            return strength;
+        }
+    }
+
+    // 用于存储重力源信息的内部类
+    public static class GravitySource {
+        public final BlockPos pos;
+        public final double strength;
+        public GravitySource(BlockPos pos, double strength) {
+            this.pos = pos;
+            this.strength = strength;
+        }
+    }
+
+    // 重力源管理器
+    public static class GravitySourceManager {
+        private static final List<GravitySourceType> REGISTERED_SOURCES = new ArrayList<>();
+        public static void registerSource(Class<? extends Block> blockClass, int radius, double strength) {
+            REGISTERED_SOURCES.add(new GravitySourceType(blockClass, radius, strength));
+        }
+        // 计算实体所受的总重力（返回向量）
+        public static Vec3 getGravityVector(Level level, BlockPos pos, Vec3 entityPos) {
+            List<GravitySource> sources = new ArrayList<>();
+            for (GravitySourceType type : REGISTERED_SOURCES) { // 遍历所有注册的重力源
+                findGravitySourcesInRange(level, pos, type, sources);
+            }
+            if (sources.isEmpty()) { // 如果没有任何重力源，返回默认重力
+                return new Vec3(0, 0, 0);
+            }
+            return gravityVector(sources, entityPos); // 否则计算合力
+        }
+        // 搜索重力源
+        private static void findGravitySourcesInRange(Level level, BlockPos center, GravitySourceType type, List<GravitySource> sources) {
+            int radius = type.getRadius(); // 读取重力源半径
+            int rSqr = radius * radius;
+            for (int x = -radius; x <= radius; x++) { // 遍历所有方块
+                for (int y = -radius; y <= radius; y++) {
+                    for (int z = -radius; z <= radius; z++) {
+                        if (x * x + y * y + z * z > rSqr) continue; // 球形
+                        BlockPos checkPos = center.offset(x, y, z);
+                        BlockState state = level.getBlockState(checkPos);
+                        if (type.getBlockClass().isInstance(state.getBlock())) {
+                            sources.add(new GravitySource(checkPos, type.getStrength()));
+                        }
+                    }
+                }
+            }
+        }
+        // 计算来自所有重力源的合力
+        public static Vec3 gravityVector(List<GravitySource> sources, Vec3 entityPosition) {
+            double fx = 0, fy = 0, fz = 0;
+            for (GravitySource source : sources) { // 遍历重力源累加引力
+                Vec3 direction = Vec3.atCenterOf(source.pos).subtract(entityPosition); // 每个重力源计算距离向量
+                double rSqr = direction.lengthSqr();
+                if (rSqr > 0.5) {
+                    double r = Math.sqrt(rSqr); // 万有引力公式计算
+                    double f = 0.0224964424376324 * source.strength / (rSqr); // 测量得 G 在0.0224964424376323和0.0224964424376324之间
+                    fx += direction.x / r * f; // 累加各分量力返回总向量
+                    fy += direction.y / r * f;
+                    fz += direction.z / r * f;
+                }
+            }
+            return new Vec3(fx, fy, fz);
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,323 +1,46 @@
 package dev.dubhe.anvilcraft.util;
 
-import dev.dubhe.anvilcraft.block.BlackHoleBlock;
-import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
-import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.projectile.Projectile;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.FallingBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.LevelChunk;
-import net.minecraft.world.phys.Vec3;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.event.level.BlockEvent;
-import net.neoforged.neoforge.event.level.ChunkEvent;
-import net.neoforged.neoforge.event.level.LevelEvent;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.lang.reflect.Method;
 
-@EventBusSubscriber(modid = "anvilcraft", bus = EventBusSubscriber.Bus.GAME)
 public class GravityManager {
+    // 重力设置
+    public static final double DEFAULT_GRAVITY = 1.0;
+    public static final double NEUTRON_IRRADIATOR_GRAVITY = 3.0;
+    public static final double MUN_GRAVITY = 0.1663;
 
-    // 维度 -> 区块索引 -> 重力源列表
-    private static final Map<ResourceKey<Level>, Map<Long, List<GravitySource>>> GRAVITY_CACHE = new ConcurrentHashMap<>();
-
-    // 维度重力倍率表
-    private static final Map<ResourceKey<Level>, Double> DIMENSION_GRAVITY_MAP = new HashMap<>();
-
-    static {
-        GravitySourceManager.registerSourceType(BlackHoleBlock.class, 7, 10.0);
-        // 在这里注册更多重力源，strength -> 距离该重力源 1 格处的重力是主世界重力的 strength 倍
-
-        // registerDimensionGravity(Level.MUN, 0.1653061224489796);
-        // 在这里注册更多维度重力，gravity -> 该维度重力是主世界重力的 gravity 倍
-    }
-
-    // 区块加载事件，搜索BlockEntity添加重力源
-    @SubscribeEvent
-    public static void onChunkLoad(ChunkEvent.Load event) {
-        if (event.getLevel() instanceof Level level && !level.isClientSide && event.getChunk() instanceof LevelChunk chunk) {
-            for (BlockPos pos : chunk.getBlockEntitiesPos()) {
-                GravitySourceType type = GravitySourceManager.getType(chunk.getBlockState(pos).getBlock());
-                if (type != null) {
-                    GravitySourceManager.addSource(level, pos, type);
-                }
-            }
+    public static double getGravity(Entity entity) {
+        Level level = entity.level();
+        BlockPos pos = entity.blockPosition();
+        // 检查应该用什么重力
+        if (isInNeutronIrradiatorRange(level, pos)) {
+            return NEUTRON_IRRADIATOR_GRAVITY;
         }
+        if (isOnMun(level)) {
+            return MUN_GRAVITY;
+        }
+        return DEFAULT_GRAVITY;
     }
 
-    // 区块卸载事件，移除记录的重力源
-    @SubscribeEvent
-    public static void onChunkUnload(ChunkEvent.Unload event) {
-        if (event.getLevel() instanceof Level level && !level.isClientSide) {
-            Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
-            if (dimCache != null) {
-                dimCache.remove(event.getChunk().getPos().toLong());
-            }
+    private static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
+        // 引用中子辐照器的检查方法
+        try {
+            Class<?> neutronIrradiatorClass = Class.forName("dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity");
+            Method isInIrradiatorRangeMethod = neutronIrradiatorClass.getMethod(
+                "isInIrradiatorRange",
+                Level.class,
+                BlockPos.class
+            );
+            return (boolean) isInIrradiatorRangeMethod.invoke(null, level, pos);
+        } catch (Exception e) {
+            return false;
         }
     }
 
-    // 世界卸载事件，清除所有缓存
-    @SubscribeEvent
-    public static void onLevelUnload(LevelEvent.Unload event) {
-        if (event.getLevel() instanceof Level level && !level.isClientSide) {
-            GRAVITY_CACHE.remove(level.dimension());
-        }
-    }
-
-    // 方块放置事件，添加重力源
-    @SubscribeEvent
-    public static void onBlockPlace(BlockEvent.EntityPlaceEvent event) {
-        if (event.getLevel() instanceof Level level && !level.isClientSide) {
-
-            GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
-            if (type != null) {
-                GravitySourceManager.addSource(level, event.getPos(), type);
-                int r = type.radius;
-                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r)).forEach(p -> {
-                    BlockState s = level.getBlockState(p);
-                    if (s.getBlock() instanceof FallingBlock) {
-                        level.scheduleTick(p, s.getBlock(), 2);
-                    }
-                });
-            }
-        }
-    }
-
-    // 方块破坏事件，移除重力源
-    @SubscribeEvent
-    public static void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (event.getLevel() instanceof Level level && !level.isClientSide) {
-            GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
-            if (type != null) {
-                GravitySourceManager.removeSource(level, event.getPos());
-                int r = type.radius;
-                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r)).forEach(pos -> {
-                    if (level.getBlockState(pos).getBlock() instanceof FallingBlock) {
-                        level.scheduleTick(pos, level.getBlockState(pos).getBlock(), 2);
-                    }
-                });
-            }
-        }
-    }
-
-    // 特殊物质定义不同引力类型
-    public enum GravityType {
-        NORMAL, // 正常实体正常重力
-        ANTI_GRAVITY, // 负物质反转重力
-        MICRO_ANTI_GRAVITY // 漂浮粉略有失重感
-    }
-
-    public static GravityType getGravityType(Entity entity) {
-        if (entity instanceof ItemEntity itemEntity) {
-            var item = itemEntity.getItem();
-
-            // 判断负物质
-            boolean isNegativeMatter = item.is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || item.is(ModItems.NEGATIVE_MATTER.get()) || item.is(
-                ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
-            if (isNegativeMatter) return GravityType.ANTI_GRAVITY;
-
-            // 判断漂浮粉
-            boolean isLevitationPowder = item.is(ModItems.LEVITATION_POWDER.get()) || item.is(ModBlocks.LEVITATION_POWDER_BLOCK.get()
-                .asItem());
-            if (isLevitationPowder) return GravityType.MICRO_ANTI_GRAVITY;
-        }
-
-        // 判断漂浮粉方块实体
-        if (entity instanceof LevitatingBlockEntity levitatingBlock && levitatingBlock.getBlockState()
-            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
-            return GravityType.ANTI_GRAVITY;
-        }
-
-        return GravityType.NORMAL;
-    }
-
-    public static GravityType getFallingBlockGravityType(Block block) {
-        if (block.equals(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
-            return GravityType.ANTI_GRAVITY; // 漂浮粉块
-        }
-        return GravityType.NORMAL; // 普通下落方块
-    }
-
-    // 得到重力向量
-    public static Vec3 getGravityVector(Entity entity) {
-        // 获取计算的引力
-        Vec3 gravityVector = GravitySourceManager.calculateGravityVector(entity);
-
-        // 如果没有受到引力，直接返回零
-        if (gravityVector.equals(Vec3.ZERO)) {
-            return Vec3.ZERO;
-        }
-
-        // 获取实体引力类型
-        GravityType type = getGravityType(entity);
-
-        // 根据类型修正向量方向/大小
-        return switch (type) {
-            case ANTI_GRAVITY -> gravityVector.reverse();
-            case MICRO_ANTI_GRAVITY -> gravityVector.scale(-0.005);
-            default -> gravityVector;
-        };
-    }
-
-    // 得到含维度的总体重力向量（用于下落方块）
-    public static Vec3 getNetGravityVectorForFallingBlock(Level level, Vec3 pos, GravityType gravityType) {
-        // 确定基础重力的大小和方向
-        double baseGravity = 0.04 * getDimensionGravity(level);
-
-        // 根据物质类型调整基础重力的方向
-        double baseGravityY = (gravityType == GravityType.ANTI_GRAVITY) ? baseGravity : -baseGravity;
-        Vec3 baseGravityVector = new Vec3(0, baseGravityY, 0);
-
-        // 计算局部重力源的引力
-        Vec3 localGravityVector = GravitySourceManager.calculateGravityVector(level, pos, Math.abs(baseGravity));
-
-        // 根据物质类型调整重力向量方向
-        if (gravityType == GravityType.ANTI_GRAVITY) {
-            localGravityVector = localGravityVector.reverse();
-        }
-
-        // 返回向量用于下落方块计算
-        return baseGravityVector.add(localGravityVector);
-    }
-
-    public static Vec3 getNetGravityVectorForFallingBlock(Entity entity) {
-        return getNetGravityVectorForFallingBlock(entity.level(), entity.getBoundingBox().getCenter(), getGravityType(entity));
-    }
-
-    // 应用维度重力
-    public static void registerDimensionGravity(ResourceKey<Level> dimension, double gravity) {
-        DIMENSION_GRAVITY_MAP.put(dimension, gravity);
-    }
-
-    public static double getDimensionGravity(Level level) {
-        return DIMENSION_GRAVITY_MAP.getOrDefault(level.dimension(), 1.0);
-    }
-
-    // 重力源定义与存储
-    public static class GravitySourceType {
-        final double strength;
-        final int radius;
-        final double radiusSqr;
-
-        public GravitySourceType(double strength, int radius) {
-            this.strength = strength;
-            this.radius = radius;
-            this.radiusSqr = radius * radius;
-        }
-    }
-
-    public static class GravitySource {
-        public final BlockPos pos;
-        public final GravitySourceType type;
-
-        public GravitySource(BlockPos pos, GravitySourceType type) {
-            this.pos = pos;
-            this.type = type;
-        }
-    }
-
-    // 重力源管理器
-    public static class GravitySourceManager {
-        private static final Map<Class<? extends Block>, GravitySourceType> REGISTRY = new HashMap<>();
-
-        public static void registerSourceType(Class<? extends Block> blockClass, int radius, double strength) {
-            REGISTRY.put(blockClass, new GravitySourceType(strength, radius));
-        }
-
-        public static GravitySourceType getType(Block block) {
-            return REGISTRY.get(block.getClass());
-        }
-
-        public static void addSource(Level level, BlockPos pos, GravitySourceType type) {
-            long chunkKey = ChunkPos.asLong(pos);
-            List<GravitySource> list = GRAVITY_CACHE.computeIfAbsent(level.dimension(), k -> new ConcurrentHashMap<>())
-                .computeIfAbsent(chunkKey, k -> new ArrayList<>());
-
-            // 检查列表中是否已经有该坐标的重力源
-            boolean alreadyExists = false;
-            for (GravitySource s : list) {
-                if (s.pos.equals(pos)) {
-                    alreadyExists = true;
-                    break;
-                }
-            }
-
-            if (!alreadyExists) {
-                list.add(new GravitySource(pos, type));
-            }
-        }
-
-        public static void removeSource(Level level, BlockPos pos) {
-            long chunkKey = ChunkPos.asLong(pos);
-            Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
-            if (dimCache != null) {
-                List<GravitySource> sources = dimCache.get(chunkKey);
-                if (sources != null) {
-                    sources.removeIf(s -> s.pos.equals(pos));
-                    if (sources.isEmpty()) {
-                        dimCache.remove(chunkKey);
-                    }
-                }
-            }
-        }
-
-        private static double getEntityG(Entity entity) {
-            return switch (entity) {
-                case LivingEntity livingEntity -> 0.08;
-                case Projectile projectile -> 0.05;
-                default -> 0.04;
-            };
-        }
-
-        public static Vec3 calculateGravityVector(Level level, Vec3 p, double g) {
-            var cache = GRAVITY_CACHE.get(level.dimension());
-            if (cache == null) return Vec3.ZERO;
-
-            double fx = 0;
-            double fy = 0;
-            double fz = 0;
-            int cx = ((int) Math.floor(p.x)) >> 4;
-            int cz = ((int) Math.floor(p.z)) >> 4;
-
-            for (int x = -1; x <= 1; x++) {
-                for (int z = -1; z <= 1; z++) {
-                    var list = cache.get(ChunkPos.asLong(cx + x, cz + z));
-                    if (list == null) continue;
-                    for (var s : list) {
-                        double dx = s.pos.getX() + 0.5 - p.x;
-                        double dy = s.pos.getY() + 0.5 - p.y;
-                        double dz = s.pos.getZ() + 0.5 - p.z;
-                        double radiusSquare = dx * dx + dy * dy + dz * dz;
-
-                        if (radiusSquare <= s.type.radiusSqr) {
-                            // 使用传入的 g
-                            double f = (g * s.type.strength) / (Math.max(radiusSquare, 1.0) * Math.sqrt(radiusSquare));
-                            fx += dx * f;
-                            fy += dy * f;
-                            fz += dz * f;
-                        }
-                    }
-                }
-            }
-            return new Vec3(fx, fy, fz);
-        }
-
-        public static Vec3 calculateGravityVector(Entity entity) {
-            return calculateGravityVector(entity.level(), entity.getBoundingBox().getCenter(), getEntityG(entity));
-        }
+    private static boolean isOnMun(Level level) {
+        return false;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,10 +1,10 @@
 package dev.dubhe.anvilcraft.util;
 
+import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
-
-import java.lang.reflect.Method;
+import net.minecraft.world.level.block.state.BlockState;
 
 public class GravityManager {
     // 重力设置
@@ -25,19 +25,16 @@ public class GravityManager {
         return DEFAULT_GRAVITY;
     }
 
-    private static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
-        // 引用中子辐照器的检查方法
-        try {
-            Class<?> neutronIrradiatorClass = Class.forName("dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity");
-            Method isInIrradiatorRangeMethod = neutronIrradiatorClass.getMethod(
-                "isInIrradiatorRange",
-                Level.class,
-                BlockPos.class
-            );
-            return (boolean) isInIrradiatorRangeMethod.invoke(null, level, pos);
-        } catch (Exception e) {
-            return false;
+    public static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
+        for (int i = 0; i <= 7; i++) {
+            BlockPos belowPos = pos.below(i);
+            BlockState blockstate = level.getBlockState(belowPos);
+
+            if (blockstate.getBlock() instanceof NeutronIrradiatorBlock) {
+                return true;
+            }
         }
+        return false;
     }
 
     private static boolean isOnMun(Level level) {

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -2,8 +2,8 @@ package dev.dubhe.anvilcraft.util;
 
 import dev.dubhe.anvilcraft.block.BlackHoleBlock;
 import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
-import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
@@ -23,7 +23,10 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @EventBusSubscriber(modid = "anvilcraft", bus = EventBusSubscriber.Bus.GAME)
@@ -280,12 +283,15 @@ public class GravityManager {
             };
         }
 
-        public static Vec3 calculateGravityVector(Level level, Vec3 p, double G) {
+        public static Vec3 calculateGravityVector(Level level, Vec3 p, double g) {
             var cache = GRAVITY_CACHE.get(level.dimension());
             if (cache == null) return Vec3.ZERO;
 
-            double fx = 0, fy = 0, fz = 0;
-            int cx = ((int) Math.floor(p.x)) >> 4, cz = ((int) Math.floor(p.z)) >> 4;
+            double fx = 0;
+            double fy = 0;
+            double fz = 0;
+            int cx = ((int) Math.floor(p.x)) >> 4;
+            int cz = ((int) Math.floor(p.z)) >> 4;
 
             for (int x = -1; x <= 1; x++) {
                 for (int z = -1; z <= 1; z++) {
@@ -295,11 +301,11 @@ public class GravityManager {
                         double dx = s.pos.getX() + 0.5 - p.x;
                         double dy = s.pos.getY() + 0.5 - p.y;
                         double dz = s.pos.getZ() + 0.5 - p.z;
-                        double rSq = dx * dx + dy * dy + dz * dz;
+                        double radiusSquare = dx * dx + dy * dy + dz * dz;
 
-                        if (rSq <= s.type.radiusSqr) {
-                            // 使用传入的 G
-                            double f = (G * s.type.strength) / (Math.max(rSq, 1.0) * Math.sqrt(rSq));
+                        if (radiusSquare <= s.type.radiusSqr) {
+                            // 使用传入的 g
+                            double f = (g * s.type.strength) / (Math.max(radiusSquare, 1.0) * Math.sqrt(radiusSquare));
                             fx += dx * f;
                             fy += dy * f;
                             fz += dz * f;

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,88 +1,156 @@
 package dev.dubhe.anvilcraft.util;
 
-import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
+import dev.dubhe.anvilcraft.block.BlackHoleBlock;
 import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.item.FallingBlockEntity;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static dev.dubhe.anvilcraft.util.GravityManager.GravitySourceManager.getGravityVector;
-
+@EventBusSubscriber(modid = "anvilcraft", bus = EventBusSubscriber.Bus.GAME)
 public class GravityManager {
-    // 维度重力映射表
+
+    // 维度 -> 区块索引 -> 重力源列表
+    private static final Map<ResourceKey<Level>, Map<Long, List<GravitySource>>> GRAVITY_CACHE = new ConcurrentHashMap<>();
+
+    // 维度重力倍率表
     private static final Map<ResourceKey<Level>, Double> DIMENSION_GRAVITY_MAP = new HashMap<>();
 
     static {
-        GravitySourceManager.registerSource(NeutronIrradiatorBlock.class, 7, 10.0);
-        // 在这里注册更多重力源，strength -> 该重力源所在方块任意表面中心的重力是主世界重力的 strength 倍
+        GravitySourceManager.registerSourceType(BlackHoleBlock.class, 7, 10.0);
+        // 在这里注册更多重力源，strength -> 距离该重力源 1 格处的重力是主世界重力的 strength 倍
 
-        registerDimensionGravity(Level.END, 0.5);
+        registerDimensionGravity(Level.END, 0.1653061224489796);
         // 在这里注册更多维度重力，gravity -> 该维度重力是主世界重力的 gravity 倍
     }
 
-    // 设置不同实体的重力系数
-    private static double getGravityFactor(Entity entity) {
-        return switch (entity) {
-            case FallingBlockEntity fallingBlockEntity -> -0.04; // 下落方块
-            case LivingEntity livingEntity -> -0.08; // 生物
-            case Projectile projectile -> -0.05; // 投掷物
-            case ItemEntity itemEntity -> -0.02; // 掉落物
-            default -> -0.08;
+    // 区块加载事件，搜索BlockEntity添加重力源
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide && event.getChunk() instanceof LevelChunk chunk) {
+            for (BlockPos pos : chunk.getBlockEntitiesPos()) {
+                BlockState state = chunk.getBlockState(pos);
+                GravitySourceType type = GravitySourceManager.getType(state.getBlock());
+                if (type != null) {
+                    GravitySourceManager.addSource(level, pos, type);
+                }
+            }
+        }
+    }
+
+    // 区块卸载事件，移除记录的重力源
+    @SubscribeEvent
+    public static void onChunkUnload(ChunkEvent.Unload event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            long chunkKey = event.getChunk().getPos().toLong();
+            Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
+            if (dimCache != null) {
+                dimCache.remove(chunkKey);
+            }
+        }
+    }
+
+    // 世界卸载事件，清除所有缓存
+    @SubscribeEvent
+    public static void onLevelUnload(LevelEvent.Unload event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            GRAVITY_CACHE.remove(level.dimension());
+        }
+    }
+
+    // 方块放置事件，添加重力源
+    @SubscribeEvent
+    public static void onBlockPlace(BlockEvent.EntityPlaceEvent event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
+            if (type != null) {
+                GravitySourceManager.addSource(level, event.getPos(), type);
+            }
+        }
+    }
+
+    // 方块破坏事件，移除重力源
+    @SubscribeEvent
+    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (event.getLevel() instanceof Level level && !level.isClientSide) {
+            GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
+            if (type != null) {
+                GravitySourceManager.removeSource(level, event.getPos());
+            }
+        }
+    }
+
+    // 特殊物质定义不同引力类型
+    public enum GravityType {
+        NORMAL, // 正常实体正常重力
+        ANTI_GRAVITY, // 负物质反转重力
+        MICRO_ANTI_GRAVITY // 漂浮粉略有失重感
+    }
+
+    public static GravityType getGravityType(Entity entity) {
+        if (entity instanceof ItemEntity itemEntity) {
+            var item = itemEntity.getItem();
+
+            // 判断负物质
+            boolean isNegativeMatter = item.is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || item.is(ModItems.NEGATIVE_MATTER.get()) || item.is(
+                ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
+            if (isNegativeMatter) return GravityType.ANTI_GRAVITY;
+
+            // 判断漂浮粉
+            boolean isLevitationPowder = item.is(ModItems.LEVITATION_POWDER.get()) || item.is(ModBlocks.LEVITATION_POWDER_BLOCK.get()
+                .asItem());
+            if (isLevitationPowder) return GravityType.MICRO_ANTI_GRAVITY;
+        }
+
+        // 判断漂浮粉方块实体
+        if (entity instanceof LevitatingBlockEntity levitatingBlock && levitatingBlock.getBlockState()
+            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+            return GravityType.ANTI_GRAVITY;
+        }
+
+        return GravityType.NORMAL;
+    }
+
+    // 处理特殊实体，最终得到重力向量
+    public static Vec3 getGravityVector(Entity entity) {
+        // 获取计算的引力
+        Vec3 gravityVector = GravitySourceManager.calculateGravityVector(entity);
+
+        // 如果没有受到引力，直接返回零
+        if (gravityVector.equals(Vec3.ZERO)) {
+            return Vec3.ZERO;
+        }
+
+        // 获取实体引力类型
+        GravityType type = getGravityType(entity);
+
+        // 根据类型修正向量方向/大小
+        return switch (type) {
+            case ANTI_GRAVITY -> gravityVector.reverse();
+            case MICRO_ANTI_GRAVITY -> gravityVector.scale(-0.005);
+            default -> gravityVector;
         };
     }
 
-    // 应用重力并处理特殊实体
-    public static Vec3 applyGravity(Entity entity, Vec3 movement) {
-        Level level = entity.level();
-        BlockPos blockPos = entity.blockPosition();
-        Vec3 entityPos = entity.position();
-        Vec3 gravityVector = getGravityVector(level, blockPos, entityPos);
-
-        // 维度重力处理，恒定向下重力
-        if (getDimensionGravity(level) != 1.0) {
-            gravityVector = gravityVector.add(0, getGravityFactor(entity) * (getDimensionGravity(level) - 1.0), 0);
-        }
-
-        // 物品实体处理，负物质反转重力，漂浮粉略有失重感
-        if (entity instanceof ItemEntity itemEntity) {
-            var item = itemEntity.getItem();
-            boolean isNegativeMatter = item.is(ModItems.NEGATIVE_MATTER_NUGGET.get()) || item.is(ModItems.NEGATIVE_MATTER.get()) || item.is(
-                ModBlocks.NEGATIVE_MATTER_BLOCK.get().asItem());
-
-            if (isNegativeMatter) {
-                boolean isLevitationPowder = item.is(ModItems.LEVITATION_POWDER.get()) || item.is(ModBlocks.LEVITATION_POWDER_BLOCK.get()
-                    .asItem());
-
-                return movement.subtract(isLevitationPowder ? gravityVector.scale(0.005) : gravityVector);
-            }
-        }
-
-        // 漂浮粉块下落方块实体：反转重力
-        if (entity instanceof LevitatingBlockEntity levitatingBlock && levitatingBlock.getBlockState()
-            .is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
-            return movement.subtract(gravityVector);
-        }
-
-        // 默认情况：正常加重力
-        return movement.add(gravityVector);
-    }
-
-    // 维度重力管理器
+    // 应用维度重力
     public static void registerDimensionGravity(ResourceKey<Level> dimension, double gravity) {
         DIMENSION_GRAVITY_MAP.put(dimension, gravity);
     }
@@ -91,92 +159,105 @@ public class GravityManager {
         return DIMENSION_GRAVITY_MAP.getOrDefault(level.dimension(), 1.0);
     }
 
-    // 重力源类型定义
+    // 重力源定义与存储
     public static class GravitySourceType {
-        private final Class<? extends Block> blockClass;
-        private final int radius;
-        private final double strength;
+        final double strength;
+        final int radius;
+        final double radiusSqr;
 
-        public GravitySourceType(Class<? extends Block> blockClass, int radius, double strength) {
-            this.blockClass = blockClass;
-            this.radius = radius;
+        public GravitySourceType(double strength, int radius) {
             this.strength = strength;
-        }
-
-        public Class<? extends Block> getBlockClass() {
-            return blockClass;
-        }
-
-        public int getRadius() {
-            return radius;
-        }
-
-        public double getStrength() {
-            return strength;
+            this.radius = radius;
+            this.radiusSqr = radius * radius;
         }
     }
 
-    // 用于存储重力源信息的内部类
     public static class GravitySource {
         public final BlockPos pos;
-        public final double strength;
+        public final GravitySourceType type;
 
-        public GravitySource(BlockPos pos, double strength) {
+        public GravitySource(BlockPos pos, GravitySourceType type) {
             this.pos = pos;
-            this.strength = strength;
+            this.type = type;
         }
     }
 
     // 重力源管理器
     public static class GravitySourceManager {
-        private static final List<GravitySourceType> REGISTERED_SOURCES = new ArrayList<>();
+        private static final Map<Class<? extends Block>, GravitySourceType> REGISTRY = new HashMap<>();
 
-        public static void registerSource(Class<? extends Block> blockClass, int radius, double strength) {
-            REGISTERED_SOURCES.add(new GravitySourceType(blockClass, radius, strength));
+        public static void registerSourceType(Class<? extends Block> blockClass, int radius, double strength) {
+            REGISTRY.put(blockClass, new GravitySourceType(strength, radius));
         }
 
-        // 计算实体所受的总重力（返回向量）
-        public static Vec3 getGravityVector(Level level, BlockPos pos, Vec3 entityPos) {
-            List<GravitySource> sources = new ArrayList<>();
-            for (GravitySourceType type : REGISTERED_SOURCES) { // 遍历所有注册的重力源
-                findGravitySourcesInRange(level, pos, type, sources);
-            }
-            if (sources.isEmpty()) { // 如果没有任何重力源，返回默认重力
-                return new Vec3(0, 0, 0);
-            }
-            return gravityVector(sources, entityPos); // 否则计算合力
+        public static GravitySourceType getType(Block block) {
+            return REGISTRY.get(block.getClass());
         }
 
-        // 搜索重力源
-        private static void findGravitySourcesInRange(Level level, BlockPos center, GravitySourceType type, List<GravitySource> sources) {
-            int radius = type.getRadius(); // 读取重力源半径
-            int rSqr = radius * radius;
-            for (int x = -radius; x <= radius; x++) { // 遍历所有方块
-                for (int y = -radius; y <= radius; y++) {
-                    for (int z = -radius; z <= radius; z++) {
-                        if (x * x + y * y + z * z > rSqr) continue; // 球形
-                        BlockPos checkPos = center.offset(x, y, z);
-                        BlockState state = level.getBlockState(checkPos);
-                        if (type.getBlockClass().isInstance(state.getBlock())) {
-                            sources.add(new GravitySource(checkPos, type.getStrength()));
-                        }
+        public static void addSource(Level level, BlockPos pos, GravitySourceType type) {
+            long chunkKey = ChunkPos.asLong(pos);
+            List<GravitySource> list = GRAVITY_CACHE.computeIfAbsent(level.dimension(), k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(chunkKey, k -> new ArrayList<>());
+
+            // 检查列表中是否已经有该坐标的重力源
+            boolean alreadyExists = false;
+            for (GravitySource s : list) {
+                if (s.pos.equals(pos)) {
+                    alreadyExists = true;
+                    break;
+                }
+            }
+
+            if (!alreadyExists) {
+                list.add(new GravitySource(pos, type));
+            }
+        }
+
+        public static void removeSource(Level level, BlockPos pos) {
+            long chunkKey = ChunkPos.asLong(pos);
+            Map<Long, List<GravitySource>> dimCache = GRAVITY_CACHE.get(level.dimension());
+            if (dimCache != null) {
+                List<GravitySource> sources = dimCache.get(chunkKey);
+                if (sources != null) {
+                    sources.removeIf(s -> s.pos.equals(pos));
+                    if (sources.isEmpty()) {
+                        dimCache.remove(chunkKey);
                     }
                 }
             }
         }
 
-        // 计算来自所有重力源的合力
-        public static Vec3 gravityVector(List<GravitySource> sources, Vec3 entityPosition) {
-            double fx = 0, fy = 0, fz = 0;
-            for (GravitySource source : sources) { // 遍历重力源累加引力
-                Vec3 direction = Vec3.atCenterOf(source.pos).subtract(entityPosition); // 每个重力源计算距离向量
-                double rSqr = direction.lengthSqr();
-                if (rSqr > 0.70710678) {
-                    double r = Math.sqrt(rSqr); // 万有引力公式计算
-                    double f = 0.0224964424376324 * source.strength / (rSqr); // 测量得 G 在0.0224964424376323和0.0224964424376324之间
-                    fx += direction.x / r * f; // 累加各分量力返回总向量
-                    fy += direction.y / r * f;
-                    fz += direction.z / r * f;
+        private static double getEntityG(Entity entity) {
+            return switch (entity) {
+                case LivingEntity livingEntity -> 0.08;
+                case Projectile projectile -> 0.05;
+                default -> 0.04;
+            };
+        }
+
+        public static Vec3 calculateGravityVector(Entity e) {
+            var cache = GRAVITY_CACHE.get(e.level().dimension());
+            if (cache == null) return Vec3.ZERO;
+
+            Vec3 p = e.position();
+            double G = getEntityG(e), fx = 0, fy = 0, fz = 0;
+            int cx = ((int) Math.floor(p.x)) >> 4, cz = ((int) Math.floor(p.z)) >> 4;
+
+            for (int x = -1; x <= 1; x++) {
+                for (int z = -1; z <= 1; z++) {
+                    var list = cache.get(ChunkPos.asLong(cx + x, cz + z));
+                    if (list == null) continue;
+                    for (var s : list) {
+                        double dx = s.pos.getX() + 0.5 - p.x, dy = s.pos.getY() + 0.5 - p.y, dz = s.pos.getZ() + 0.5 - p.z;
+                        double rSq = dx * dx + dy * dy + dz * dz;
+
+                        if (rSq <= s.type.radiusSqr) {
+                            double f = (G * s.type.strength) / (Math.max(rSq, 1.0) * Math.sqrt(rSq));
+                            fx += dx * f;
+                            fy += dy * f;
+                            fz += dz * f;
+                        }
+                    }
                 }
             }
             return new Vec3(fx, fy, fz);

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -42,7 +42,7 @@ public class GravityManager {
         GravitySourceManager.registerSourceType(BlackHoleBlock.class, 7, 10.0);
         // 在这里注册更多重力源，strength -> 距离该重力源 1 格处的重力是主世界重力的 strength 倍
 
-        registerDimensionGravity(Level.END, 0.1653061224489796);
+        // registerDimensionGravity(Level.MUN, 0.1653061224489796);
         // 在这里注册更多维度重力，gravity -> 该维度重力是主世界重力的 gravity 倍
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,0 +1,39 @@
+package dev.dubhe.anvilcraft.util;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+
+public class GravityManager {
+    // 重力设置
+    public static final double DEFAULT_GRAVITY = 1.0;
+    public static final double NEUTRON_IRRADIATOR_GRAVITY = 3.0;
+    public static final double MUN_GRAVITY = 0.1663;
+
+    public static double getGravity(Entity entity) {
+        Level level = entity.level();
+        BlockPos pos = entity.blockPosition();
+        // 检查应该用什么重力
+        if (isInNeutronIrradiatorRange(level, pos)) {
+            return NEUTRON_IRRADIATOR_GRAVITY;
+        } if (isOnMun(level)) {
+            return MUN_GRAVITY;
+        } return DEFAULT_GRAVITY;
+    }
+
+    private static boolean isInNeutronIrradiatorRange(Level level, BlockPos pos) {
+        // 引用中子辐照器的检查方法
+        try {
+            Class<?> neutronIrradiatorClass = Class.forName("dev.dubhe.anvilcraft.block.entity.NeutronIrradiatorBlockEntity");
+            java.lang.reflect.Method isInIrradiatorRangeMethod = neutronIrradiatorClass.getMethod(
+                "isInIrradiatorRange", Level.class, BlockPos.class);
+            return (boolean) isInIrradiatorRangeMethod.invoke(null, level, pos);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static boolean isOnMun(Level level) {
+        return false;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.phys.Vec3;
@@ -83,6 +84,16 @@ public class GravityManager {
             GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
             if (type != null) {
                 GravitySourceManager.addSource(level, event.getPos(), type);
+                int r = type.radius;
+                // 遍历黑洞影响范围内的方块
+                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r))
+                    .forEach(pos -> {
+                        BlockState state = level.getBlockState(pos);
+                        // 如果是下落方块，给计划刻让它更新
+                        if (state.getBlock() instanceof FallingBlock) {
+                            level.scheduleTick(pos, state.getBlock(), 2);
+                        }
+                    });
             }
         }
     }
@@ -94,6 +105,16 @@ public class GravityManager {
             GravitySourceType type = GravitySourceManager.getType(event.getState().getBlock());
             if (type != null) {
                 GravitySourceManager.removeSource(level, event.getPos());
+                int r = type.radius;
+                // 遍历黑洞影响范围内的方块
+                BlockPos.betweenClosedStream(event.getPos().offset(-r, -r, -r), event.getPos().offset(r, r, r))
+                    .forEach(pos -> {
+                        BlockState state = level.getBlockState(pos);
+                        // 如果是下落方块，给计划刻让它更新
+                        if (state.getBlock() instanceof FallingBlock) {
+                            level.scheduleTick(pos, state.getBlock(), 2);
+                        }
+                    });
             }
         }
     }
@@ -127,6 +148,13 @@ public class GravityManager {
         }
 
         return GravityType.NORMAL;
+    }
+
+    public static GravityType getFallingBlockGravityType(Block block) {
+        if (block.equals(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
+            return GravityType.ANTI_GRAVITY; // 漂浮粉块
+        }
+        return GravityType.NORMAL; // 普通下落方块
     }
 
     // 处理特殊实体，最终得到重力向量
@@ -235,12 +263,11 @@ public class GravityManager {
             };
         }
 
-        public static Vec3 calculateGravityVector(Entity e) {
-            var cache = GRAVITY_CACHE.get(e.level().dimension());
+        public static Vec3 calculateGravityVector(Level level, Vec3 p, double G) {
+            var cache = GRAVITY_CACHE.get(level.dimension());
             if (cache == null) return Vec3.ZERO;
 
-            Vec3 p = e.position();
-            double G = getEntityG(e), fx = 0, fy = 0, fz = 0;
+            double fx = 0, fy = 0, fz = 0;
             int cx = ((int) Math.floor(p.x)) >> 4, cz = ((int) Math.floor(p.z)) >> 4;
 
             for (int x = -1; x <= 1; x++) {
@@ -248,10 +275,13 @@ public class GravityManager {
                     var list = cache.get(ChunkPos.asLong(cx + x, cz + z));
                     if (list == null) continue;
                     for (var s : list) {
-                        double dx = s.pos.getX() + 0.5 - p.x, dy = s.pos.getY() + 0.5 - p.y, dz = s.pos.getZ() + 0.5 - p.z;
+                        double dx = s.pos.getX() + 0.5 - p.x;
+                        double dy = s.pos.getY() + 0.5 - p.y;
+                        double dz = s.pos.getZ() + 0.5 - p.z;
                         double rSq = dx * dx + dy * dy + dz * dz;
 
                         if (rSq <= s.type.radiusSqr) {
+                            // 使用传入的 G
                             double f = (G * s.type.strength) / (Math.max(rSq, 1.0) * Math.sqrt(rSq));
                             fx += dx * f;
                             fy += dy * f;
@@ -261,6 +291,10 @@ public class GravityManager {
                 }
             }
             return new Vec3(fx, fy, fz);
+        }
+
+        public static Vec3 calculateGravityVector(Entity entity) {
+            return calculateGravityVector(entity.level(), entity.getBoundingBox().getCenter(), getEntityG(entity));
         }
     }
 }

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -26,6 +26,7 @@
     "EntityTypeBuilderMixin",
     "ExplosionMixin",
     "FallingBlockEntityMixin",
+    "FallingBlockMixin",
     "FlyingHitEntityMixin",
     "GrowingPlantBlockMixin",
     "HolderReferenceMixin",

--- a/src/main/resources/assets/anvilcraft/blockstates/black_hole.json
+++ b/src/main/resources/assets/anvilcraft/blockstates/black_hole.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "anvilcraft:block/black_hole"
+    }
+  }
+}


### PR DESCRIPTION
本PR完全重构了模组的重力机制，引入了全新的 **GravityManager**，实现了一套基于三维向量的通用重力系统，所有实体均接入，受局部重力源和维度重力的共同影响。该系统支持维度差异化重力、局部重力源，并重写了下落方块和其实体的物理判定逻辑使其能够在任意重力方向下正确运动、滑行和着陆，并支持便捷的注册新的重力源或维度。

### **1. 重力管理器**
建立了一套全局的重力计算框架，实体的受力不再局限于垂直向下：

**重力源管理：**
定义和管理各种重力源，缓存各个维度和区块中的重力源位置及强度，监听游戏事件（区块加载/卸载、方块放置/破坏）来动态维护重力源。定义维度的重力系数。

**重力向量计算：**
为不同实体计算所受的重力向量，支持维度特定的重力倍率，结合不同实体基础重力和局部重力源的影响
某方向的重力源重力分量 = 实体基础重力 * 重力源强度 * 该方向的相对距离 / 总距离的立方

**重力向量应用：**
总重力 **y** 方向分量 = 实体基础重力 * 维度重力系数 - 重力源重力 y 方向分量 -> 作为标量 Mixin 传入 Entity.getGravity( ) 实现各种实体 y 方向精确的重力处理
总重力的 **x & z** 方向分量 -> 通过 Mixin Entity.tick( ) setDeltaMovement(getDeltaMovement.add(x, 0, z)) 实现 x & z 方向对于大部分实体精确的重力处理


### **2. 重力方块重构**
通过 Mixin 对 FallingBlockEntity 进行了深度改造，使其适应复杂的引力环境：

**任意方向着陆：**
重写 onGround( ) 判定，支持在天花板、墙壁或斜面上“着陆”。

**智能激活：**
重力方块现在会计算合力方向的切向分量。如果受到侧向引力且摩擦力不足以维持静止，方块将自动激活为实体。

**增强物理模拟：**
引入切向力与法向力的物理模型。实体在冰面上更容易滑向引力源，在粗糙表面则更稳定。在着陆前预测“变成方块后是否稳定”，防止实体在“方块/实体”状态间高频转换。精确处理不完整方块（如半砖、炼药锅）的碰撞逻辑，判定是着陆还是碎裂。

**漂浮粉块重构：**
移除了漂浮粉块旧版硬编码的物理逻辑，通过extend FallingBlock并标记为 ANTI_GRAVITY 类型，完全复用新的通用物理引擎。
