### PR TITLE
Fix the branch reference error in the style check workflow 修复样式检查工作流的分支引用错误

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.number }}/merge
       - name: Setup Java 17
         uses: actions/setup-java@v3.6.0
         with:


### PR DESCRIPTION
- 修正了checkout步骤，指定了pull请求的合并引用
- 确保样式检查在正确的代码状态下执行
- 避免因引用错误导致的CI流程失败