### PR TITLE
Delete the unnecessary plugin import configurations 删除无用的插件导入配置

### DIFF
--- a/src/main/resources/kubejs.plugins.txt
+++ b/src/main/resources/kubejs.plugins.txt
@@ -1,1 +1,0 @@
-dev.dubhe.anvilcraft.integration.kubejs.AnvilCraftKubeJsPlugin


### PR DESCRIPTION
- 移除了对AnvilCraftKubeJsPlugin的导入声明
- 清理了kubejs插件配置文件
- 减少了无效的依赖引用风险
- 改善项目结构和可维护性