### PR TITLE
Fix NPE and block rotations 修复空指针引用与方块旋转问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/AccelerationRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/AccelerationRingBlock.java
@@ -16,6 +16,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -172,5 +174,17 @@ public class AccelerationRingBlock extends FlexibleMultiPartBlock<DirectionCube3
     @Override
     public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
         return FACING;
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(HALF, state.getValue(HALF).rotate(rotation))
+            .setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(HALF, state.getValue(HALF).mirror(mirror))
+            .setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/DeflectionRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/DeflectionRingBlock.java
@@ -17,6 +17,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -174,5 +176,17 @@ public class DeflectionRingBlock extends FlexibleMultiPartBlock<DirectionCube3x3
     @Override
     public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
         return FACING;
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(HALF, state.getValue(HALF).rotate(rotation))
+            .setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(HALF, state.getValue(HALF).mirror(mirror))
+            .setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/LaserReceiverBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/LaserReceiverBlock.java
@@ -13,7 +13,9 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -155,5 +157,15 @@ public class LaserReceiverBlock extends BaseLaserBlock implements IHammerRemovab
     @Override
     public @Nullable Property<?> getChangeableProperty(BlockState blockState) {
         return FACING;
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SpectralAnvilBlock.java
@@ -21,6 +21,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -151,5 +153,17 @@ public class SpectralAnvilBlock extends Block implements IHammerRemovable {
             level.scheduleTick(pos, this, 4);
             level.setBlockAndUpdate(pos, state.setValue(POWERED, false));
         }
+
+
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/StampingPlatformBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/StampingPlatformBlock.java
@@ -10,6 +10,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -119,5 +121,15 @@ public class StampingPlatformBlock extends Block implements SimpleWaterloggedBlo
         if (!(state.getBlock() instanceof StampingPlatformBlock)) return Vec3.ZERO;
         Vec3i normal = state.getValue(FACING).getNormal();
         return new Vec3(normal.getX(), normal.getY(), normal.getZ()).scale(0.7);
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
@@ -17,6 +17,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
@@ -301,5 +303,15 @@ public class ActivatorSlidingRailBlock extends BaseSlidingRailBlock implements I
     @Override
     public @Nullable BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return ModBlockEntities.ACTIVATOR_SLIDING_RAIL.create(pos, state);
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
@@ -17,6 +17,8 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -163,5 +165,15 @@ public class DetectorSlidingRailBlock extends BaseSlidingRailBlock implements IH
         if (state.getBlock() != this) return;
         level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_ALL);
         level.getBlockEntity(pos, ModBlockEntities.DETECTOR_SLIDING_RAIL.get()).ifPresent(DetectorSlidingRailBlockEntity::cleanPower);
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
@@ -16,6 +16,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -268,5 +270,15 @@ public class PoweredSlidingRailBlock extends BaseSlidingRailBlock implements IHa
     @Override
     public boolean canMoveSlidingToTop(LevelReader level, BlockPos pos, BlockState state, Direction side) {
         return state.getValue(POWERED) && state.getValue(FACING) == side.getOpposite();
+    }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    protected BlockState mirror(BlockState state, Mirror mirror) {
+        return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailBlock.java
@@ -10,6 +10,8 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -157,4 +159,10 @@ public class SlidingRailBlock extends BaseSlidingRailBlock implements IHammerCha
     @Override
     public void onSlidingAbove(Level level, BlockPos pos, BlockState state, SlidingBlockEntity entity) {
     }
+
+    @Override
+    protected BlockState rotate(BlockState state, Rotation rotation) {
+        return RotatedPillarBlock.rotatePillar(state, rotation);
+    }
+
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/state/DirectionCube3x3PartHalf.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/state/DirectionCube3x3PartHalf.java
@@ -2,6 +2,11 @@ package dev.dubhe.anvilcraft.block.state;
 
 import lombok.Getter;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
 
 @Getter
 public enum DirectionCube3x3PartHalf
@@ -38,6 +43,34 @@ public enum DirectionCube3x3PartHalf
     private final int offsetX;
     private final int offsetY;
     private final int offsetZ;
+    private DirectionCube3x3PartHalf clockwise90;
+    private DirectionCube3x3PartHalf clockwise180;
+    private DirectionCube3x3PartHalf clockwise270;
+    private DirectionCube3x3PartHalf mirrorX;
+    private DirectionCube3x3PartHalf mirrorZ;
+
+    @Nullable
+    public static DirectionCube3x3PartHalf findByOffset(int offsetX, int offsetY, int offsetZ) {
+        return Arrays.stream(DirectionCube3x3PartHalf.values())
+            .filter(part -> part.offsetX == offsetX)
+            .filter(part -> part.offsetY == offsetY)
+            .filter(part -> part.offsetZ == offsetZ)
+            .findFirst()
+            .orElse(null);
+    }
+
+    static {
+        for (DirectionCube3x3PartHalf half : DirectionCube3x3PartHalf.values()) {
+            int x = half.offsetX;
+            int y = half.offsetY;
+            int z = half.offsetZ;
+            half.clockwise90 = findByOffset(-z, y, x);
+            half.clockwise180 = findByOffset(-x, y, -z);
+            half.clockwise270 = findByOffset(z, y, -x);
+            half.mirrorX = findByOffset(-x, y, z);
+            half.mirrorZ = findByOffset(x, y, -z);
+        }
+    }
 
     DirectionCube3x3PartHalf(String name, int offsetX, int offsetY, int offsetZ) {
         this.name = name;
@@ -73,5 +106,22 @@ public enum DirectionCube3x3PartHalf
     @Override
     public boolean isMain() {
         return this == MID_CENTER;
+    }
+
+    public DirectionCube3x3PartHalf rotate(Rotation rotation) {
+        return switch (rotation) {
+            case NONE -> this;
+            case CLOCKWISE_90 -> this.clockwise90;
+            case CLOCKWISE_180 -> this.clockwise180;
+            case COUNTERCLOCKWISE_90 -> this.clockwise270;
+        };
+    }
+
+    public DirectionCube3x3PartHalf mirror(Mirror mirror) {
+        return switch (mirror) {
+            case NONE -> this;
+            case LEFT_RIGHT -> this.mirrorZ;
+            case FRONT_BACK -> this.mirrorX;
+        };
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ZombieVillagerMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ZombieVillagerMixin.java
@@ -34,7 +34,7 @@ public abstract class ZombieVillagerMixin extends Zombie {
         )
     )
     private void discountForAllPlayers(Villager villager, ServerLevel serverLevel, Operation<Void> original) {
-        if (this.conversionStarter.equals(ModDispenserBehavior.ANVILCRAFT_DISPENSER)) {
+        if (ModDispenserBehavior.ANVILCRAFT_DISPENSER.equals(this.conversionStarter)) {
             serverLevel.getServer()
                 .getPlayerList()
                 .getPlayers()

--- a/src/main/java/dev/dubhe/anvilcraft/util/mixin/ProvidenceRef.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/mixin/ProvidenceRef.java
@@ -1,7 +1,7 @@
 package dev.dubhe.anvilcraft.util.mixin;
 
 public class ProvidenceRef {
-    private static final ThreadLocal<Boolean> SHOULD_TRIGGER = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> SHOULD_TRIGGER = ThreadLocal.withInitial(() -> false);
 
     public static void shouldTrigger() {
         SHOULD_TRIGGER.set(true);


### PR DESCRIPTION
- 修复了 #3276 ，解决了在检测由发射器转化而来的僵尸村民的过程中可能产生的NPE问题。
- 修复了 #3275 ，解决了`ThreadLocal`产生的NPE问题。
- 修复了 #3270， 为一些方块重写了`rotate` 与`mirror`方法。
- fixed #3276 
- fixed #3275
- fixed #3270