### PR TITLE
Complete the adjustment of the powered sliding rail完成动力滑轨调整

### DIFF
--- a/src/generated/resources/data/anvilcraft/tags/block/sliding_rail_stop_like.json
+++ b/src/generated/resources/data/anvilcraft/tags/block/sliding_rail_stop_like.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "#anvilcraft:heatable_blocks",
+    "minecraft:campfire",
+    "anvilcraft:sliding_rail_stop",
+    "anvilcraft:heater",
+    "anvilcraft:corrupted_beacon",
+    "anvilcraft:neutron_irradiator"
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
@@ -3,6 +3,8 @@ package dev.dubhe.anvilcraft.block.sliding;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.entity.MagnetizedNodeEntity;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import dev.dubhe.anvilcraft.event.NeighbourNotifyListener;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
@@ -177,6 +179,17 @@ public class PoweredSlidingRailBlock extends BaseSlidingRailBlock implements IHa
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos fromPos, boolean isMoving) {
         boolean powered = this.updatePower(level, pos, state, fromPos);
+        Direction facing = state.getValue(FACING);
+        pullFromStopLike:
+        if (powered) {
+            BlockPos railStopPos = pos.relative(facing.getOpposite());
+            BlockPos blockToPush = railStopPos.above();
+            if (!level.getBlockState(railStopPos).is(ModBlockTags.SLIDING_RAIL_STOP_LIKE)
+                || level.isEmptyBlock(blockToPush)) break pullFromStopLike;
+            if (NeighbourNotifyListener.canMoveBlockTo(level, railStopPos, level.getBlockState(blockToPush), facing)) {
+                NeighbourNotifyListener.moveBlocksAbove(level, railStopPos, facing);
+            }
+        }
         pushAbove:
         if (powered) {
             fromPos = pos.above();

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailStopBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailStopBlock.java
@@ -2,32 +2,22 @@ package dev.dubhe.anvilcraft.block.sliding;
 
 import dev.anvilcraft.lib.v2.util.MathUtil;
 import dev.anvilcraft.lib.v2.util.Util;
-import dev.dubhe.anvilcraft.api.sliding.SlidingBlockStructureResolver;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.apache.commons.lang3.tuple.Triple;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 public class SlidingRailStopBlock extends BaseSlidingRailBlock {
@@ -105,32 +95,6 @@ public class SlidingRailStopBlock extends BaseSlidingRailBlock {
         ISlidingRail.stopSlidingBlock(entity);
     }
 
-    @Override
-    protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos fromPos, boolean isMoving) {
-        super.neighborChanged(state, level, pos, neighborBlock, fromPos, isMoving);
-        if (level.isEmptyBlock(pos.above())) return;
-        BlockState topBlock = level.getBlockState(pos.above());
-        if (!PistonBaseBlock.isPushable(topBlock, level, pos, null, true, null)) return;
-        Direction moveTo = MathUtil.getDirection(fromPos, pos);
-        if (moveTo.getAxis() == Direction.Axis.Y) return;
-        if (this.canMoveBlockTo(level, pos, topBlock, moveTo)) {
-            SlidingRailStopBlock.moveBlocksAbove(level, pos, moveTo);
-        } else if (this.canMoveBlockTo(level, pos, topBlock, moveTo.getCounterClockWise())) {
-            SlidingRailStopBlock.moveBlocksAbove(level, pos, moveTo.getCounterClockWise());
-        } else if (this.canMoveBlockTo(level, pos, topBlock, moveTo.getClockWise())) {
-            SlidingRailStopBlock.moveBlocksAbove(level, pos, moveTo.getClockWise());
-        }
-    }
-
-    private boolean canMoveBlockTo(Level level, BlockPos pos, BlockState topBlock, Direction moveTo) {
-        if (moveTo.getAxis() == Direction.Axis.Y) return false;
-        BlockPos railPos = pos.relative(moveTo);
-        BlockState railState = level.getBlockState(railPos);
-        return Util.castSafely(railState.getBlock(), ISlidingRail.class)
-            .map(rail -> rail.canMoveBlockToTop(level, railPos, railState, topBlock, moveTo.getOpposite()))
-            .orElse(false);
-    }
-
     private boolean canMoveSlidingTo(Level level, BlockPos pos, Direction moveTo) {
         if (moveTo.getAxis() == Direction.Axis.Y) return false;
         BlockPos railPos = pos.relative(moveTo);
@@ -138,57 +102,5 @@ public class SlidingRailStopBlock extends BaseSlidingRailBlock {
         return Util.castSafely(railState.getBlock(), ISlidingRail.class)
             .map(rail -> rail.canMoveSlidingToTop(level, railPos, railState, moveTo.getOpposite()))
             .orElse(false);
-    }
-
-    private static void moveBlocksAbove(Level level, BlockPos pos, Direction moveToSide) {
-        SlidingBlockStructureResolver resolver = new SlidingBlockStructureResolver(level, pos.above(), moveToSide, true);
-        if (!resolver.resolve()) return;
-        List<Triple<BlockPos, BlockState, Optional<CompoundTag>>> toPushes = new ArrayList<>();
-        List<BlockPos> toPushPoses = new ArrayList<>(resolver.getToPush());
-
-        for (Iterator<BlockPos> iterator = toPushPoses.iterator(); iterator.hasNext(); ) {
-            BlockPos toPushPos = iterator.next();
-            if (toPushPos.equals(pos)) {
-                iterator.remove();
-                continue;
-            }
-            BlockState toPushState = level.getBlockState(toPushPos);
-            if (toPushState.hasProperty(BlockStateProperties.WATERLOGGED)) {
-                toPushState = toPushState.setValue(BlockStateProperties.WATERLOGGED, false);
-            }
-            Optional<CompoundTag> toPushEntityData = Optional.ofNullable(level.getBlockEntity(toPushPos))
-                .map(entity -> entity.saveCustomOnly(level.registryAccess()));
-            toPushes.add(Triple.of(toPushPos, toPushState, toPushEntityData));
-        }
-
-        List<BlockPos> toDestroys = resolver.getToDestroy();
-
-        for (int i = toDestroys.size() - 1; i >= 0; i--) {
-            BlockPos destroyingPos = toDestroys.get(i);
-            BlockState destroyingState = level.getBlockState(destroyingPos);
-            BlockEntity destroyingEntity = destroyingState.hasBlockEntity() ? level.getBlockEntity(destroyingPos) : null;
-            Block.dropResources(destroyingState, level, destroyingPos, destroyingEntity);
-            destroyingState.onDestroyedByPushReaction(level, destroyingPos, moveToSide, level.getFluidState(destroyingPos));
-        }
-
-        BlockState air = Blocks.AIR.defaultBlockState();
-
-        for (BlockPos toPushPos : toPushPoses) {
-            level.setBlock(toPushPos, air, 0b1010010);
-        }
-
-        for (var toPushEntry : toPushes) {
-            BlockPos toPushPos = toPushEntry.getLeft();
-            BlockState toPushState = toPushEntry.getMiddle();
-            toPushState.updateIndirectNeighbourShapes(level, toPushPos, 0b0000010);
-            air.updateNeighbourShapes(level, toPushPos, 0b0000010);
-            air.updateIndirectNeighbourShapes(level, toPushPos, 0b0000010);
-        }
-
-        for (var toPushEntry : toPushes) {
-            level.updateNeighborsAt(toPushEntry.getLeft(), air.getBlock());
-        }
-
-        SlidingBlockEntity.slid(level, pos.above(), moveToSide, toPushes);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailStopBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailStopBlock.java
@@ -79,23 +79,27 @@ public class SlidingRailStopBlock extends BaseSlidingRailBlock {
 
     @Override
     public void onSlidingAbove(Level level, BlockPos pos, BlockState state, SlidingBlockEntity entity) {
+        changeSlidingDirection(level, pos, entity);
+    }
+
+    public static void changeSlidingDirection(Level level, BlockPos pos, SlidingBlockEntity entity) {
         Direction moveTo = entity.getMoveDirection();
-        if (this.canMoveSlidingTo(level, pos, moveTo)) {
+        if (canMoveSlidingTo(level, pos, moveTo)) {
             return;
-        } else if (this.canMoveSlidingTo(level, pos, moveTo.getCounterClockWise())) {
+        } else if (canMoveSlidingTo(level, pos, moveTo.getCounterClockWise())) {
             entity.setMoveDirection(moveTo.getCounterClockWise());
             return;
-        } else if (this.canMoveSlidingTo(level, pos, moveTo.getClockWise())) {
+        } else if (canMoveSlidingTo(level, pos, moveTo.getClockWise())) {
             entity.setMoveDirection(moveTo.getClockWise());
             return;
-        } else if (this.canMoveSlidingTo(level, pos, moveTo.getOpposite())) {
+        } else if (canMoveSlidingTo(level, pos, moveTo.getOpposite())) {
             entity.setMoveDirection(moveTo.getOpposite());
             return;
         }
         ISlidingRail.stopSlidingBlock(entity);
     }
 
-    private boolean canMoveSlidingTo(Level level, BlockPos pos, Direction moveTo) {
+    private static boolean canMoveSlidingTo(Level level, BlockPos pos, Direction moveTo) {
         if (moveTo.getAxis() == Direction.Axis.Y) return false;
         BlockPos railPos = pos.relative(moveTo);
         BlockState railState = level.getBlockState(railPos);

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -134,6 +134,14 @@ public class BlockTagLoader {
             .addTag(Tags.Blocks.GLASS_PANES)
             .addTag(BlockTags.REPLACEABLE);
 
+        provider.addTag(ModBlockTags.SLIDING_RAIL_STOP_LIKE)
+            .addTag(ModBlockTags.HEATABLE_BLOCKS)
+            .add(findResourceKey(Blocks.CAMPFIRE))
+            .add(ModBlocks.SLIDING_RAIL_STOP.getKey())
+            .add(ModBlocks.HEATER.getKey())
+            .add(ModBlocks.CORRUPTED_BEACON.getKey())
+            .add(ModBlocks.NEUTRON_IRRADIATOR.getKey());
+
         provider.addTag(ModBlockTags.END_PORTAL_UNABLE_CHANGE).add(findResourceKey(Blocks.DRAGON_EGG));
 
         provider.addTag(ModBlockTags.NEUTRONIUM_CANNOT_PASS_THROUGH)

--- a/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.entity;
 import dev.anvilcraft.lib.v2.util.Util;
 import dev.dubhe.anvilcraft.api.sliding.SlidingBlockSection;
 import dev.dubhe.anvilcraft.block.sliding.ISlidingRail;
+import dev.dubhe.anvilcraft.block.sliding.SlidingRailStopBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import dev.dubhe.anvilcraft.network.SlidingEntitySyncPacket;
@@ -101,6 +102,8 @@ public class SlidingBlockEntity extends Entity {
         BlockState belowState = this.level().getBlockState(belowPos);
         if (belowState.getBlock() instanceof ISlidingRail slidingRail && !this.level().isClientSide) {
             slidingRail.onSlidingAbove(this.level(), belowPos, belowState, this);
+        } else if (belowState.is(ModBlockTags.SLIDING_RAIL_STOP_LIKE)) {
+            SlidingRailStopBlock.changeSlidingDirection(this.level(), belowPos, this);
         }
         Direction.Axis horizontalAnother = this.moveDirection.getClockWise().getAxis();
         this.setPos(this.position().with(horizontalAnother, Math.ceil(this.position().get(horizontalAnother)) - 0.5));

--- a/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.entity;
 import dev.anvilcraft.lib.v2.util.Util;
 import dev.dubhe.anvilcraft.api.sliding.SlidingBlockSection;
 import dev.dubhe.anvilcraft.block.sliding.ISlidingRail;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import dev.dubhe.anvilcraft.network.SlidingEntitySyncPacket;
 import lombok.Getter;
@@ -121,7 +122,8 @@ public class SlidingBlockEntity extends Entity {
     }
 
     protected boolean checkCanMove() {
-        if (!(this.level().getBlockState(this.blockPosition().below()).getBlock() instanceof ISlidingRail)) return false;
+        BlockState belowStack = this.level().getBlockState(this.blockPosition().below());
+        if (!(belowStack.getBlock() instanceof ISlidingRail || belowStack.is(ModBlockTags.SLIDING_RAIL_STOP_LIKE))) return false;
         if (this.time > 1 && this.getDeltaMovement().equals(Vec3.ZERO)) return false;
         for (Vec3i pos : this.section.getWallsOnSide(this.moveDirection)) {
             BlockPos checking = this.blockPosition().offset(pos);

--- a/src/main/java/dev/dubhe/anvilcraft/event/NeighbourNotifyListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/NeighbourNotifyListener.java
@@ -1,0 +1,118 @@
+package dev.dubhe.anvilcraft.event;
+
+import dev.anvilcraft.lib.v2.util.Util;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.sliding.SlidingBlockStructureResolver;
+import dev.dubhe.anvilcraft.block.sliding.ISlidingRail;
+import dev.dubhe.anvilcraft.block.sliding.PoweredSlidingRailBlock;
+import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.piston.PistonBaseBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.BlockEvent;
+import org.apache.commons.lang3.tuple.Triple;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+@EventBusSubscriber(modid = AnvilCraft.MOD_ID)
+public class NeighbourNotifyListener {
+    // 类滑轨站方块上方的方块受到更新时检测是否有动力滑轨吸它
+    @SubscribeEvent
+    public static void onNeighbourNotify(BlockEvent.NeighborNotifyEvent event) {
+        if (!(event.getLevel() instanceof Level level)) return;
+        BlockPos pos = event.getPos();
+        if (level.isEmptyBlock(pos)) return;
+        BlockPos belowPos = pos.below();
+        if (level.isEmptyBlock(belowPos)) return;
+        BlockState state = level.getBlockState(pos);
+        if (!PistonBaseBlock.isPushable(state, level, pos, null, true, null)) return;
+        BlockState belowState = level.getBlockState(belowPos);
+        if (belowState.is(ModBlockTags.SLIDING_RAIL_STOP_LIKE)) {
+            for (Direction direction : Direction.Plane.HORIZONTAL) {
+                BlockState railState = level.getBlockState(belowPos.relative(direction));
+                if (railState.is(ModBlocks.POWERED_SLIDING_RAIL)
+                    && railState.getValue(PoweredSlidingRailBlock.FACING) == direction
+                    && railState.getValue(PoweredSlidingRailBlock.POWERED)) {
+                    if (canMoveBlockTo(level, belowPos, state, direction)) {
+                        moveBlocksAbove(level, belowPos, direction);
+                    }
+                }
+            }
+        }
+
+    }
+
+    public static boolean canMoveBlockTo(Level level, BlockPos pos, BlockState state, Direction moveTo) {
+        BlockPos railPos = pos.relative(moveTo);
+        BlockState railState = level.getBlockState(railPos);
+        return Util.castSafely(railState.getBlock(), ISlidingRail.class)
+            .map(rail -> rail.canMoveBlockToTop(level, railPos, railState, state, moveTo.getOpposite()))
+            .orElse(false);
+    }
+
+    public static void moveBlocksAbove(Level level, BlockPos pos, Direction moveToSide) {
+        SlidingBlockStructureResolver resolver = new SlidingBlockStructureResolver(level, pos.above(), moveToSide, true);
+        if (!resolver.resolve()) return;
+        List<Triple<BlockPos, BlockState, Optional<CompoundTag>>> toPushes = new ArrayList<>();
+        List<BlockPos> toPushPoses = new ArrayList<>(resolver.getToPush());
+
+        for (Iterator<BlockPos> iterator = toPushPoses.iterator(); iterator.hasNext(); ) {
+            BlockPos toPushPos = iterator.next();
+            if (toPushPos.equals(pos)) {
+                iterator.remove();
+                continue;
+            }
+            BlockState toPushState = level.getBlockState(toPushPos);
+            if (toPushState.hasProperty(BlockStateProperties.WATERLOGGED)) {
+                toPushState = toPushState.setValue(BlockStateProperties.WATERLOGGED, false);
+            }
+            Optional<CompoundTag> toPushEntityData = Optional.ofNullable(level.getBlockEntity(toPushPos))
+                .map(entity -> entity.saveCustomOnly(level.registryAccess()));
+            toPushes.add(Triple.of(toPushPos, toPushState, toPushEntityData));
+        }
+
+        List<BlockPos> toDestroys = resolver.getToDestroy();
+
+        for (int i = toDestroys.size() - 1; i >= 0; i--) {
+            BlockPos destroyingPos = toDestroys.get(i);
+            BlockState destroyingState = level.getBlockState(destroyingPos);
+            BlockEntity destroyingEntity = destroyingState.hasBlockEntity() ? level.getBlockEntity(destroyingPos) : null;
+            Block.dropResources(destroyingState, level, destroyingPos, destroyingEntity);
+            destroyingState.onDestroyedByPushReaction(level, destroyingPos, moveToSide, level.getFluidState(destroyingPos));
+        }
+
+        BlockState air = Blocks.AIR.defaultBlockState();
+
+        for (BlockPos toPushPos : toPushPoses) {
+            level.setBlock(toPushPos, air, 0b1010010);
+        }
+
+        for (var toPushEntry : toPushes) {
+            BlockPos toPushPos = toPushEntry.getLeft();
+            BlockState toPushState = toPushEntry.getMiddle();
+            toPushState.updateIndirectNeighbourShapes(level, toPushPos, 0b0000010);
+            air.updateNeighbourShapes(level, toPushPos, 0b0000010);
+            air.updateIndirectNeighbourShapes(level, toPushPos, 0b0000010);
+        }
+
+        for (var toPushEntry : toPushes) {
+            level.updateNeighborsAt(toPushEntry.getLeft(), air.getBlock());
+        }
+
+        SlidingBlockEntity.slid(level, pos.above(), moveToSide, toPushes);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
@@ -43,6 +43,7 @@ public class ModBlockTags {
     public static final TagKey<Block> ANVIL_TIER_1 = bind("anvil_tier_1");
     public static final TagKey<Block> ANVIL_TIER_2 = bind("anvil_tier_2");
     public static final TagKey<Block> ANVIL_TIER_3 = bind("anvil_tier_3");
+    public static final TagKey<Block> SLIDING_RAIL_STOP_LIKE = bind("sliding_rail_stop_like");
 
     // common tags
     public static final TagKey<Block> ORES_TUNGSTEN = bindC("ores/tungsten");


### PR DESCRIPTION
- Resolved #3346 
- fixed #3324 

添加类滑轨站tag 实现类滑轨站方块上方的方块受到更新时检测是否有动力滑轨吸它 把滑轨站被吸相关的方法一起移到了NeighbourNotifyListener中 (有更好的地方推荐的话我就把canMoveBlockTo和moveBlocksAbove挪过去)

粘连部分我肘不动  #3227 修不好 并且现在在加热的钨块上放粘液块 被动力滑轨拉时动力滑轨会被一起肘飞(被粘液块粘着一起往前走 但是钨块没动)