### PR TITLE
Refactor build type and version number environment variable handling logic 重构构建类型与版本号环境变量处理逻辑

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      CI_BUILD: true
-      HOTFIX_BUILD: false
-      PR_BUILD: false
+      BUILD_TYPE: snapshot
       VERSION_TYPE: alpha
     steps:
       - name: checkout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,8 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      CI_BUILD: true
-      PR_BUILD: true
+      BUILD_TYPE: pr
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     env:
-      CI_BUILD: false
-      PR_BUILD: false
+      BUILD_TYPE: release
       VERSION_TYPE: ${{ github.event.release.prerelease && 'beta' || 'release' }}
     steps:
       - name: checkout

--- a/build.gradle
+++ b/build.gradle
@@ -8,17 +8,24 @@ plugins {
     alias libs.plugins.machete
 }
 
-String buildNumber
-String buildType = 'snapshot'
-if (System.getenv("CI_BUILD") == 'false') buildNumber = null
-else {
-    if (System.getenv("PR_BUILD") != 'false') buildType = 'pr'
-    buildNumber = System.getenv("GITHUB_RUN_NUMBER")
+String buildType
+String buildNumber = System.getenv("GITHUB_RUN_NUMBER")
+String buildTypeEnv = System.getenv("BUILD_TYPE")
+if (buildTypeEnv == "pr") {
+    buildType = 'pr'
+} else if (buildTypeEnv == "hotfix") {
+    buildType = 'hotfix'
+} else if (buildTypeEnv == "snapshot") {
+    buildType = 'snapshot'
+} else if (buildTypeEnv == "release") {
+    buildType = null
+    buildNumber = null
+} else {
+    buildType = 'build'
 }
-if (System.getenv("HOTFIX_BUILD") != 'false') buildType = 'hotfix'
-def envVersion = System.getenv("GITHUB_REF")
-if (envVersion != null && envVersion.startsWith("refs/tags/")) {
-    version = envVersion.substring(envVersion.lastIndexOf('/') + 1)
+def githubRef = System.getenv("GITHUB_REF")
+if (githubRef != null && githubRef.startsWith("refs/tags/")) {
+    version = githubRef.substring(githubRef.lastIndexOf('/') + 1)
 } else {
     version = "${mod_version}" + (buildNumber != null ? "+${buildType}.${buildNumber}" : "")
 }


### PR DESCRIPTION
- 统一使用 BUILD_TYPE 环境变量代替多个布尔型环境变量管理构建类型
- 支持 pr、hotfix、snapshot、release 等多种构建类型的区分
- 对 release 类型构建屏蔽 buildNumber 和 version
- 优化版本号获取逻辑，支持直接从 GitHub tag 提取版本
- 更新 GitHub Actions workflow 配置以适配新的 BUILD_TYPE 变量规范

(cherry picked from commit d99a8b08b95d1b8c54b0d18a4adf5e4ff7148dbe)