### PR TITLE
Add AnvilCraft: GuideME integration link 添加 AnvilCraft: GuideME 的集成链接

### DIFF
--- a/src/main/resources/integrations.json
+++ b/src/main/resources/integrations.json
@@ -65,6 +65,14 @@
           ],
           "extra": [
             {
+              "type": "curseforge",
+              "url": "https://www.curseforge.com/minecraft/mc-mods/anvilcraft-guideme"
+            },
+            {
+              "type": "modrinth",
+              "url": "https://modrinth.com/mod/anvilcraft-guideme"
+            },
+            {
               "type": "github",
               "url": "https://github.com/Anvil-Dev/AnvilCraft-GuideME"
             }


### PR DESCRIPTION
- 在 integrations.json 中新增 CurseForge 类型及相关 URL
- 添加 Modrinth 类型及其对应 URL
- 保持 GitHub 集成链接不变，补充多源支持
- 扩展集成平台以提高可访问性与覆盖率