### PR TITLE
Fix the branch deletion command in the style_check workflow 修复 style_check 工作流中的分支删除命令

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -17,7 +17,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git remote prune origin
-          git branch -D releases/1.21 || true
+          git update-ref -d refs/remotes/origin/releases/1.21 || true
           gh pr checkout ${{ github.event.number }}
       - name: Setup Java 17
         uses: actions/setup-java@v3.6.0


### PR DESCRIPTION
- 将删除本地分支命令替换为删除远程引用命令
- 修正了 releases/1.21 分支的清理逻辑
- 保证工作流在拉取请求检出时不报错