### PR TITLE
Update and add integration project link information 更新和新增整合项目链接信息

### DIFF
--- a/src/main/resources/integrations.json
+++ b/src/main/resources/integrations.json
@@ -22,16 +22,16 @@
           ],
           "extra": [
             {
-              "type": "github",
-              "url": "https://github.com/Anvil-Dev/AnvilCraft-Ponder"
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-ponder"
             },
             {
               "type": "modrinth",
               "url": "https://modrinth.com/project/anvilcraft-ponder"
             },
             {
-              "type": "curseforge",
-              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-ponder"
+              "type": "github",
+              "url": "https://github.com/Anvil-Dev/AnvilCraft-Ponder"
             }
           ]
         }
@@ -100,16 +100,16 @@
           ],
           "extra": [
             {
-              "type": "github",
-              "url": "https://github.com/Anvil-Dev/AnvilCraft-Patchouli"
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-patchouli"
             },
             {
               "type": "modrinth",
               "url": "https://modrinth.com/project/anvilcraft-patchouli"
             },
             {
-              "type": "curseforge",
-              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-patchouli"
+              "type": "github",
+              "url": "https://github.com/Anvil-Dev/AnvilCraft-Patchouli"
             }
           ]
         }
@@ -190,25 +190,25 @@
           "target": [
             {
               "type": "mcmod",
-              "url": "https://www.mcmod.cn/class/2021.html"
+              "url": "https://www.mcmod.cn/class/2450.html"
             },
             {
               "type": "curseforge",
-              "url": "https://www.curseforge.com/minecraft/mc-mods/create"
+              "url": "https://www.curseforge.com/minecraft/mc-mods/kubejs"
             },
             {
               "type": "modrinth",
-              "url": "https://modrinth.com/mod/create"
+              "url": "https://modrinth.com/mod/kubejs"
             },
             {
               "type": "github",
-              "url": "https://github.com/Creators-of-Create/Create"
+              "url": "https://github.com/KubeJS-Mods/KubeJS"
             }
           ],
           "extra": [
             {
               "type": "github",
-              "url": "https://github.com/Anvil-Dev/AnvilCraft-Create-Addition"
+              "url": "https://github.com/Anvil-Dev/AnvilCraft-KubeJS"
             }
           ]
         }
@@ -246,6 +246,49 @@
             {
               "type": "github",
               "url": "https://github.com/Anvil-Dev/AnvilCraft-Create-Addition"
+            }
+          ]
+        }
+      },
+      {
+        "id": "curios",
+        "type": "extra",
+        "name": [
+          {
+            "translate": "integration.anvilcraft.interaction.curios"
+          }
+        ],
+        "links": {
+          "target": [
+            {
+              "type": "mcmod",
+              "url": "https://www.mcmod.cn/class/2029.html"
+            },
+            {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/curios"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/mod/curios"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/TheIllusiveC4/Curios"
+            }
+          ],
+          "extra": [
+            {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-curios"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/mod/anvilcraft-curios"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/Anvil-Dev/AnvilCraft-Curios"
             }
           ]
         }


### PR DESCRIPTION
- 调整 anvilcraft-ponder 的链接顺序，规范各平台链接顺序
- 调整 anvilcraft-patchouli 的链接顺序，保持与其他项目一致
- 更新 target 中 mcmod、curseforge、modrinth、github 链接指向 kubejs 相关资源
- 修改 extra 中 github 链接指向 AnvilCraft-KubeJS 仓库
- 新增 curios 整合模块，包含 mcmod、curseforge、modrinth、github 的 target 和 extra 链接信息