### PR TITLE
Fix about fire immune 火焰免疫相关修复

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
@@ -245,6 +245,11 @@ public class CauldronOutletEntity extends Entity {
     }
 
     @Override
+    public boolean fireImmune() {
+        return true;
+    }
+
+    @Override
     protected void defineSynchedData(SynchedEntityData.Builder builder) {
         builder.define(DATA_CAULDRON_POS, BlockPos.ZERO)
             .define(DATA_ATTACHED_DIRECTION, Direction.UP)

--- a/src/main/java/dev/dubhe/anvilcraft/entity/MagnetizedNodeEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/MagnetizedNodeEntity.java
@@ -84,6 +84,11 @@ public class MagnetizedNodeEntity extends Entity {
     }
 
     @Override
+    public boolean fireImmune() {
+        return true;
+    }
+
+    @Override
     protected void defineSynchedData(SynchedEntityData.Builder builder) {
         builder.define(DATA_BLOCK_POS, BlockPos.ZERO).define(DATA_BLOCK_STATE, Blocks.AIR.defaultBlockState());
     }

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -3953,6 +3953,7 @@ public class ModBlocks {
             DangerUtil.genConfiguredModel("block/multiphase_matter_block").get()
         ))
         .item(MultiphaseMatterBlockItem::new)
+        .initialProperties(() -> new Item.Properties().fireResistant())
         .tag(Tags.Items.STORAGE_BLOCKS, ModItemTags.STORAGE_BLOCKS_MULTIPHASE_MATTER)
         .build()
         .tag(

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/ModItems.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/ModItems.java
@@ -726,7 +726,8 @@ public class ModItems {
         ItemTags.MINING_ENCHANTABLE,
         ItemTags.FISHING_ENCHANTABLE,
         ItemTags.STRIDER_TEMPT_ITEMS
-    ).properties((properties) -> properties.durability(2031)).model(DataGenUtil::noExtraModelOrState).register();
+    ).properties((properties) -> properties.durability(2031).fireResistant())
+        .model(DataGenUtil::noExtraModelOrState).register();
 
     public static final ItemEntry<? extends SpectralSlingshotItem> SPECTRAL_SLINGSHOT = REGISTRATE
         .item("spectral_slingshot", SpectralSlingshotItem::new)

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/TranscendiumRecipeCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/TranscendiumRecipeCategory.java
@@ -218,7 +218,6 @@ public class TranscendiumRecipeCategory implements IRecipeCategory<TranscendiumR
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(ModBlocks.CURSED_GOLD_BLOCK.asStack(), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
         registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);

--- a/src/main/java/dev/dubhe/anvilcraft/item/EmberMetalResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/EmberMetalResonatorItem.java
@@ -7,7 +7,7 @@ public class EmberMetalResonatorItem extends ResonatorItem {
     public EmberMetalResonatorItem(Properties properties) {
         super(
             ModTiers.EMBER_METAL,
-            properties
+            properties.fireResistant()
                 .attributes(ResonatorItem.createAttributes(ModTiers.EMBER_METAL, 10, -3f))
                 .component(ModComponents.FIRE_REFORGING, Unit.INSTANCE)
         );

--- a/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalAxeItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalAxeItem.java
@@ -8,8 +8,7 @@ public class FrostMetalAxeItem extends AxeItem {
     public FrostMetalAxeItem(Properties properties) {
         super(
             ModTiers.FROST_METAL,
-            properties.fireResistant()
-                .attributes(AxeItem.createAttributes(ModTiers.FROST_METAL, 9, -3f))
+            properties.attributes(AxeItem.createAttributes(ModTiers.FROST_METAL, 9, -3f))
                 .component(ModComponents.MERCILESS, Merciless.DEFAULT)
         );
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalHoeItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalHoeItem.java
@@ -8,8 +8,7 @@ public class FrostMetalHoeItem extends HoeItem {
     public FrostMetalHoeItem(Properties properties) {
         super(
             ModTiers.FROST_METAL,
-            properties.fireResistant()
-                .attributes(HoeItem.createAttributes(ModTiers.FROST_METAL, 1, 0))
+            properties.attributes(HoeItem.createAttributes(ModTiers.FROST_METAL, 1, 0))
                 .component(ModComponents.MERCILESS, Merciless.DEFAULT)
         );
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalPickaxeItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalPickaxeItem.java
@@ -8,8 +8,7 @@ public class FrostMetalPickaxeItem extends PickaxeItem {
     public FrostMetalPickaxeItem(Properties properties) {
         super(
             ModTiers.FROST_METAL,
-            properties.fireResistant()
-                .attributes(PickaxeItem.createAttributes(ModTiers.FROST_METAL, 4, -2.8f))
+            properties.attributes(PickaxeItem.createAttributes(ModTiers.FROST_METAL, 4, -2.8f))
                 .component(ModComponents.MERCILESS, Merciless.DEFAULT)
         );
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalShovelItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalShovelItem.java
@@ -8,8 +8,7 @@ public class FrostMetalShovelItem extends ShovelItem {
     public FrostMetalShovelItem(Properties properties) {
         super(
             ModTiers.FROST_METAL,
-            properties.fireResistant()
-                .attributes(ShovelItem.createAttributes(ModTiers.FROST_METAL, 5, -3f))
+            properties.attributes(ShovelItem.createAttributes(ModTiers.FROST_METAL, 5, -3f))
                 .component(ModComponents.MERCILESS, Merciless.DEFAULT)
         );
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalSwordItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/FrostMetalSwordItem.java
@@ -8,8 +8,7 @@ public class FrostMetalSwordItem extends SwordItem {
     public FrostMetalSwordItem(Properties properties) {
         super(
             ModTiers.FROST_METAL,
-            properties.fireResistant()
-                .attributes(SwordItem.createAttributes(ModTiers.FROST_METAL, 7, -2.4f))
+            properties.attributes(SwordItem.createAttributes(ModTiers.FROST_METAL, 7, -2.4f))
                 .component(ModComponents.MERCILESS, Merciless.DEFAULT)
         );
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/ResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ResonatorItem.java
@@ -70,9 +70,7 @@ public abstract class ResonatorItem extends TieredItem {
     public ResonatorItem(Tier tier, Properties properties) {
         super(
             tier,
-            properties
-                .component(DataComponents.TOOL, createToolProperties(tier))
-                .fireResistant()
+            properties.component(DataComponents.TOOL, createToolProperties(tier))
         );
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/item/TranscendenceResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/TranscendenceResonatorItem.java
@@ -16,7 +16,7 @@ public class TranscendenceResonatorItem extends ResonatorItem {
     public TranscendenceResonatorItem(Properties properties) {
         super(
             ModTiers.TRANSCENDIUM,
-            properties
+            properties.fireResistant()
                 .attributes(ResonatorItem.createAttributes(ModTiers.TRANSCENDIUM, 17, -3f))
                 .component(ModComponents.MULTIPHASE, new MultiphaseRef())
                 .component(DataComponents.ITEM_NAME, Multiphase.firstPhaseName(NAME))


### PR DESCRIPTION
- 修复了 #3311 。
  - 现在磁化节点、炼药锅输出口会免疫火焰。
- 修复了 #3255 与 #3257。
  - 现在浮霜合金相关工具不具有抗火属性了。
- 修复了诅咒金块错误地被显示为超限合金配方的工作方块的问题。
- fixed #3311
- fixed #3255 
- fixed #3257