### PR TITLE
Change the default build type to snapshot 修改默认构建类型为 snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 String buildNumber
-String buildType = 'build'
+String buildType = 'snapshot'
 if (System.getenv("CI_BUILD") == 'false') buildNumber = null
 else {
     if (System.getenv("PR_BUILD") != 'false') buildType = 'pr'


### PR DESCRIPTION
- 将默认构建类型由 build 修改为 snapshot
- 保持 CI 和 PR 构建类型逻辑不变
- 适配环境变量判断机制以支持新的默认类型