### PR TITLE
Enable the anvil hammer to change the direction of the acceleration ring and deflection ring 让铁砧锤能够修改加速环和偏转环的的方向

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/AccelerationRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/AccelerationRingBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block;
 
+import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.power.IPowerComponent;
 import dev.dubhe.anvilcraft.api.power.IPowerConsumer;
@@ -8,6 +9,8 @@ import dev.dubhe.anvilcraft.block.multipart.FlexibleMultiPartBlock;
 import dev.dubhe.anvilcraft.block.state.DirectionCube3x3PartHalf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -27,13 +30,12 @@ import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
 public class AccelerationRingBlock extends FlexibleMultiPartBlock<DirectionCube3x3PartHalf, DirectionProperty, Direction>
-    implements EntityBlock, IHammerRemovable {
+    implements EntityBlock, IHammerRemovable, IHammerChangeable {
     public static final EnumProperty<DirectionCube3x3PartHalf> HALF = EnumProperty.create("half", DirectionCube3x3PartHalf.class);
     public static final DirectionProperty FACING = BlockStateProperties.FACING;
     public static final BooleanProperty OVERLOAD = IPowerComponent.OVERLOAD;
@@ -69,7 +71,7 @@ public class AccelerationRingBlock extends FlexibleMultiPartBlock<DirectionCube3
     }
 
     @Override
-    protected BlockState placedState(DirectionCube3x3PartHalf part, BlockState state) {
+    public BlockState placedState(DirectionCube3x3PartHalf part, BlockState state) {
         return state
             .setValue(this.getPart(), part);
     }
@@ -157,7 +159,18 @@ public class AccelerationRingBlock extends FlexibleMultiPartBlock<DirectionCube3
     }
 
     @Override
-    protected float getShadeBrightness(@NotNull BlockState state, @NotNull BlockGetter getter, @NotNull BlockPos pos) {
+    protected float getShadeBrightness(BlockState state, BlockGetter getter, BlockPos pos) {
         return 1.0F;
+    }
+
+    @Override
+    public boolean change(Player player, BlockPos blockPos, Level level, ItemStack anvilHammer) {
+        this.change(blockPos, level, (state) -> state.cycle(FACING));
+        return true;
+    }
+
+    @Override
+    public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
+        return FACING;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/DeflectionRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/DeflectionRingBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block;
 
+import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.power.IPowerComponent;
 import dev.dubhe.anvilcraft.api.power.IPowerConsumer;
@@ -9,6 +10,8 @@ import dev.dubhe.anvilcraft.block.multipart.FlexibleMultiPartBlock;
 import dev.dubhe.anvilcraft.block.state.DirectionCube3x3PartHalf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -32,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 
 public class DeflectionRingBlock extends FlexibleMultiPartBlock<DirectionCube3x3PartHalf, DirectionProperty, Direction>
-    implements EntityBlock, IHammerRemovable {
+    implements EntityBlock, IHammerRemovable, IHammerChangeable {
     public static final EnumProperty<DirectionCube3x3PartHalf> HALF = EnumProperty.create("half", DirectionCube3x3PartHalf.class);
     public static final DirectionProperty FACING = BlockStateProperties.FACING;
     public static final BooleanProperty OVERLOAD = IPowerComponent.OVERLOAD;
@@ -68,7 +71,7 @@ public class DeflectionRingBlock extends FlexibleMultiPartBlock<DirectionCube3x3
     }
 
     @Override
-    protected BlockState placedState(DirectionCube3x3PartHalf part, BlockState state) {
+    public BlockState placedState(DirectionCube3x3PartHalf part, BlockState state) {
         return state
             .setValue(this.getPart(), part);
     }
@@ -160,5 +163,16 @@ public class DeflectionRingBlock extends FlexibleMultiPartBlock<DirectionCube3x3
     @Override
     protected float getShadeBrightness(BlockState state, BlockGetter getter, BlockPos pos) {
         return 1.0F;
+    }
+
+    @Override
+    public boolean change(Player player, BlockPos blockPos, Level level, ItemStack anvilHammer) {
+        this.change(blockPos, level, (state) -> state.cycle(FACING));
+        return true;
+    }
+
+    @Override
+    public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
+        return FACING;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/GiantAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/GiantAnvilBlock.java
@@ -237,7 +237,7 @@ public class GiantAnvilBlock extends SimpleMultiPartBlock<Cube3x3PartHalf> imple
     }
 
     @Override
-    protected BlockState placedState(Cube3x3PartHalf part, BlockState state) {
+    public BlockState placedState(Cube3x3PartHalf part, BlockState state) {
         return super.placedState(part, state)
             .setValue(CUBE, part == Cube3x3PartHalf.MID_CENTER ? GiantAnvilCube.CENTER : GiantAnvilCube.CORNER);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/block/OverseerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/OverseerBlock.java
@@ -91,7 +91,7 @@ public class OverseerBlock
     }
 
     @Override
-    protected BlockState placedState(Vertical3PartHalf part, BlockState state) {
+    public BlockState placedState(Vertical3PartHalf part, BlockState state) {
         return super.placedState(part, state).setValue(LEVEL, 1);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/RemoteTransmissionPoleBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/RemoteTransmissionPoleBlock.java
@@ -104,7 +104,7 @@ public class RemoteTransmissionPoleBlock
     }
 
     @Override
-    protected BlockState placedState(Vertical4PartHalf part, BlockState state) {
+    public BlockState placedState(Vertical4PartHalf part, BlockState state) {
         return super.placedState(part, state).setValue(SWITCH, IPowerComponent.Switch.ON);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/TeslaTowerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/TeslaTowerBlock.java
@@ -115,7 +115,7 @@ public class TeslaTowerBlock
     }
 
     @Override
-    protected BlockState placedState(Vertical4PartHalf part, BlockState state) {
+    public BlockState placedState(Vertical4PartHalf part, BlockState state) {
         return super.placedState(part, state).setValue(SWITCH, IPowerComponent.Switch.ON);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/TransmissionPoleBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/TransmissionPoleBlock.java
@@ -26,7 +26,6 @@ import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class TransmissionPoleBlock extends SimpleMultiPartBlock<Vertical3PartHalf>
@@ -63,7 +62,7 @@ public class TransmissionPoleBlock extends SimpleMultiPartBlock<Vertical3PartHal
 
     @Override
     @Nullable
-    public BlockState getPlacementState(@NotNull BlockPlaceContext context) {
+    public BlockState getPlacementState(BlockPlaceContext context) {
         Level level = context.getLevel();
         BlockPos pos = context.getClickedPos();
         IPowerComponent.Switch sw =
@@ -75,7 +74,7 @@ public class TransmissionPoleBlock extends SimpleMultiPartBlock<Vertical3PartHal
     }
 
     @Override
-    protected void createBlockStateDefinition(@NotNull StateDefinition.Builder<Block, BlockState> builder) {
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(HALF).add(OVERLOAD).add(SWITCH);
     }
 
@@ -102,13 +101,13 @@ public class TransmissionPoleBlock extends SimpleMultiPartBlock<Vertical3PartHal
     }
 
     @Override
-    protected BlockState placedState(@NotNull Vertical3PartHalf part, BlockState state) {
+    public BlockState placedState(Vertical3PartHalf part, BlockState state) {
         return super.placedState(part, state).setValue(SWITCH, IPowerComponent.Switch.ON);
     }
 
     @Nullable
     @Override
-    public BlockEntity newBlockEntity(@NotNull BlockPos pos, BlockState state) {
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new TransmissionPoleBlockEntity(pos, state);
     }
 
@@ -153,10 +152,10 @@ public class TransmissionPoleBlock extends SimpleMultiPartBlock<Vertical3PartHal
     }
 
     @Override
-    public void onPlace(@NotNull Level level, BlockPos pos, BlockState state) {
+    public void onPlace(Level level, BlockPos pos, BlockState state) {
     }
 
     @Override
-    public void onRemove(@NotNull Level level, BlockPos pos, BlockState state) {
+    public void onRemove(Level level, BlockPos pos, BlockState state) {
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/multipart/AbstractMultiPartBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/multipart/AbstractMultiPartBlock.java
@@ -32,7 +32,7 @@ public abstract class AbstractMultiPartBlock<P extends Enum<P>> extends Block im
 
     public abstract Vec3i getOffset(BlockState state);
 
-    protected BlockState placedState(P part, BlockState state) {
+    public BlockState placedState(P part, BlockState state) {
         return state.setValue(this.getPart(), part);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/multipart/FlexibleMultiPartBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/multipart/FlexibleMultiPartBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block.multipart;
 
+import com.tterrag.registrate.util.nullness.NonNullFunction;
 import dev.dubhe.anvilcraft.block.state.IFlexibleMultiPartBlockState;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -18,7 +19,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.phys.BlockHitResult;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -74,7 +74,7 @@ public abstract class FlexibleMultiPartBlock<
     }
 
     @Override
-    public Vec3i getOffset(@NotNull BlockState state) {
+    public Vec3i getOffset(BlockState state) {
         return state.getValue(this.getPart()).getOffset(state.getValue(this.getAdditionalProperty()));
     }
 
@@ -87,6 +87,11 @@ public abstract class FlexibleMultiPartBlock<
     public BlockPos getMainPartPos(BlockPos pos, BlockState state) {
         return pos.subtract(this.getOffset(state))
                 .offset(this.mainPart.getOffset(state.getValue(this.getAdditionalProperty())));
+    }
+
+    @Override
+    public BlockState mapRealModelHolderBlock(Level level, BlockPos blockPos, BlockState original) {
+        return level.getBlockState(this.getMainPartPos(blockPos, original));
     }
 
     /**
@@ -160,5 +165,14 @@ public abstract class FlexibleMultiPartBlock<
             BlockHitResult hit
     ) {
         return InteractionResult.PASS;
+    }
+
+    public void change(BlockPos blockPos, Level level, NonNullFunction<BlockState, BlockState> factory) {
+        BlockState blockState = level.getBlockState(blockPos);
+        for (P part : this.getParts()) {
+            BlockPos offset = blockPos.offset(this.offsetFrom(blockState, part));
+            BlockState blockState1 = this.placedState(part, factory.apply(blockState));
+            level.setBlockAndUpdate(offset, blockState1);
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/multipart/IMultiPartBlockModelHolder.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/multipart/IMultiPartBlockModelHolder.java
@@ -1,9 +1,11 @@
 package dev.dubhe.anvilcraft.block.multipart;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public interface IMultiPartBlockModelHolder {
-    default BlockState mapRealModelHolderBlock(BlockState original) {
+    default BlockState mapRealModelHolderBlock(Level level, BlockPos blockPos, BlockState original) {
         return original;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
@@ -167,7 +167,9 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                         detectionEnd,
                         state,
                         state.getBlock() instanceof IMultiPartBlockModelHolder holder
-                            ? withPropertyValue(holder.mapRealModelHolderBlock(this.replacementLevel, this.targetBlockPos, state), this.property, state)
+                            ? withPropertyValue(holder.mapRealModelHolderBlock(this.replacementLevel, this.targetBlockPos, state),
+                            this.property,
+                            state)
                             : state,
                         Component.literal(
                             "%s".formatted(

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
@@ -45,6 +45,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.BlockHitResult;
@@ -166,7 +167,7 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                         detectionEnd,
                         state,
                         state.getBlock() instanceof IMultiPartBlockModelHolder holder
-                            ? holder.mapRealModelHolderBlock(state)
+                            ? withPropertyValue(holder.mapRealModelHolderBlock(this.replacementLevel, this.targetBlockPos, state), this.property, state)
                             : state,
                         Component.literal(
                             "%s".formatted(
@@ -192,6 +193,10 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 .mul(RADIUS),
             -this.targetAngle
         ).mul(1, -1);
+    }
+
+    private <T extends Comparable<T>> BlockState withPropertyValue(BlockState state, Property<T> property, BlockState blockState) {
+        return state.trySetValue(property, blockState.getValue(property));
     }
 
     @Override
@@ -389,14 +394,25 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 .add(centerX, centerY);
             float x = center.x;
             float y = center.y;
-            renderRotatedBlock(
-                poseStack,
-                value.modelBlock,
-                x,
-                y,
-                100,
-                ZOOM
-            );
+            if (value.state.getBlock() instanceof IMultiPartBlockModelHolder) {
+                renderRotatedBlock(
+                    poseStack,
+                    value.modelBlock,
+                    x + 5,
+                    y - 4,
+                    100,
+                    5
+                );
+            } else {
+                renderRotatedBlock(
+                    poseStack,
+                    value.modelBlock,
+                    x,
+                    y,
+                    100,
+                    ZOOM
+                );
+            }
             final int textAlpha = (int) (progress * 0xff) << 24;
             poseStack.pushPose();
             float coordinateScale = 0.7f;
@@ -461,14 +477,25 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
         for (SelectionItem value : this.items) {
             float x = value.center.x;
             float y = value.center.y;
-            renderRotatedBlock(
-                poseStack,
-                value.modelBlock,
-                x,
-                y,
-                -100,
-                ZOOM
-            );
+            if (value.state.getBlock() instanceof IMultiPartBlockModelHolder) {
+                renderRotatedBlock(
+                    poseStack,
+                    value.modelBlock,
+                    x + 4,
+                    y - 4,
+                    -100,
+                    5
+                );
+            } else {
+                renderRotatedBlock(
+                    poseStack,
+                    value.modelBlock,
+                    x,
+                    y,
+                    -100,
+                    ZOOM
+                );
+            }
             poseStack.pushPose();
             float coordinateScale = 0.7f;
             float offsetX = 0.1f * this.width;
@@ -602,9 +629,11 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 Block.UPDATE_CLIENTS,
                 0
             );
-            PacketDistributor.sendToServer(new HammerChangeBlockPacket(this.targetBlockPos, this.currentBlockState
-                )
-            );
+            PacketDistributor.sendToServer(new HammerChangeBlockPacket(
+                this.targetBlockPos,
+                this.currentBlockState,
+                this.currentBlockState.getValue(BlockStateProperties.FACING)
+            ));
         } else {
             PacketDistributor.sendToServer(new HammerUsePacket(this.targetBlockPos, this.hand, this.hitVec));
             super.removed();

--- a/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/DestroyType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/DestroyType.java
@@ -1,6 +1,5 @@
 package dev.dubhe.anvilcraft.event.giantanvil.shock;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -209,7 +208,6 @@ enum DestroyType {
             Level level = context.level();
             for (BlockPos blockPos : list) {
                 BlockState blockState = level.getBlockState(blockPos);
-                AnvilCraft.LOGGER.debug("block: {}", blockState.getBlock());
                 if (blockState.isAir() || !(blockState.getBlock() instanceof AmethystClusterBlock)) {
                     continue;
                 }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -2,18 +2,22 @@ package dev.dubhe.anvilcraft.network;
 
 import dev.anvilcraft.lib.util.CodecUtil;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.block.multipart.FlexibleMultiPartBlock;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 public record HammerChangeBlockPacket(
     BlockPos pos,
-    BlockState state
+    BlockState state,
+    Direction direction
 ) implements CustomPacketPayload {
     public static final Type<HammerChangeBlockPacket> TYPE = new Type<>(AnvilCraft.of("hammer_change_block"));
 
@@ -23,6 +27,8 @@ public record HammerChangeBlockPacket(
             HammerChangeBlockPacket::pos,
             CodecUtil.BLOCK_STATE_STREAM_CODEC,
             HammerChangeBlockPacket::state,
+            Direction.STREAM_CODEC,
+            HammerChangeBlockPacket::direction,
             HammerChangeBlockPacket::new
         );
 
@@ -31,11 +37,15 @@ public record HammerChangeBlockPacket(
         return TYPE;
     }
 
-    public void handle(IPayloadContext context) {
+    public  void handle(IPayloadContext context) {
         context.enqueueWork(() -> {
             Level level = context.player().level();
             if (level.isLoaded(pos)) {
-                level.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
+                if (state.getBlock() instanceof FlexibleMultiPartBlock<?,?,?> block) {
+                    block.change(pos, level, blockState -> blockState.setValue(BlockStateProperties.FACING, direction));
+                } else {
+                    level.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
+                }
             }
         });
     }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -41,8 +41,12 @@ public record HammerChangeBlockPacket(
         context.enqueueWork(() -> {
             Level level = context.player().level();
             if (level.isLoaded(pos)) {
-                if (state.getBlock() instanceof FlexibleMultiPartBlock<?,?,?> block) {
-                    block.change(pos, level, blockState -> blockState.setValue(BlockStateProperties.FACING, direction));
+                if (state.getBlock() instanceof FlexibleMultiPartBlock<?, ?, ?> block) {
+                    block.change(
+                        pos,
+                        level,
+                        blockState -> blockState.setValue(BlockStateProperties.FACING, direction)
+                    );
                 } else {
                     level.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
                 }

--- a/src/main/java/dev/dubhe/anvilcraft/network/UsePillBoxPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/UsePillBoxPacket.java
@@ -35,7 +35,6 @@ public record UsePillBoxPacket() implements CustomPacketPayload {
         Inventory inventory = player.getInventory();
         for (int i = 0; i < inventory.items.size(); i++) {
             ItemStack item = inventory.getItem(i);
-            AnvilCraft.LOGGER.debug("item: {}", item);
             if (item.is(ModItems.PILL_BOX)) {
                 if (player.getCooldowns().isOnCooldown(item.getItem())) {
                     return;


### PR DESCRIPTION
- 为AccelerationRingBlock和DeflectionRingBlock添加IHammerChangeable接口支持
- 实现change方法以支持方块状态的循环变换
- 添加getChangeableProperty方法返回可变属性
- 修改placedState方法访问权限从protected到public
- 更新AnvilHammerScreen以支持多方块模型渲染偏移
- 扩展IMultiPartBlockModelHolder接口方法签名
- 增强HammerChangeBlockPacket以传递方向信息
- 优化客户端GUI中多方块结构的渲染位置
- Fixed #2805 
- Resolved #2803 
- Fixed #2269 