### PR TITLE
Fixed the bug with the adjustable slot item limit container 修复了可调整槽位物品上限容器bug

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
@@ -12,6 +12,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -293,5 +294,34 @@ public abstract class BaseChuteBlockEntity
             if (itemstack.isEmpty() || itemstack.getCount() != itemstack.getMaxStackSize()) return false;
         }
         return true;
+    }
+
+    /**
+     * 获取更新标签 (由服务端调用，决定发给客户端什么数据)
+     */
+    @Override
+    public CompoundTag getUpdateTag(HolderLookup.Provider provider) {
+        CompoundTag tag = new CompoundTag();
+        this.saveAdditional(tag, provider);
+        return tag;
+    }
+
+    /**
+     * 获取更新数据包 (区块加载时调用)
+     */
+    @Nullable
+    @Override
+    public ClientboundBlockEntityDataPacket getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    /**
+     * 客户端接收数据包 (由客户端调用)
+     * 收到包 -> 读取NBT -> 覆盖本地数据
+     */
+    @Override
+    public void onDataPacket(net.minecraft.network.Connection net, ClientboundBlockEntityDataPacket pkt, HolderLookup.Provider lookupProvider) {
+        CompoundTag tag = pkt.getTag();
+        this.loadAdditional(tag, lookupProvider);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseChuteBlockEntity.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -320,7 +321,7 @@ public abstract class BaseChuteBlockEntity
      * 收到包 -> 读取NBT -> 覆盖本地数据
      */
     @Override
-    public void onDataPacket(net.minecraft.network.Connection net, ClientboundBlockEntityDataPacket pkt, HolderLookup.Provider lookupProvider) {
+    public void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt, HolderLookup.Provider lookupProvider) {
         CompoundTag tag = pkt.getTag();
         this.loadAdditional(tag, lookupProvider);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/network/SlotFilterMaxStackSizeChangePacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/SlotFilterMaxStackSizeChangePacket.java
@@ -9,6 +9,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.handling.DirectionalPayloadHandler;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
@@ -59,6 +60,10 @@ public class SlotFilterMaxStackSizeChangePacket implements CustomPacketPayload {
             if (!(player.containerMenu instanceof IFilterMenu menu)) return;
             if (!(menu.getFilterBlockEntity() instanceof IFilterBlockEntity blockEntity)) return;
             blockEntity.setSlotLimit(data.index, data.maxStackSize);
+            if (blockEntity instanceof BlockEntity be) {
+                be.setChanged();
+                be.getLevel().sendBlockUpdated(be.getBlockPos(), be.getBlockState(), be.getBlockState(), 3);
+            }
             menu.flush();
             PacketDistributor.sendToPlayer(player, data);
         });


### PR DESCRIPTION
- fixed#2998
1. 加入getUpdatePacket和onDataPacket同步客户端和服务端，解决数字不显示
2. 给网络包加入be.setChanged()，再触发一次更新，解决空槽位不保存