### PR TITLE
Update and add integration project link information 更新和新增整合项目链接信息

### DIFF
--- a/src/main/resources/integrations.json
+++ b/src/main/resources/integrations.json
@@ -207,6 +207,14 @@
           ],
           "extra": [
             {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraf-kubejs"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/project/anvilcraf-kubejs"
+            },
+            {
               "type": "github",
               "url": "https://github.com/Anvil-Dev/AnvilCraft-KubeJS"
             }
@@ -358,6 +366,14 @@
             }
           ],
           "extra": [
+            {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-better-beacons-compatible"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/project/anvilcraft-better-beacons-compatible"
+            },
             {
               "type": "github",
               "url": "https://github.com/Anvil-Dev/AnvilCraft-Better-Beacons-Compatible"


### PR DESCRIPTION
- 为 AnvilCraft-KubeJS 集成添加了 CurseForge 和 Modrinth 链接
- 为 AnvilCraft-Better-Beacons-Compatible 集成添加了 CurseForge 和 Modrinth 链接
- 保持现有 GitHub 链接不变以保证兼容性