### PR TITLE
Optimize the redstone connection judgment logic of AdvancedComparatorBlock 优化 AdvancedComparatorBlock 的红石连接判断逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/AdvancedComparatorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/AdvancedComparatorBlock.java
@@ -94,9 +94,7 @@ public class AdvancedComparatorBlock extends HorizontalDirectionalBlock implemen
 
     @Override
     public boolean canConnectRedstone(BlockState state, BlockGetter level, BlockPos pos, @Nullable Direction direction) {
-        if (direction == null) return false;
-        if (!(state.getBlock() instanceof AdvancedComparatorBlock)) return false;
-        return state.getValue(FACING).getAxis().equals(direction.getAxis());
+        return direction != null && direction != Direction.DOWN && direction != Direction.UP;
     }
 
     @Override


### PR DESCRIPTION
- fixed #3099
- 改用简洁的逻辑表达式
- 排除方向为上下（DOWN 和 UP）时的红石连接