### PR TITLE
Fix the issue where the anvil hammer cannot rotate blocks with right-click functionality 修复铁砧锤对于有右键功能的方块无法旋转的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/event/ClientBlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/ClientBlockEventListener.java
@@ -44,8 +44,8 @@ public class ClientBlockEventListener {
         }
         if (event.getLevel().isClientSide() && clientHandle(event, state, hand, event.getHitVec())) {
             event.setCancellationResult(InteractionResult.SUCCESS);
-            event.setCanceled(true);
         }
+        event.setCanceled(true);
     }
 
     private static boolean clientHandle(


### PR DESCRIPTION
- fixed #3135
- 调整了事件取消状态的设置顺序，确保先调用setCanceled(true)
- 保证事件处理逻辑在客户端侧正确生效
- 优化了交互结果的设置逻辑，提高代码可读性