### PR TITLE
Fix bugs about recipes in frost smithing table again, fix wrong range of applicable items of disintegration enchantment 再修复浮霜锻造台配方的问题，修复崩解魔咒可应用物品范围错误的问题

### DIFF
--- a/src/generated/resources/data/anvilcraft/enchantment/disintegration.json
+++ b/src/generated/resources/data/anvilcraft/enchantment/disintegration.json
@@ -68,7 +68,7 @@
     "mainhand"
   ],
   "supported_items": {
-    "type": "neoforge:and",
+    "type": "neoforge:or",
     "values": [
       "#minecraft:enchantable/mining_loot",
       "#minecraft:enchantable/weapon"

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_axe_and_ember_metal_axe.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_axe_and_ember_metal_axe.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_heavy_halberd_and_ember_metal_heavy_halberd.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_heavy_halberd_and_ember_metal_heavy_halberd.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_hoe_and_ember_metal_hoe.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_hoe_and_ember_metal_hoe.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_pickaxe_and_ember_metal_pickaxe.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_pickaxe_and_ember_metal_pickaxe.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_resonator_and_ember_metal_resonator.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_resonator_and_ember_metal_resonator.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_shovel_and_ember_metal_shovel.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_shovel_and_ember_metal_shovel.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_sword_and_ember_metal_sword.json
+++ b/src/generated/resources/data/anvilcraft/recipe/permutation/frost_metal_sword_and_ember_metal_sword.json
@@ -17,9 +17,18 @@
         {
           "type": "anvilcraft:remove_data",
           "types": [
-            "anvilcraft:merciless",
-            "anvilcraft:merciless_enchantments"
+            "anvilcraft:merciless"
           ]
+        },
+        {
+          "type": "anvilcraft:change_data_type",
+          "dest": {
+            "type": "anvilcraft:item_enchantments",
+            "component": "minecraft:enchantments",
+            "input": 0
+          },
+          "input": "input.0",
+          "orig": "anvilcraft:merciless_enchantments"
         },
         {
           "type": "anvilcraft:remove_attribute",

--- a/src/main/java/dev/dubhe/anvilcraft/api/recipe/number/EnchantmentLevelProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/recipe/number/EnchantmentLevelProvider.java
@@ -20,7 +20,6 @@ public record EnchantmentLevelProvider(
 ) implements INumberProvider {
     public static final MapCodec<EnchantmentLevelProvider> CODEC = RecordCodecBuilder.mapCodec(ins -> ins.group(
         RecipeInputSlot.CODEC
-            .fieldOf("slot")
             .forGetter(EnchantmentLevelProvider::slot),
         ResourceKey.codec(Registries.ENCHANTMENT)
             .fieldOf("enchantment")

--- a/src/main/java/dev/dubhe/anvilcraft/api/recipe/result/RecipeResult.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/recipe/result/RecipeResult.java
@@ -9,12 +9,14 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.anvilcraft.lib.util.CodecUtil;
 import dev.dubhe.anvilcraft.api.recipe.data.ICustomDataComponent;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.ApplyData;
+import dev.dubhe.anvilcraft.api.recipe.result.modifier.ChangeDataType;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.CopyData;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.IResultModifier;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.MergeData;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.ModifyCount;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.RemoveAttribute;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.RemoveData;
+import dev.dubhe.anvilcraft.api.recipe.slot.RecipeInputSlot;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -181,6 +183,15 @@ public record RecipeResult(Item result, @Unmodifiable List<IResultModifier> modi
 
         public Builder removeAttribute(ResourceLocation... attrs) {
             return this.removeAttribute(RemoveAttribute.removeAttr(attrs));
+        }
+
+        public <T> Builder changeDataType(ChangeDataType.Builder<T> builder) {
+            this.modifiers.add(builder.build());
+            return this;
+        }
+
+        public <T> Builder changeDataType(RecipeInputSlot slot, DataComponentType<T> orig, ICustomDataComponent<T> dest) {
+            return this.changeDataType(ChangeDataType.changeDataType(slot, orig, dest));
         }
 
         public RecipeResult build() {

--- a/src/main/java/dev/dubhe/anvilcraft/api/recipe/result/modifier/ChangeDataType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/recipe/result/modifier/ChangeDataType.java
@@ -1,0 +1,101 @@
+package dev.dubhe.anvilcraft.api.recipe.result.modifier;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.dubhe.anvilcraft.api.recipe.data.ICustomDataComponent;
+import dev.dubhe.anvilcraft.api.recipe.result.ResultContext;
+import dev.dubhe.anvilcraft.api.recipe.slot.RecipeInputSlot;
+import dev.dubhe.anvilcraft.init.recipe.ModResultModifierTypes;
+import dev.dubhe.anvilcraft.util.Util;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * 复制指定输入物品的数据，并将其粘贴到另一个数据组件类型下。
+ */
+public record ChangeDataType<T>(RecipeInputSlot input, DataComponentType<T> orig, ICustomDataComponent<T> dest) implements IResultModifier {
+    public static final MapCodec<ChangeDataType<?>> CODEC = RecordCodecBuilder.mapCodec(ins -> ins.group(
+        ResourceLocation.CODEC
+            .fieldOf("orig")
+            .forGetter(ChangeDataType::origId),
+        ICustomDataComponent.CODEC
+            .fieldOf("dest")
+            .forGetter(ChangeDataType::dest),
+        RecipeInputSlot.CODEC
+            .forGetter(ChangeDataType::input)
+    ).apply(ins, ChangeDataType::new));
+    public static final StreamCodec<RegistryFriendlyByteBuf, ChangeDataType<?>> STREAM_CODEC = StreamCodec.composite(
+        ResourceLocation.STREAM_CODEC,
+        ChangeDataType::origId,
+        ICustomDataComponent.STREAM_CODEC,
+        ChangeDataType::dest,
+        RecipeInputSlot.STREAM_CODEC,
+        ChangeDataType::input,
+        ChangeDataType::new
+    );
+
+    public ChangeDataType(ResourceLocation origId, ICustomDataComponent<T> dest, RecipeInputSlot slot) {
+        this(
+            slot,
+            Util.cast(BuiltInRegistries.DATA_COMPONENT_TYPE.get(origId)),
+            dest
+        );
+    }
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    public static <T> Builder<T> changeDataType(RecipeInputSlot input, DataComponentType<T> orig, ICustomDataComponent<T> dest) {
+        return new Builder<T>().input(input).orig(orig).dest(dest);
+    }
+
+    @Override
+    public void modify(ResultContext ctx) {
+        T value = ctx.getInput(this.input).get(this.orig);
+        if (value == null) return;
+        ctx.getResult().set(this.orig, null);
+        ctx.getResult().set(
+            this.dest.getDataComponentType(),
+            this.dest.merge(ctx.getResult().get(this.dest.getDataComponentType()), value)
+        );
+    }
+
+    @Override
+    public Type type() {
+        return ModResultModifierTypes.CHANGE_DATA_TYPE.get();
+    }
+
+    private ResourceLocation origId() {
+        return BuiltInRegistries.DATA_COMPONENT_TYPE.getKey(this.orig);
+    }
+
+    public static class Type implements IResultModifier.Type<ChangeDataType<?>> {
+        @Override
+        public MapCodec<ChangeDataType<?>> codec() {
+            return CODEC;
+        }
+
+        @Override
+        public StreamCodec<RegistryFriendlyByteBuf, ChangeDataType<?>> streamCodec() {
+            return STREAM_CODEC;
+        }
+    }
+
+    @Accessors(fluent = true, chain = true)
+    @Setter
+    public static class Builder<T> {
+        private RecipeInputSlot input;
+        private DataComponentType<T> orig;
+        private ICustomDataComponent<T> dest;
+
+        public ChangeDataType<T> build() {
+            return new ChangeDataType<>(this.input, this.orig, this.dest);
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/recipe/result/modifier/RemoveData.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/recipe/result/modifier/RemoveData.java
@@ -41,7 +41,7 @@ public record RemoveData(List<DataComponentType<?>> types) implements IResultMod
     @Override
     public void modify(ResultContext ctx) {
         for (var type : this.types) {
-            ctx.getResult().remove(type);
+            ctx.getResult().set(type, null);
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/api/recipe/slot/RecipeInputSlot.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/recipe/slot/RecipeInputSlot.java
@@ -15,7 +15,7 @@ import net.minecraft.util.StringRepresentable;
 public class RecipeInputSlot implements StringRepresentable {
     public static final MapCodec<RecipeInputSlot> CODEC = RecordCodecBuilder.mapCodec(ins -> ins.group(
         Codec.STRING
-            .fieldOf("value")
+            .fieldOf("input")
             .forGetter(RecipeInputSlot::getSerializedName)
     ).apply(ins, RecipeInputSlot::new));
     public static final StreamCodec<ByteBuf, RecipeInputSlot> STREAM_CODEC = StreamCodec.composite(
@@ -32,7 +32,6 @@ public class RecipeInputSlot implements StringRepresentable {
     // 实例&构建
     public static final RecipeInputSlot TEMPLATE = new RecipeInputSlot("template");
     public static final RecipeInputSlot MATERIAL = new RecipeInputSlot("material");
-    public static final RecipeInputSlot INPUT = new RecipeInputSlot("input");
 
     public static RecipeInputSlot input(int index) {
         return new RecipeInputSlot("input." + index);

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/PermutationRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/PermutationRecipeLoader.java
@@ -2,12 +2,15 @@ package dev.dubhe.anvilcraft.data.recipe;
 
 import com.tterrag.registrate.providers.RegistrateRecipeProvider;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.recipe.data.ItemEnchantmentsData;
 import dev.dubhe.anvilcraft.api.recipe.result.RecipeResult;
+import dev.dubhe.anvilcraft.api.recipe.slot.RecipeInputSlot;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.item.property.component.Merciless;
 import dev.dubhe.anvilcraft.recipe.frost.PermutationRecipe;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
@@ -72,7 +75,8 @@ public class PermutationRecipeLoader {
             ).input(
                 RecipeResult.builder()
                     .result(ember)
-                    .removeData(ModComponents.MERCILESS, ModComponents.MERCILESS_ENCHANTMENTS)
+                    .removeData(ModComponents.MERCILESS)
+                    .changeDataType(RecipeInputSlot.input(0), ModComponents.MERCILESS_ENCHANTMENTS, ItemEnchantmentsData.enchantments(0))
                     .removeAttribute(Merciless.MERCILESS_ID)
             )
         );
@@ -89,7 +93,8 @@ public class PermutationRecipeLoader {
             ).input(
                 RecipeResult.builder()
                     .result(ember)
-                    .removeData(ModComponents.MERCILESS, ModComponents.MERCILESS_ENCHANTMENTS)
+                    .removeData(ModComponents.MERCILESS)
+                    .changeDataType(RecipeInputSlot.input(0), ModComponents.MERCILESS_ENCHANTMENTS, ItemEnchantmentsData.enchantments(0))
                     .removeAttribute(Merciless.MERCILESS_ID)
             )
         );

--- a/src/main/java/dev/dubhe/anvilcraft/init/enchantment/ModEnchantments.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/enchantment/ModEnchantments.java
@@ -23,6 +23,7 @@ import net.minecraft.world.item.enchantment.effects.SetValue;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.storage.loot.predicates.MatchTool;
 import net.neoforged.neoforge.registries.holdersets.AndHolderSet;
+import net.neoforged.neoforge.registries.holdersets.OrHolderSet;
 
 public class ModEnchantments {
 
@@ -121,7 +122,7 @@ public class ModEnchantments {
             DISINTEGRATION_KEY,
             Enchantment.enchantment(
                 Enchantment.definition(
-                    new AndHolderSet<>(
+                    new OrHolderSet<>(
                         itemHolderGetter.getOrThrow(ItemTags.MINING_LOOT_ENCHANTABLE),
                         itemHolderGetter.getOrThrow(ItemTags.WEAPON_ENCHANTABLE)
                     ),

--- a/src/main/java/dev/dubhe/anvilcraft/init/recipe/ModResultModifierTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/recipe/ModResultModifierTypes.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.init.recipe;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.ApplyData;
+import dev.dubhe.anvilcraft.api.recipe.result.modifier.ChangeDataType;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.CopyData;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.IResultModifier;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.MergeData;
@@ -34,6 +35,9 @@ public class ModResultModifierTypes {
 
     public static final DeferredHolder<IResultModifier.Type<?>, ModifyCount.Type> MODIFY_COUNT = DF
         .register("modify_count", ModifyCount.Type::new);
+
+    public static final DeferredHolder<IResultModifier.Type<?>, ChangeDataType.Type> CHANGE_DATA_TYPE = DF
+        .register("change_data_type", ChangeDataType.Type::new);
 
     public static void register(IEventBus bus) {
         DF.register(bus);

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/frost/IFrostSmithingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/frost/IFrostSmithingRecipe.java
@@ -9,6 +9,7 @@ import dev.dubhe.anvilcraft.recipe.anvil.builder.AbstractRecipeBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentPredicate;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.resources.ResourceLocation;
@@ -63,7 +64,14 @@ public interface IFrostSmithingRecipe extends Recipe<FrostSmithingRecipeInput> {
 
     default ItemStack assemble(int selected, FrostSmithingRecipeInput inputting, Level level) {
         RecipeResult input = this.inputs(inputting.input()).get(selected);
-        var builder = ResultContext.builder(level.registryAccess(), level.getRandom(), inputting.input().transmuteCopy(input.result()))
+        ItemStack result = inputting.input().transmuteCopy(input.result());
+        if (input.result().components().keySet().contains(DataComponents.TOOL)) {
+            result.set(DataComponents.TOOL, input.result().components().get(DataComponents.TOOL));
+        }
+        if (input.result().components().keySet().contains(DataComponents.ATTRIBUTE_MODIFIERS)) {
+            result.set(DataComponents.ATTRIBUTE_MODIFIERS, input.result().components().get(DataComponents.ATTRIBUTE_MODIFIERS));
+        }
+        var builder = ResultContext.builder(level.registryAccess(), level.getRandom(), result)
             .slot(RecipeInputSlot.TEMPLATE, inputting.template())
             .slot(RecipeInputSlot.MATERIAL, inputting.material())
             .input(0, inputting.input());


### PR DESCRIPTION
- 修复了嬗变配方嬗变浮霜->余烬工具时会删除魔咒的问题
- 修复了嬗变&形变配方会保留工具属性的问题
- 修复了崩解魔咒可应用物品范围错误的问题