### PR TITLE
Fix not enough fluid in cauldron will execute recipes 修复炼药锅内流体不足也可执行配方的问题

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -562,6 +562,7 @@
   "entity.anvilcraft.thrown_frost_metal_heavy_halberd": "pɹǝqןɐH ʎʌɐǝH ןɐʇǝW ʇsoɹℲ uʍoɹɥ⟘",
   "entity.anvilcraft.thrown_transcendence_heavy_halberd": "pɹǝqןɐH ʎʌɐǝH ǝɔuǝpuǝɔsuɐɹ⟘ uʍoɹɥ⟘",
   "entity.minecraft.villager.anvilcraft.jeweler": "ɹǝןǝʍǝſ",
+  "fluid.anvilcraft.fire": ")uoɹpןnɐƆ ǝɹıℲ ɟo ʇuǝʇuoɔ ǝɥ⟘( ןıO buıuɹnᗺ",
   "gui.anvilcraft.category.anvil_collision": "uoısıןןoƆ ןıʌuⱯ",
   "gui.anvilcraft.category.anvil_collision.consume": "%d :ןıʌuⱯ ǝɯnsuoƆ",
   "gui.anvilcraft.category.anvil_collision.maxcount": "%s :ʇunoƆ xɐW",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -562,6 +562,7 @@
   "entity.anvilcraft.thrown_frost_metal_heavy_halberd": "Thrown Frost Metal Heavy Halberd",
   "entity.anvilcraft.thrown_transcendence_heavy_halberd": "Thrown Transcendence Heavy Halberd",
   "entity.minecraft.villager.anvilcraft.jeweler": "Jeweler",
+  "fluid.anvilcraft.fire": "Burning Oil (The content of Fire Cauldron)",
   "gui.anvilcraft.category.anvil_collision": "Anvil Collision",
   "gui.anvilcraft.category.anvil_collision.consume": "Consume Anvil: %d",
   "gui.anvilcraft.category.anvil_collision.maxcount": "Max Count: %s",

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/FluidLang.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/FluidLang.java
@@ -1,0 +1,10 @@
+package dev.dubhe.anvilcraft.data.lang;
+
+import com.tterrag.registrate.providers.RegistrateLangProvider;
+
+public class FluidLang {
+    @SuppressWarnings("checkstyle:LineLength")
+    public static void init(RegistrateLangProvider provider) {
+        provider.add("fluid.anvilcraft.fire", "Burning Oil (The content of Fire Cauldron)");
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/LangHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/LangHandler.java
@@ -18,5 +18,6 @@ public class LangHandler {
         ToolPropertyLang.init(provider);
         CommandLang.init(provider);
         KeyMappingLang.init(provider);
+        FluidLang.init(provider);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
@@ -80,7 +80,15 @@ public record HasCauldron(Vec3 offset, ResourceLocation fluid, int consume, Reso
         Block transformCauldron = this.getTransformCauldron();
         
         // 检查是否是目标炼药锅类型
-        if (curState.is(fluidCauldron)) return true;
+        if (curState.is(fluidCauldron)) {
+            Optional<Tuple<IntegerProperty, Integer>> optionalCur = HasCauldron.getFluidLevel(curState);
+            // 检查是否为空炼药锅或炼药锅内液体量足够执行配方
+            return curState.is(Blocks.CAULDRON)
+                   || HasCauldron.layer2Mb(
+                       optionalCur.map(Tuple::getA).orElse(IntegerProperty.create("level", 0, 1)),
+                       optionalCur.map(Tuple::getB).orElse(0)
+            ) >= this.consume;
+        }
         
         // 如果不需要特定液体且不需要转换，则允许空炼药锅
         if (!HasCauldron.isNotEmpty(this.fluid()) && !HasCauldron.isNotEmpty(this.transform())) {


### PR DESCRIPTION
- fixed #3059
- 修复了fluid.anvilcraft.fire没有翻译的问题