### PR TITLE
Refactor interaction logic of pill box 重构药盒的交互逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/item/PillBoxItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/PillBoxItem.java
@@ -54,51 +54,63 @@ public class PillBoxItem extends Item {
         Player player,
         SlotAccess access
     ) {
+        final PillBocContents contents = stack.getOrDefault(ModComponents.PILL_BOC_CONTENTS, PillBocContents.EMPTY);
+        final PillBocContents.Mutable mutable = contents.mutable();
         if (!slot.allowModification(player)) {
             return false;
         }
-        PillBocContents contents = stack.getOrDefault(ModComponents.PILL_BOC_CONTENTS, PillBocContents.EMPTY);
-        PillBocContents.Mutable mutable = contents.mutable();
-        if (other.isEmpty()) {
-            Optional<ItemStack> stackOptional = mutable.get();
-            if (stackOptional.isPresent()) {
-                ItemStack itemStack = stackOptional.get();
-                if (!itemStack.isEmpty()) {
-                    access.set(itemStack);
+        if (action == ClickAction.PRIMARY) {
+            if (!other.isEmpty()) {
+                if (mutable.insert(other)) {
                     stack.set(ModComponents.PILL_BOC_CONTENTS, mutable.immutable());
+                    access.set(ItemStack.EMPTY);
                     return true;
                 }
             }
-        } else if (mutable.insert(other)) {
-            stack.set(ModComponents.PILL_BOC_CONTENTS, mutable.immutable());
-            access.set(ItemStack.EMPTY);
-            return true;
+        } else if (action == ClickAction.SECONDARY) {
+            if (other.isEmpty()) {
+                Optional<ItemStack> stackOptional = mutable.get();
+                if (stackOptional.isPresent()) {
+                    ItemStack itemStack = stackOptional.get();
+                    if (!itemStack.isEmpty()) {
+                        access.set(itemStack);
+                        stack.set(ModComponents.PILL_BOC_CONTENTS, mutable.immutable());
+                        return true;
+                    }
+                }
+            }
         }
         return false;
     }
 
     @Override
     public boolean overrideStackedOnOther(ItemStack stack, Slot slot, ClickAction action, Player player) {
+        final PillBocContents contents = stack.getOrDefault(ModComponents.PILL_BOC_CONTENTS, PillBocContents.EMPTY);
+        final PillBocContents.Mutable mutable = contents.mutable();
+        final ItemStack other = slot.getItem();
         if (!slot.allowModification(player)) {
             return false;
         }
-        PillBocContents contents = stack.getOrDefault(ModComponents.PILL_BOC_CONTENTS, PillBocContents.EMPTY);
-        PillBocContents.Mutable mutable = contents.mutable();
-        ItemStack other = slot.getItem();
-        if (other.isEmpty()) {
-            Optional<ItemStack> stackOptional = mutable.get();
-            if (stackOptional.isPresent()) {
-                ItemStack itemStack = stackOptional.get();
-                if (!itemStack.isEmpty()) {
-                    slot.set(itemStack);
+        if (action == ClickAction.PRIMARY) {
+            if (!other.isEmpty()) {
+                if (mutable.insert(other)) {
                     stack.set(ModComponents.PILL_BOC_CONTENTS, mutable.immutable());
+                    slot.set(ItemStack.EMPTY);
                     return true;
                 }
             }
-        } else if (mutable.insert(other)) {
-            stack.set(ModComponents.PILL_BOC_CONTENTS, mutable.immutable());
-            slot.set(ItemStack.EMPTY);
-            return true;
+        } else if (action == ClickAction.SECONDARY) {
+            if (other.isEmpty()) {
+                Optional<ItemStack> stackOptional = mutable.get();
+                if (stackOptional.isPresent()) {
+                    ItemStack itemStack = stackOptional.get();
+                    if (!itemStack.isEmpty()) {
+                        slot.set(itemStack);
+                        stack.set(ModComponents.PILL_BOC_CONTENTS, mutable.immutable());
+                        return true;
+                    }
+                }
+            }
         }
         return false;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/property/component/PillBocContents.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/property/component/PillBocContents.java
@@ -91,6 +91,9 @@ public record PillBocContents(int index, List<ItemStack> pills) {
         }
 
         public Optional<ItemStack> get() {
+            if (this.index == -1 && !this.pills.isEmpty()) {
+                return Optional.of(this.pills.removeFirst());
+            }
             if (this.index < 0 || this.index > this.pills.size() - 1) {
                 return Optional.empty();
             }


### PR DESCRIPTION
新的药盒交互逻辑如下：

- 鼠标指针上没有物品时
    - 左键拿起药盒
    - 默认没有选中任何药片槽位时右键取出药盒里第一个药片物品
    - 滚动滚落选中槽位右键取出对应药片物品

- 鼠标指针上拿着物品
   - 如果是药片物品，左键将药片物品放入药盒，如果不是药片则交换手上和槽位上的物品
   - 右键交换手上和槽位上的物品

交互逻辑和新版本mc的收纳袋类似

- Fixed #3093 