### PR TITLE
Fix block falling and attraction logic judgment 修复方块下落与吸引逻辑判断

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/mixin/AnvilBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/AnvilBlockMixin.java
@@ -36,9 +36,11 @@ abstract class AnvilBlockMixin extends FallingBlock {
         BlockPos pos,
         RandomSource random
     ) {
-        if (anvilcraft$isAttracts(level.getBlockState(pos.above()))
+        if (
+            anvilcraft$isAttracts(level.getBlockState(pos.above()))
             || !FallingBlock.isFree(level.getBlockState(pos.below()))
-            || pos.getY() < level.getMinBuildHeight()) {
+            || pos.getY() < level.getMinBuildHeight()
+        ) {
             return;
         }
         super.tick(state, level, pos, random);

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/FallingBlockMixin.java
@@ -30,6 +30,8 @@ public abstract class FallingBlockMixin extends Block {
         throw new AssertionError();
     }
 
+    @Shadow public abstract void falling(FallingBlockEntity entity);
+
     @Inject(
         method = "tick", at = @At("HEAD"), cancellable = true
     )
@@ -95,7 +97,8 @@ public abstract class FallingBlockMixin extends Block {
             if (state.is(ModBlocks.LEVITATION_POWDER_BLOCK.get())) {
                 LevitatingBlockEntity.levitate(level, pos, state);
             } else {
-                FallingBlockEntity.fall(level, pos, state);
+                FallingBlockEntity entity = FallingBlockEntity.fall(level, pos, state);
+                this.falling(entity);
             }
             ci.cancel();
         } else {


### PR DESCRIPTION
- fixed #3132
- 在 AnvilBlockMixin 中改进方块下方检测逻辑，避免异常下落行为
- 在 FallingBlockMixin 中添加 falling 方法 Shadow，用于处理方块实体下落回调
- 修改 tick 方法注入逻辑，调用 falling 方法处理自定义方块下落实体
- 增强方块下落和吸引机制的兼容性和稳定性