### PR TITLE
Add blacklist to DragonRod and BlockDevourer 为龙杖和方块吞噬器添加黑名单#3379

### DIFF
--- a/src/generated/resources/data/anvilcraft/tags/block/devour_blacklist.json
+++ b/src/generated/resources/data/anvilcraft/tags/block/devour_blacklist.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "#c:chests/trapped",
+    "#c:chests/wooden"
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/anvil/BlockDevourerBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/anvil/BlockDevourerBehavior.java
@@ -33,7 +33,7 @@ public class BlockDevourerBehavior implements IAnvilBehavior {
         );
         if (
             hitBlockState.getValue(BlockDevourerBlock.FACING) == Direction.DOWN
-            && level.getBlockState(hitBlockPos.below()).getBlock().defaultDestroyTime() >= 0
+            && BlockDevourerBlock.canDevour(level.getBlockState(hitBlockPos.below()))
         ) {
             level.setBlockAndUpdate(hitBlockPos, Blocks.AIR.defaultBlockState());
             level.setBlockAndUpdate(hitBlockPos.below(), hitBlockState.setValue(BlockDevourerBlock.TRIGGERED, true));

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlockDevourerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlockDevourerBlock.java
@@ -274,7 +274,7 @@ public class BlockDevourerBlock extends DirectionalBlock implements HammerRotate
         if (filteredBlockPosList.contains(devourBlockPos)) return;
         BlockState devourBlockState = level.getBlockState(devourBlockPos);
         if (devourBlockState.isAir()) return;
-        if (!canDevour(devourBlockState)) return;
+        if (!BlockDevourerBlock.canDevour(devourBlockState)) return;
         if (
             !(anvil instanceof FrostAnvilBlock)
             && devourBlockState.is(ModBlockTags.BLOCK_DEVOURER_PROBABILITY_DROPPING)

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlockDevourerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlockDevourerBlock.java
@@ -254,6 +254,15 @@ public class BlockDevourerBlock extends DirectionalBlock implements HammerRotate
         }
     }
 
+    /**
+     * 检查目标位置是否可以破坏
+     *
+     * @param devourBlockState       目标方块
+     * */
+    public static boolean canDevour(BlockState devourBlockState){
+        return !devourBlockState.is(ModBlockTags.DEVOUR_BLACKLIST) && devourBlockState.getBlock().defaultDestroyTime() >= 0;
+    }
+
     private static void devourSingleBlockInternalLogic(
         ServerLevel level, @Nullable Block anvil, BlockPos devourBlockPos, List<BlockPos> filteredBlockPosList,
         @Nullable List<IItemHandler> itemHandlerList, Vec3 center
@@ -265,7 +274,7 @@ public class BlockDevourerBlock extends DirectionalBlock implements HammerRotate
         if (filteredBlockPosList.contains(devourBlockPos)) return;
         BlockState devourBlockState = level.getBlockState(devourBlockPos);
         if (devourBlockState.isAir()) return;
-        if (devourBlockState.getBlock().defaultDestroyTime() < 0) return;
+        if (!canDevour(devourBlockState)) return;
         if (
             !(anvil instanceof FrostAnvilBlock)
             && devourBlockState.is(ModBlockTags.BLOCK_DEVOURER_PROBABILITY_DROPPING)

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlockDevourerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlockDevourerBlock.java
@@ -259,7 +259,7 @@ public class BlockDevourerBlock extends DirectionalBlock implements HammerRotate
      *
      * @param devourBlockState       目标方块
      * */
-    public static boolean canDevour(BlockState devourBlockState){
+    public static boolean canDevour(BlockState devourBlockState) {
         return !devourBlockState.is(ModBlockTags.DEVOUR_BLACKLIST) && devourBlockState.getBlock().defaultDestroyTime() >= 0;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -221,6 +221,10 @@ public class BlockTagLoader {
             .addTag(Tags.Blocks.CHESTS_ENDER)
             .addTag(Tags.Blocks.CHESTS_TRAPPED)
             .addTag(Tags.Blocks.CHESTS_WOODEN);
+        provider.addTag(ModBlockTags.DEVOUR_BLACKLIST)
+            .addTag(Tags.Blocks.CHESTS_TRAPPED)
+            .addTag(Tags.Blocks.CHESTS_WOODEN);
+
         provider.addTag(ModBlockTags.FELLING_APPLICABLE)
             .addTag(BlockTags.LOGS)
             .addTag(BlockTags.WART_BLOCKS)

--- a/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
@@ -125,9 +125,12 @@ public class PlayerEventListener {
         final Direction blockFace = event.getFace();
 
         if (blockFace == null) return;
-        if (state.getDestroySpeed(level, pos) == 0.0F) return;
+        if (state.getDestroySpeed(level, pos) < 0.0F) return;
         if (!stack.has(ModComponents.DEVOUR_RANGE)) return;
-        if (!DragonRodItem.canDevour(player, stack) || !BlockDevourerBlock.canDevour(state)) event.setCanceled(true);
+        if (!DragonRodItem.canDevour(player, stack) || !BlockDevourerBlock.canDevour(state)) {
+            event.setCanceled(true);
+            return;
+        }
 
         if (event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.START && !level.isClientSide) {
             DragonRodItem.devourBlock((ServerLevel) level, player, hand, pos, state, blockFace);

--- a/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.event;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.amulet.AmuletManager;
 import dev.dubhe.anvilcraft.api.power.PowerGrid;
+import dev.dubhe.anvilcraft.block.BlockDevourerBlock;
 import dev.dubhe.anvilcraft.block.item.ResinBlockItem;
 import dev.dubhe.anvilcraft.entity.MagnetizedNodeEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
@@ -126,7 +127,7 @@ public class PlayerEventListener {
         if (blockFace == null) return;
         if (state.getDestroySpeed(level, pos) == 0.0F) return;
         if (!stack.has(ModComponents.DEVOUR_RANGE)) return;
-        if (!DragonRodItem.canDevour(player, stack)) event.setCanceled(true);
+        if (!DragonRodItem.canDevour(player, stack) || !BlockDevourerBlock.canDevour(state)) event.setCanceled(true);
 
         if (event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.START && !level.isClientSide) {
             DragonRodItem.devourBlock((ServerLevel) level, player, hand, pos, state, blockFace);

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
@@ -100,6 +100,7 @@ public class ModBlockTags {
     public static final TagKey<Block> NEEDS_TRANSCENDIUM_TOOL = bind("needs_transcendium_tool");
 
     public static final TagKey<Block> ANVIL_HAMMER_BLACKLIST = bind("anvil_hammer_blacklist");
+    public static final TagKey<Block> DEVOUR_BLACKLIST = bind("devour_blacklist");
 
     public static final TagKey<Block> FELLING_APPLICABLE = bind("felling_applicable");
     public static final TagKey<Block> CLEANING_APPLICABLE = bind("cleaning_applicable");

--- a/src/main/java/dev/dubhe/anvilcraft/item/DragonRodItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/DragonRodItem.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.item;
 
 import com.google.common.collect.Streams;
+import dev.dubhe.anvilcraft.block.BlockDevourerBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
@@ -98,6 +99,7 @@ public class DragonRodItem extends Item {
         ServerLevel level, Player player, InteractionHand hand,
         BlockPos centerPos, BlockState centerState, Direction clickedSide
     ) {
+        if (centerState.is(ModBlockTags.DEVOUR_BLACKLIST)) return;
         if (centerState.getDestroySpeed(level, centerPos) == 0.0F) return;
         ItemStack dragonRod = player.getItemInHand(hand);
         if (!canDevour(player, dragonRod)) return;
@@ -125,7 +127,7 @@ public class DragonRodItem extends Item {
         for (BlockPos devouringPos : devouringPoses) {
             BlockState devouringState = level.getBlockState(devouringPos);
             if (devouringState.isAir()) continue;
-            if (devouringState.getBlock().defaultDestroyTime() < 0) continue;
+            if (!BlockDevourerBlock.canDevour(devouringState)) continue;
             if (devouringState.is(ModBlockTags.BLOCK_DEVOURER_PROBABILITY_DROPPING)
                 && level.random.nextDouble() > 0.05) {
                 level.destroyBlock(devouringPos, false);

--- a/src/main/java/dev/dubhe/anvilcraft/item/DragonRodItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/DragonRodItem.java
@@ -100,7 +100,7 @@ public class DragonRodItem extends Item {
         BlockPos centerPos, BlockState centerState, Direction clickedSide
     ) {
         if (centerState.is(ModBlockTags.DEVOUR_BLACKLIST)) return;
-        if (centerState.getDestroySpeed(level, centerPos) == 0.0F) return;
+        if (centerState.getDestroySpeed(level, centerPos) < 0.0F) return;
         ItemStack dragonRod = player.getItemInHand(hand);
         if (!canDevour(player, dragonRod)) return;
         int range = dragonRod.getOrDefault(ModComponents.DEVOUR_RANGE, -1);


### PR DESCRIPTION
- resolved #3379 
- 通过`#anvilcraft:devour_blacklist.json`定义龙杖和方块吞噬器的破坏黑名单
- 修复龙杖吞噬判定，现在可以对破坏速度为0的方块（如红石粉）正确触发吞噬