### PR TITLE
Delete old branches to optimize the style check process 删除旧分支以优化样式检查流程

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -17,6 +17,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git remote prune origin
+          git branch -D releases/1.21 || true
           gh pr checkout ${{ github.event.number }}
       - name: Setup Java 17
         uses: actions/setup-java@v3.6.0


### PR DESCRIPTION
- 在style_check.yml中添加删除本地releases/1.21分支命令
- 确保旧分支不会影响GitHub Actions的拉取请求检出
- 修改提升CI运行的清洁度和稳定性