### PR TITLE
Add Modrinth and CurseForge integration links 添加 Modrinth 和 CurseForge 集成链接

### DIFF
--- a/src/main/resources/integrations.json
+++ b/src/main/resources/integrations.json
@@ -24,6 +24,14 @@
             {
               "type": "github",
               "url": "https://github.com/Anvil-Dev/AnvilCraft-Ponder"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/project/anvilcraft-ponder"
+            },
+            {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-ponder"
             }
           ]
         }

--- a/src/main/resources/integrations.json
+++ b/src/main/resources/integrations.json
@@ -94,6 +94,14 @@
             {
               "type": "github",
               "url": "https://github.com/Anvil-Dev/AnvilCraft-Patchouli"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/project/anvilcraft-patchouli"
+            },
+            {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-patchouli"
             }
           ]
         }


### PR DESCRIPTION
- [添加 AnvilCraft-Patchouli 的 Modrinth 和 CurseForge 集成链接](https://github.com/Anvil-Dev/AnvilCraft/pull/3134/commits/54722ecda2797e2ecf564c37c2f4b9276af4aca0)
- [添加 AnvilCraft-Ponder 的 Modrinth 和 CurseForge 集成链接](https://github.com/Anvil-Dev/AnvilCraft/pull/3134/commits/89912066c8e307b359f6a9af44916e5ab9be29e6)