### PR TITLE
Fix error handling for baby entity damage events 修复幼年实体伤害事件的错误处理

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
@@ -141,6 +141,7 @@ public class AnvilEventListener {
         if (!(hurtedEntity instanceof LivingEntity entity)) return;
         if (!(hurtedEntity.level() instanceof ServerLevel serverLevel)) return;
         if (!entity.isAlive()) return;
+        if (!entity.isBaby()) return;
         if (entity.isDeadOrDying()) return;
         if (entity.hurtTime > 0) return;
         float damage = event.getDamage();


### PR DESCRIPTION
- fixed #3113
- 添加判断避免对非幼年实体触发伤害事件处理
- 防止幼年状态实体错误进入伤害逻辑
- 增强事件监听器的实体状态校验逻辑