### PR TITLE
Fix the issue of incorrect products in super heating raw block recipes and remove compatibility with wrenches for other mod 修复高温熔炼粗矿块配方的产物不正确的问题和移除对其他模组的扳手的兼容

### DIFF
--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/lead_block_from_storage_blocks/raw_lead.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/lead_block_from_storage_blocks/raw_lead.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/lead_ingot_from_storage_blocks/raw_lead"
+        "recipe": "anvilcraft:super_heating/metal_block/lead_block_from_storage_blocks/raw_lead"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/lead_ingot_from_storage_blocks/raw_lead"
+      "anvilcraft:super_heating/metal_block/lead_block_from_storage_blocks/raw_lead"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/silver_block_from_storage_blocks/raw_silver.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/silver_block_from_storage_blocks/raw_silver.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/zinc_ingot_from_storage_blocks/raw_zinc"
+        "recipe": "anvilcraft:super_heating/metal_block/silver_block_from_storage_blocks/raw_silver"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/zinc_ingot_from_storage_blocks/raw_zinc"
+      "anvilcraft:super_heating/metal_block/silver_block_from_storage_blocks/raw_silver"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/tin_block_from_storage_blocks/raw_tin.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/tin_block_from_storage_blocks/raw_tin.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/silver_ingot_from_storage_blocks/raw_silver"
+        "recipe": "anvilcraft:super_heating/metal_block/tin_block_from_storage_blocks/raw_tin"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/silver_ingot_from_storage_blocks/raw_silver"
+      "anvilcraft:super_heating/metal_block/tin_block_from_storage_blocks/raw_tin"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/titanium_block_from_storage_blocks/raw_titanium.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/titanium_block_from_storage_blocks/raw_titanium.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/titanium_ingot_from_storage_blocks/raw_titanium"
+        "recipe": "anvilcraft:super_heating/metal_block/titanium_block_from_storage_blocks/raw_titanium"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/titanium_ingot_from_storage_blocks/raw_titanium"
+      "anvilcraft:super_heating/metal_block/titanium_block_from_storage_blocks/raw_titanium"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/tungsten_block_from_storage_blocks/raw_tungsten.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/tungsten_block_from_storage_blocks/raw_tungsten.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/tin_ingot_from_storage_blocks/raw_tin"
+        "recipe": "anvilcraft:super_heating/metal_block/tungsten_block_from_storage_blocks/raw_tungsten"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/tin_ingot_from_storage_blocks/raw_tin"
+      "anvilcraft:super_heating/metal_block/tungsten_block_from_storage_blocks/raw_tungsten"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/uranium_block_from_storage_blocks/raw_uranium.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/uranium_block_from_storage_blocks/raw_uranium.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/tungsten_ingot_from_storage_blocks/raw_tungsten"
+        "recipe": "anvilcraft:super_heating/metal_block/uranium_block_from_storage_blocks/raw_uranium"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/tungsten_ingot_from_storage_blocks/raw_tungsten"
+      "anvilcraft:super_heating/metal_block/uranium_block_from_storage_blocks/raw_uranium"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/zinc_block_from_storage_blocks/raw_zinc.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/super_heating/metal_block/zinc_block_from_storage_blocks/raw_zinc.json
@@ -3,7 +3,7 @@
   "criteria": {
     "has_the_recipe": {
       "conditions": {
-        "recipe": "anvilcraft:super_heating/metal_block/uranium_ingot_from_storage_blocks/raw_uranium"
+        "recipe": "anvilcraft:super_heating/metal_block/zinc_block_from_storage_blocks/raw_zinc"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -15,7 +15,7 @@
   ],
   "rewards": {
     "recipes": [
-      "anvilcraft:super_heating/metal_block/uranium_ingot_from_storage_blocks/raw_uranium"
+      "anvilcraft:super_heating/metal_block/zinc_block_from_storage_blocks/raw_zinc"
     ]
   }
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/lead_block_from_storage_blocks/raw_lead.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/lead_block_from_storage_blocks/raw_lead.json
@@ -8,7 +8,7 @@
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:lead_ingot"
+      "id": "anvilcraft:lead_block"
     }
   ]
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/silver_block_from_storage_blocks/raw_silver.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/silver_block_from_storage_blocks/raw_silver.json
@@ -8,7 +8,7 @@
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:silver_ingot"
+      "id": "anvilcraft:silver_block"
     }
   ]
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/tin_block_from_storage_blocks/raw_tin.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/tin_block_from_storage_blocks/raw_tin.json
@@ -2,13 +2,13 @@
   "type": "anvilcraft:super_heating",
   "ingredients": [
     {
-      "items": "#c:storage_blocks/raw_zinc"
+      "items": "#c:storage_blocks/raw_tin"
     }
   ],
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:zinc_ingot"
+      "id": "anvilcraft:tin_block"
     }
   ]
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/titanium_block_from_storage_blocks/raw_titanium.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/titanium_block_from_storage_blocks/raw_titanium.json
@@ -8,7 +8,7 @@
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:titanium_ingot"
+      "id": "anvilcraft:titanium_block"
     }
   ]
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/tungsten_block_from_storage_blocks/raw_tungsten.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/tungsten_block_from_storage_blocks/raw_tungsten.json
@@ -2,13 +2,13 @@
   "type": "anvilcraft:super_heating",
   "ingredients": [
     {
-      "items": "#c:storage_blocks/raw_tin"
+      "items": "#c:storage_blocks/raw_tungsten"
     }
   ],
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:tin_ingot"
+      "id": "anvilcraft:tungsten_block"
     }
   ]
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/uranium_block_from_storage_blocks/raw_uranium.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/uranium_block_from_storage_blocks/raw_uranium.json
@@ -8,7 +8,7 @@
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:uranium_ingot"
+      "id": "anvilcraft:uranium_block"
     }
   ]
 }

--- a/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/zinc_block_from_storage_blocks/raw_zinc.json
+++ b/src/generated/resources/data/anvilcraft/recipe/super_heating/metal_block/zinc_block_from_storage_blocks/raw_zinc.json
@@ -2,13 +2,13 @@
   "type": "anvilcraft:super_heating",
   "ingredients": [
     {
-      "items": "#c:storage_blocks/raw_tungsten"
+      "items": "#c:storage_blocks/raw_zinc"
     }
   ],
   "results": [
     {
       "count": 2,
-      "id": "anvilcraft:tungsten_ingot"
+      "id": "anvilcraft:zinc_block"
     }
   ]
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/plate/HealthPercentPressurePlateBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/plate/HealthPercentPressurePlateBlock.java
@@ -51,9 +51,8 @@ public class HealthPercentPressurePlateBlock extends PowerLevelPressurePlateBloc
             ));
         }
 
-        float healthPercent = HealthPercentPressurePlateBlock.getLargestHealthPercent(entities);
-
         try {
+            float healthPercent = getLargestHealthPercent(entities);
             return new Pair<>(Math.max(healthPercent, 0), Math.min(healthPercent, 1));
         } catch (NoSuchElementException ignored) {
             return new Pair<>(0F, 0F);

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/SuperHeatingRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/SuperHeatingRecipeLoader.java
@@ -90,13 +90,13 @@ public class SuperHeatingRecipeLoader {
         metalBlockFromRaw(provider, Tags.Items.STORAGE_BLOCKS_RAW_COPPER, Items.COPPER_BLOCK);
         metalBlockFromRaw(provider, Tags.Items.STORAGE_BLOCKS_RAW_IRON, Items.IRON_BLOCK);
         metalBlockFromRaw(provider, Tags.Items.STORAGE_BLOCKS_RAW_GOLD, Items.GOLD_BLOCK);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_ZINC, ModItems.ZINC_INGOT);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_TIN, ModItems.TIN_INGOT);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_TITANIUM, ModItems.TITANIUM_INGOT);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_TUNGSTEN, ModItems.TUNGSTEN_INGOT);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_LEAD, ModItems.LEAD_INGOT);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_SILVER, ModItems.SILVER_INGOT);
-        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_URANIUM, ModItems.URANIUM_INGOT);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_ZINC, ModBlocks.ZINC_BLOCK);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_TIN, ModBlocks.TIN_BLOCK);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_TITANIUM, ModBlocks.TITANIUM_BLOCK);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_TUNGSTEN, ModBlocks.TUNGSTEN_BLOCK);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_LEAD, ModBlocks.LEAD_BLOCK);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_SILVER, ModBlocks.SILVER_BLOCK);
+        metalBlockFromRaw(provider, ModItemTags.STORAGE_BLOCKS_RAW_URANIUM, ModBlocks.URANIUM_BLOCK);
 
         // limePowder
         limePowder(provider, ModItems.CRAB_CLAW, 1);

--- a/src/main/java/dev/dubhe/anvilcraft/event/BlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/BlockEventListener.java
@@ -2,13 +2,10 @@ package dev.dubhe.anvilcraft.event;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
-import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.BlockTags;
@@ -16,7 +13,6 @@ import net.minecraft.util.ParticleUtils;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -28,9 +24,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
-import net.neoforged.neoforge.event.level.BlockEvent;
 
 @EventBusSubscriber(modid = AnvilCraft.MOD_ID)
 public class BlockEventListener {
@@ -63,8 +57,7 @@ public class BlockEventListener {
         BlockPos blockPos = event.getPos();
         BlockState targetBlockState = level.getBlockState(blockPos);
         if (
-            itemStack.getItem() instanceof AnvilHammerItem
-                || (itemStack.is(Tags.Items.TOOLS_WRENCH) && targetBlockState.getBlock() instanceof IHammerChangeable)
+            itemStack.getItem() instanceof AnvilHammerItem && targetBlockState.getBlock() instanceof IHammerChangeable
         ) {
             if (player.level().isClientSide()) return;
             if (AnvilHammerItem.ableToUseAnvilHammer(level, blockPos, player)) {


### PR DESCRIPTION
- Fixed #3049 
- Fixed #1923 
- Fixed #2863 