### PR TITLE
Several fixes for JEI plugin JEI插件相关修复

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/AnvilCraftJeiPlugin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/AnvilCraftJeiPlugin.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei;
 
+import com.google.common.collect.ImmutableList;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.gui.screen.BaseChuteScreen;
 import dev.dubhe.anvilcraft.client.gui.screen.BatchCrafterScreen;
@@ -96,9 +97,20 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.level.ItemLike;
 
 @JeiPlugin
 public class AnvilCraftJeiPlugin implements IModPlugin {
+
+    public static final ImmutableList<ItemLike> ANVIL_PROCESSING_CATALYSTS = ImmutableList.of(
+        Items.ANVIL,
+        ModBlocks.ROYAL_ANVIL,
+        ModBlocks.EMBER_ANVIL,
+        ModBlocks.FROST_ANVIL,
+        ModBlocks.TRANSCENDENCE_ANVIL,
+        ModBlocks.SPECTRAL_ANVIL,
+        ModBlocks.GIANT_ANVIL
+    );
 
     public static final RecipeType<MeshRecipeGroup> MESH = createRecipeType("mesh", MeshRecipeGroup.class);
     public static final RecipeType<CementStainingRecipe> CEMENT_STAINING =
@@ -361,5 +373,10 @@ public class AnvilCraftJeiPlugin implements IModPlugin {
 
     public static <R extends Recipe<?>> RecipeType<RecipeHolder<R>> createRecipeHolderType(String name) {
         return RecipeType.createRecipeHolderType(AnvilCraft.of(name));
+    }
+
+    public static void addAnvilProcessingCatalysts(IRecipeCatalystRegistration registration, RecipeType<?> recipeType) {
+        ANVIL_PROCESSING_CATALYSTS.forEach(item ->
+            registration.addRecipeCatalyst(new ItemStack(item), recipeType));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/TranscendiumRecipeCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/TranscendiumRecipeCategory.java
@@ -21,8 +21,6 @@ import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import org.jetbrains.annotations.Nullable;
 
@@ -218,10 +216,6 @@ public class TranscendiumRecipeCategory implements IRecipeCategory<TranscendiumR
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.TRANSCENDIUM_RECIPE);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/VoidDecayCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/VoidDecayCategory.java
@@ -5,13 +5,18 @@ import dev.dubhe.anvilcraft.client.support.RenderSupport;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.recipe.VoidDecayRecipe;
-import dev.dubhe.anvilcraft.integration.jei.util.BlockTagUtil;
 import dev.dubhe.anvilcraft.integration.jei.util.JeiRenderHelper;
 import dev.dubhe.anvilcraft.util.LevelLike;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawablesView;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.gui.placement.HorizontalAlignment;
+import mezz.jei.api.gui.placement.VerticalAlignment;
+import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
+import mezz.jei.api.gui.widgets.IScrollGridWidget;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
@@ -33,14 +38,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class VoidDecayCategory implements IRecipeCategory<VoidDecayRecipe> {
     public static final int WIDTH = 162;
     public static final int HEIGHT = 128;
     public static final int MAX_SHOWN_ROW = 7;
     public static final int MAX_SHOWN_COLUMN = 5;
-    public static final int MAX_SHOWN_COUNT = MAX_SHOWN_ROW * MAX_SHOWN_COLUMN;
 
     private final IDrawable slot;
     private final Component title;
@@ -110,22 +113,23 @@ public class VoidDecayCategory implements IRecipeCategory<VoidDecayRecipe> {
             .addItemStack(new ItemStack(recipe.catalyst.asItem(), recipe.catalystCount))
             .addRichTooltipCallback((recipeSlotView, tooltip) ->
                 tooltip.addAll(List.of(aroundTooltip, notConsumedTooltip)));
-        builder.addInvisibleIngredients(RecipeIngredientRole.OUTPUT)
-            .addIngredients(BlockTagUtil.toIngredient(recipe.result));
-        AtomicInteger slotId = new AtomicInteger(0);
         RegistryUtil.getRegistry(Registries.BLOCK)
             .getTag(recipe.result)
             .stream()
             .flatMap(HolderSet.ListBacked::stream)
             .map(h -> h.value().asItem().getDefaultInstance())
-            .limit(MAX_SHOWN_COUNT)
-            .forEach(stack -> {
-                int id = slotId.getAndAdd(1);
-                builder.addSlot(RecipeIngredientRole.RENDER_ONLY,
-                        (id % MAX_SHOWN_COLUMN) * 18 + 66,
-                        (id / MAX_SHOWN_COLUMN) * 18 + 4)
-                    .addItemStack(stack);
-            });
+            .forEach(stack -> builder.addOutputSlot().addItemStack(stack));
+    }
+
+    @Override
+    public void createRecipeExtras(IRecipeExtrasBuilder builder, VoidDecayRecipe recipe, IFocusGroup focuses) {
+        IRecipeSlotDrawablesView recipeSlots = builder.getRecipeSlots();
+        List<IRecipeSlotDrawable> outputSlots = recipeSlots.getSlots(RecipeIngredientRole.OUTPUT);
+
+        IScrollGridWidget scrollGridWidget =
+            builder.addScrollGridWidget(outputSlots, MAX_SHOWN_COLUMN, MAX_SHOWN_ROW);
+        scrollGridWidget.setPosition(60, 4,
+            getWidth(), getHeight(), HorizontalAlignment.LEFT, VerticalAlignment.TOP);
     }
 
     @Override
@@ -148,14 +152,6 @@ public class VoidDecayCategory implements IRecipeCategory<VoidDecayRecipe> {
 
         slot.draw(guiGraphics, 7, 83);
         slot.draw(guiGraphics, 7, 101);
-        for (int i = 0; i < MAX_SHOWN_ROW; i++) {
-            for (int j = 0; j < MAX_SHOWN_COLUMN; j++) {
-                int x = 65 + j * 18;
-                int y = 3 + i * 18;
-                slot.draw(guiGraphics, x, y);
-            }
-        }
-
         arrowDefault.draw(guiGraphics, 35, 87);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BlockCompressCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BlockCompressCategory.java
@@ -2,7 +2,6 @@ package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.anvilcraft.lib.v2.recipe.component.BlockStatePredicate;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.util.BlockTagUtil;
@@ -175,10 +174,6 @@ public class BlockCompressCategory implements IRecipeCategory<RecipeHolder<Block
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.BLOCK_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.BLOCK_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.BLOCK_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.BLOCK_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.BLOCK_COMPRESS);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.BLOCK_COMPRESS);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BlockCrushCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BlockCrushCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.util.JeiRecipeUtil;
@@ -164,10 +163,6 @@ public class BlockCrushCategory implements IRecipeCategory<RecipeHolder<BlockCru
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.BLOCK_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.BLOCK_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.BLOCK_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.BLOCK_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.BLOCK_CRUSH);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.BLOCK_CRUSH);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BlockSmearCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BlockSmearCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.util.BlockTagUtil;
@@ -187,10 +186,6 @@ public class BlockSmearCategory implements IRecipeCategory<RecipeHolder<BlockSme
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.BLOCK_SMEAR);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.BLOCK_SMEAR);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.BLOCK_SMEAR);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.BLOCK_SMEAR);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.BLOCK_SMEAR);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.BLOCK_SMEAR);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BoilingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BoilingCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.drawable.DrawableBlockStateIcon;
@@ -90,11 +89,7 @@ public class BoilingCategory extends AbstractProgressCategory<BoilingRecipe> {
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.BOILING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.BOILING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.BOILING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.BOILING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.BOILING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.BOILING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.BOILING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAMPFIRE), AnvilCraftJeiPlugin.BOILING);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BulgingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/BulgingCategory.java
@@ -2,7 +2,6 @@ package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.drawable.DrawableBlockStateIcon;
@@ -235,11 +234,7 @@ public class BulgingCategory implements IRecipeCategory<RecipeHolder<BulgingReci
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.BULGING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.BULGING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.BULGING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.BULGING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.BULGING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.BULGING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.BULGING);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/CementStainingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/CementStainingCategory.java
@@ -153,11 +153,7 @@ public class CementStainingCategory implements IRecipeCategory<CementStainingRec
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.CEMENT_STAINING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.CEMENT_STAINING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.CEMENT_STAINING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.CEMENT_STAINING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.CEMENT_STAINING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.CEMENT_STAINING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.CEMENT_STAINING);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ConcreteCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ConcreteCategory.java
@@ -148,11 +148,7 @@ public class ConcreteCategory implements IRecipeCategory<ColoredConcreteRecipe> 
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.COLORED_CONCRETE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.COLORED_CONCRETE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.COLORED_CONCRETE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.COLORED_CONCRETE);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.COLORED_CONCRETE);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.COLORED_CONCRETE);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.COLORED_CONCRETE);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/CookingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/CookingCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.drawable.DrawableBlockStateIcon;
@@ -82,11 +81,7 @@ public class CookingCategory extends AbstractProgressCategory<CookingRecipe> {
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.COOKING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.COOKING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.COOKING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.COOKING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.COOKING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.COOKING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.COOKING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAMPFIRE), AnvilCraftJeiPlugin.COOKING);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ItemCompressCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ItemCompressCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.drawable.DrawableBlockStateIcon;
@@ -72,11 +71,7 @@ public class ItemCompressCategory extends AbstractProgressCategory<ItemCompressR
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.ITEM_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.ITEM_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.ITEM_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.ITEM_COMPRESS);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.ITEM_COMPRESS);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.ITEM_COMPRESS);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.ITEM_COMPRESS);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ItemCrushCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ItemCrushCategory.java
@@ -17,7 +17,6 @@ import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.Blocks;
 
@@ -79,11 +78,7 @@ public class ItemCrushCategory extends AbstractProgressCategory<ItemCrushRecipe>
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.ITEM_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.ITEM_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.ITEM_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.ITEM_CRUSH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.ITEM_CRUSH);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.ITEM_CRUSH);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.CRUSHING_TABLE), AnvilCraftJeiPlugin.ITEM_CRUSH);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ItemInjectCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/ItemInjectCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.util.JeiRecipeUtil;
@@ -158,10 +157,6 @@ public class ItemInjectCategory implements IRecipeCategory<RecipeHolder<ItemInje
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.ITEM_INJECT);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.ITEM_INJECT);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.ITEM_INJECT);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.ITEM_INJECT);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.ITEM_INJECT);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.ITEM_INJECT);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/MassInjectCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/MassInjectCategory.java
@@ -26,8 +26,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.Blocks;
 
@@ -151,10 +149,6 @@ public class MassInjectCategory implements IRecipeCategory<RecipeHolder<MassInje
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(ModBlocks.SPACE_OVERCOMPRESSOR.asStack(), AnvilCraftJeiPlugin.MASS_INJECT);
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.MASS_INJECT);
-        registration.addRecipeCatalyst(ModBlocks.ROYAL_ANVIL.asStack(), AnvilCraftJeiPlugin.MASS_INJECT);
-        registration.addRecipeCatalyst(ModBlocks.EMBER_ANVIL.asStack(), AnvilCraftJeiPlugin.MASS_INJECT);
-        registration.addRecipeCatalyst(ModBlocks.GIANT_ANVIL.asStack(), AnvilCraftJeiPlugin.MASS_INJECT);
-        registration.addRecipeCatalyst(ModBlocks.SPECTRAL_ANVIL.asStack(), AnvilCraftJeiPlugin.MASS_INJECT);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.MASS_INJECT);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/MeshRecipeCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/MeshRecipeCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.drawable.DrawableBlockStateIcon;
 import dev.dubhe.anvilcraft.integration.jei.recipe.MeshRecipeGroup;
@@ -121,11 +120,7 @@ public class MeshRecipeCategory implements IRecipeCategory<MeshRecipeGroup> {
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.MESH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.MESH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.MESH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.MESH);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.MESH);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.MESH);
         registration.addRecipeCatalyst(new ItemStack(Items.SCAFFOLDING), AnvilCraftJeiPlugin.MESH);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/NeutronIrradiationCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/NeutronIrradiationCategory.java
@@ -189,11 +189,7 @@ public class NeutronIrradiationCategory implements IRecipeCategory<RecipeHolder<
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.NEUTRON_IRRADIATOR), AnvilCraftJeiPlugin.NEUTRON_IRRADIATION);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/SqueezingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/SqueezingCategory.java
@@ -4,7 +4,6 @@ import dev.anvilcraft.lib.v2.recipe.component.BlockStatePredicate;
 import dev.anvilcraft.lib.v2.recipe.component.ChanceBlockState;
 import dev.anvilcraft.lib.v2.recipe.component.ChanceItemStack;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.util.JeiRecipeUtil;
@@ -189,11 +188,7 @@ public class SqueezingCategory implements IRecipeCategory<RecipeHolder<Squeezing
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.SQUEEZING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.SQUEEZING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.SQUEEZING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.SQUEEZING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.SQUEEZING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.SQUEEZING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.SQUEEZING);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/StampingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/StampingCategory.java
@@ -17,7 +17,6 @@ import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.Blocks;
 
@@ -81,11 +80,7 @@ public class StampingCategory extends AbstractProgressCategory<StampingRecipe> {
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.STAMPING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.STAMPING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.STAMPING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.STAMPING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.STAMPING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.STAMPING);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.STAMPING_PLATFORM), AnvilCraftJeiPlugin.STAMPING);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/SuperHeatingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/SuperHeatingCategory.java
@@ -172,11 +172,7 @@ public class SuperHeatingCategory extends AbstractProgressCategory<SuperHeatingR
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.SUPER_HEATING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.SUPER_HEATING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.SUPER_HEATING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.SUPER_HEATING);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.SUPER_HEATING);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.SUPER_HEATING);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.SUPER_HEATING);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.HEATER), AnvilCraftJeiPlugin.SUPER_HEATING);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/TimeWarpCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/TimeWarpCategory.java
@@ -242,11 +242,7 @@ public class TimeWarpCategory implements IRecipeCategory<RecipeHolder<TimeWarpRe
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.TIME_WARP);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.TIME_WARP);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.TIME_WARP);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.TIME_WARP);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.TIME_WARP);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.TIME_WARP);
         registration.addRecipeCatalyst(new ItemStack(Items.CAULDRON), AnvilCraftJeiPlugin.TIME_WARP);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.CORRUPTED_BEACON), AnvilCraftJeiPlugin.TIME_WARP);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/UnpackCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/UnpackCategory.java
@@ -1,7 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.anvil;
 
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
 import dev.dubhe.anvilcraft.integration.jei.drawable.DrawableBlockStateIcon;
@@ -83,11 +82,7 @@ public class UnpackCategory extends AbstractProgressCategory<UnpackRecipe> {
     }
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(new ItemStack(Items.ANVIL), AnvilCraftJeiPlugin.UNPACK);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.ROYAL_ANVIL), AnvilCraftJeiPlugin.UNPACK);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.EMBER_ANVIL), AnvilCraftJeiPlugin.UNPACK);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.GIANT_ANVIL), AnvilCraftJeiPlugin.UNPACK);
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.SPECTRAL_ANVIL), AnvilCraftJeiPlugin.UNPACK);
+        AnvilCraftJeiPlugin.addAnvilProcessingCatalysts(registration, AnvilCraftJeiPlugin.UNPACK);
         registration.addRecipeCatalyst(new ItemStack(Items.IRON_TRAPDOOR), AnvilCraftJeiPlugin.UNPACK);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/multiblock/MultiBlockCraftingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/multiblock/MultiBlockCraftingCategory.java
@@ -1,9 +1,6 @@
 package dev.dubhe.anvilcraft.integration.jei.category.multiblock;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.math.Axis;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.block.GiantAnvilBlock;
 import dev.dubhe.anvilcraft.block.state.Cube3x3PartHalf;
@@ -19,7 +16,6 @@ import dev.dubhe.anvilcraft.integration.jei.util.TextureConstants;
 import dev.dubhe.anvilcraft.recipe.multiblock.MultiblockRecipe;
 import dev.dubhe.anvilcraft.util.LevelLike;
 import dev.dubhe.anvilcraft.util.RecipeUtil;
-import dev.dubhe.anvilcraft.util.VertexConsumerWithPose;
 import mezz.jei.api.gui.ITickTimer;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -32,25 +28,11 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
-import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.client.resources.model.BakedModel;
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Mth;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeHolder;
-import net.minecraft.world.level.block.RenderShape;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.FluidState;
-import net.neoforged.neoforge.client.model.data.ModelData;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Comparator;
@@ -60,7 +42,6 @@ import java.util.Map;
 
 public class MultiBlockCraftingCategory implements IRecipeCategory<RecipeHolder<MultiblockRecipe>> {
     private static final Component TITLE = Component.translatable("gui.anvilcraft.category.multiblock");
-    private static final RandomSource RANDOM = RandomSource.createNewThreadLocalInstance();
 
     private static final Comparator<ItemStack> BY_COUNT_DECREASING =
         Comparator.comparing(ItemStack::getCount).thenComparing(ItemStack::getDescriptionId).reversed();
@@ -176,71 +157,10 @@ public class MultiBlockCraftingCategory implements IRecipeCategory<RecipeHolder<
         }
         final boolean renderAllLayers = level.isAllLayersVisible();
         final int visibleLayer = level.getCurrentVisibleLayer();
-        RenderSystem.enableBlend();
-        final int xPos = 45;
-        final int yPos = 50;
+        RenderSupport.renderLevelLike(level, guiGraphics, 45, 50, SCALE_FAC, 2.0f);
         Minecraft minecraft = Minecraft.getInstance();
-        DeltaTracker tracker = minecraft.getTimer();
-        ClientLevel clientLevel = minecraft.level;
         PoseStack pose = guiGraphics.pose();
-        int sizeX = level.horizontalSize();
         int sizeY = level.verticalSize();
-
-        float scaleX = SCALE_FAC / (sizeX * Mth.SQRT_OF_TWO);
-        float scaleY = SCALE_FAC / (float) sizeY;
-        float scale = Math.min(scaleY, scaleX);
-
-        pose.pushPose();
-        pose.translate(xPos, yPos, 100);
-
-        pose.scale(-scale, -scale, -scale);
-
-        pose.translate(-(float) sizeX / 2, -(float) sizeY / 2, 0);
-        pose.mulPose(Axis.XP.rotationDegrees(-30));
-
-        float offsetX = (float) -sizeX / 2;
-        float offsetZ = (float) -sizeX / 2 + 1;
-        float rotationY = (clientLevel.getGameTime() + tracker.getGameTimeDeltaPartialTick(true)) * 2f;
-
-        pose.translate(-offsetX, 0, -offsetZ);
-        pose.mulPose(Axis.YP.rotationDegrees(rotationY + 45));
-
-        pose.translate(offsetX, 0, offsetZ);
-
-        Iterable<BlockPos> iter;
-        if (renderAllLayers) {
-            iter = BlockPos.betweenClosed(BlockPos.ZERO, new BlockPos(sizeX - 1, sizeY - 1, sizeX - 1));
-        } else {
-            iter = BlockPos.betweenClosed(
-                BlockPos.ZERO.atY(visibleLayer), new BlockPos(sizeX - 1, visibleLayer, sizeX - 1));
-        }
-        pose.pushPose();
-        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-        pose.translate(0, 0, -1);
-        MultiBufferSource.BufferSource buffers = minecraft.renderBuffers().bufferSource();
-        BlockRenderDispatcher blockRenderer = minecraft.getBlockRenderer();
-        for (BlockPos pos : iter) {
-            BlockState state = level.getBlockState(pos);
-            pose.pushPose();
-            pose.translate(pos.getX(), pos.getY(), pos.getZ());
-            FluidState fluid = state.getFluidState();
-            if (!fluid.isEmpty()) {
-                RenderType renderType = ItemBlockRenderTypes.getRenderLayer(fluid);
-                VertexConsumer vertex = buffers.getBuffer(renderType);
-                blockRenderer.renderLiquid(pos, level, new VertexConsumerWithPose(vertex, pose.last(), pos), state, fluid);
-            }
-            if (state.getRenderShape() != RenderShape.INVISIBLE) {
-                BakedModel bakedModel = blockRenderer.getBlockModel(state);
-                for (RenderType type : bakedModel.getRenderTypes(state, RANDOM, ModelData.EMPTY)) {
-                    VertexConsumer vertex = buffers.getBuffer(type);
-                    blockRenderer.renderBatched(state, pos, level, pose, vertex, false, RANDOM, ModelData.EMPTY, type);
-                }
-            }
-            pose.popPose();
-        }
-        buffers.endBatch();
-        pose.popPose();
-        pose.popPose();
         Component component;
         if (renderAllLayers) {
             component = Component.translatable("gui.anvilcraft.category.multiblock.all_layers");

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/multiblock/MultiBlockCraftingCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/multiblock/MultiBlockCraftingCategory.java
@@ -32,6 +32,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.Nullable;
 
@@ -266,6 +267,7 @@ public class MultiBlockCraftingCategory implements IRecipeCategory<RecipeHolder<
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(ModBlocks.GIANT_ANVIL.asStack(), AnvilCraftJeiPlugin.MULTIBLOCK_CRAFTING);
         registration.addRecipeCatalyst(ModBlocks.TRANSPARENT_CRAFTING_TABLE.asStack(), AnvilCraftJeiPlugin.MULTIBLOCK_CRAFTING);
+        registration.addRecipeCatalyst(Items.CRAFTING_TABLE.getDefaultInstance(), AnvilCraftJeiPlugin.MULTIBLOCK_CRAFTING);
         registration.addRecipeCatalyst(ModBlocks.SPACE_OVERCOMPRESSOR.asStack(), AnvilCraftJeiPlugin.MULTIBLOCK_CRAFTING);
     }
 


### PR DESCRIPTION
- 修复了 #3352 的问题。
  - 现在多方块合成配方也能渲染方块实体了。
- 将超限铁砧、浮霜铁砧加入了各类铁砧处理配方的工作方块列表中，并优化了相关代码。
- 现在虚空衰变配方可以显示全部产物了。
- 将原版工作台加入了多方块合成配方的工作方块列表中。
- fixed #3352