### PR TITLE
Fixed some problems when smart block placer is bule print mode 修复了一些蓝图模式下智能方块放置器的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/SmartBlockPlacerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/SmartBlockPlacerBlockEntity.java
@@ -1629,25 +1629,8 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
             // 放置成功后，修正方块的朝向为蓝图中的朝向
             this.applyBlueprintBlockFacing(level, targetPos, index);
             
-            // 获取蓝图中的目标状态（已经包含旋转和倒挂处理）
+            // 获取蓝图中的目标状态（已经包含旋转、倒挂和状态过滤处理）
             BlockState blueprintState = getBlueprintBlockState(index, level);
-            
-            // 侦测器不继承POWERED状态
-            if (blueprintState.is(net.minecraft.world.level.block.Blocks.OBSERVER) 
-                && blueprintState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.POWERED)) {
-                blueprintState = blueprintState.setValue(
-                    net.minecraft.world.level.block.state.properties.BlockStateProperties.POWERED, 
-                    false
-                );
-            }
-            
-            // 移除waterlogged属性
-            if (blueprintState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED)) {
-                blueprintState = blueprintState.setValue(
-                    net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED, 
-                    false
-                );
-            }
             
             // 先删除源方块
             IS_BEING_MOVED_BY_PLACER.set(true);
@@ -2148,6 +2131,27 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
             rotatedState = flipHalfProperty(rotatedState);
         }
         
+        // 忽略活塞的推出状态
+        if (rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.EXTENDED)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.EXTENDED, false);
+        }
+        
+        // 忽略侦测器的红石信号状态
+        if (rotatedState.is(net.minecraft.world.level.block.Blocks.OBSERVER)
+            && rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.POWERED)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.POWERED, false);
+        }
+        
+        // 忽略方块的含水状态
+        if (rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED, false);
+        }
+        
+        // 忽略信标的点亮状态
+        if (rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT, false);
+        }
+        
         return rotatedState;
     }
     
@@ -2184,6 +2188,22 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
         // 对于活塞方块，忽略其推出状态，默认放置未推出的活塞
         if (rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.EXTENDED)) {
             rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.EXTENDED, false);
+        }
+        
+        // 忽略侦测器的红石信号状态
+        if (rotatedState.is(net.minecraft.world.level.block.Blocks.OBSERVER)
+            && rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.POWERED)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.POWERED, false);
+        }
+        
+        // 忽略方块的含水状态
+        if (rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.WATERLOGGED, false);
+        }
+        
+        // 忽略信标的点亮状态
+        if (rotatedState.hasProperty(net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT)) {
+            rotatedState = rotatedState.setValue(net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT, false);
         }
 
         if (!worldState.equals(rotatedState)) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/StructureScannerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/StructureScannerBlockEntity.java
@@ -266,12 +266,23 @@ public class StructureScannerBlockEntity extends BaseMachineBlockEntity implemen
         net.minecraft.world.level.block.Block block = blockState.getBlock();
         
         // 使用switch表达式检查是否实现了多方块方块相关接口
-        return switch (block) {
-            case dev.dubhe.anvilcraft.block.multipart.MultiPartBlockEntity<?, ?> ignored1 -> true;
-            case dev.dubhe.anvilcraft.block.multipart.AbstractMultiPartBlock<?> ignored2 -> true;
-            case dev.dubhe.anvilcraft.api.IHasMultiBlock ignored3 -> true;
-            default -> false;
-        };
+        if (switch (block) {
+                case dev.dubhe.anvilcraft.block.multipart.MultiPartBlockEntity<?, ?> ignored1 -> true;
+                case dev.dubhe.anvilcraft.block.multipart.AbstractMultiPartBlock<?> ignored2 -> true;
+                case dev.dubhe.anvilcraft.api.IHasMultiBlock ignored3 -> true;
+                default -> false;
+            }) {
+            return true;
+        }
+        
+        // 检查原版多方块方块
+        // 床（BED）：由两个方块组成
+        if (block instanceof net.minecraft.world.level.block.BedBlock) {
+            return true;
+        }
+        
+        // 门（DOOR）：由上下两个方块组成
+        return block instanceof net.minecraft.world.level.block.DoorBlock;
     }
 
     public StructureScannerBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
@@ -1186,18 +1186,13 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
         if (this.isBlueprintMode) {
             var loadedStructure = blockEntity.getLoadedStructure();
             if (loadedStructure != null && !loadedStructure.isEmpty()) {
-                // 获取放置器朝向
-                Direction placerFacing = Direction.NORTH;  // 默认
-                if (this.minecraft.level != null) {
-                    BlockState placerState = this.minecraft.level.getBlockState(blockEntity.getBlockPos());
-                    if (placerState.hasProperty(HorizontalDirectionalBlock.FACING)) {
-                        placerFacing = placerState.getValue(HorizontalDirectionalBlock.FACING);
-                    }
-                }
+                // 预览中放置器固定朝北，所以使用NORTH作为forward参数
+                // 这样旋转计算才能与预览中的朝向一致
+                Direction previewFacing = Direction.NORTH;
                 
                 // 对结构方块应用旋转和倒挂翻转（与服务端放置逻辑保持一致）
                 List<dev.dubhe.anvilcraft.util.StructureLoadUtil.BlockPosition> rotatedBlocks = 
-                    this.rotateStructureForPreview(loadedStructure, placerFacing, upsideDown);
+                    this.rotateStructureForPreview(loadedStructure, previewFacing, upsideDown);
                 
                 // 渲染旋转后的结构方块
                 for (dev.dubhe.anvilcraft.util.StructureLoadUtil.BlockPosition blockPos : rotatedBlocks) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/StructureDiskPreviewSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/StructureDiskPreviewSupport.java
@@ -188,10 +188,34 @@ public class StructureDiskPreviewSupport {
         
         LevelLike levelLike = new LevelLike(minecraft.level);
         
-        // 设置方块
+        // 计算旋转（基于scannerFacing）
+        // 磁盘预览固定朝北显示，需要根据scannerFacing旋转方块朝向
+        int scannerFacingValue = data.scannerFacing;
+        
+        // 根据Scanner朝向计算旋转步数
+        int rotationSteps = switch (scannerFacingValue) {
+            case 2 -> 0;  // Scanner北 → 0度
+            case 3 -> 2;  // Scanner南 → 180度
+            case 4 -> 1;  // Scanner西 → 90度
+            case 5 -> 3;  // Scanner东 → 270度
+            default -> 0;
+        };
+        
+        // 转换为Minecraft原生Rotation
+        net.minecraft.world.level.block.Rotation rotation = switch (rotationSteps) {
+            case 1 -> net.minecraft.world.level.block.Rotation.CLOCKWISE_90;
+            case 2 -> net.minecraft.world.level.block.Rotation.CLOCKWISE_180;
+            case 3 -> net.minecraft.world.level.block.Rotation.COUNTERCLOCKWISE_90;
+            default -> net.minecraft.world.level.block.Rotation.NONE;
+        };
+        
+        // 设置旋转后的方块
         for (StructureLoadUtil.BlockPosition blockPos : data.blocks) {
+            // 旋转方块朝向
+            net.minecraft.world.level.block.state.BlockState rotatedState = blockPos.state().rotate(rotation);
+            
             BlockPos pos = new BlockPos(blockPos.x(), blockPos.y(), blockPos.z());
-            levelLike.setBlockState(pos, blockPos.state());
+            levelLike.setBlockState(pos, rotatedState);
         }
         
         return levelLike;

--- a/src/main/java/dev/dubhe/anvilcraft/util/StructureLoadUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StructureLoadUtil.java
@@ -321,11 +321,22 @@ public class StructureLoadUtil {
         Block block = state.getBlock();
             
         // 使用switch表达式检查是否实现了多方块方块相关接口
-        return switch (block) {
-            case MultiPartBlockEntity<?, ?> ignored1 -> true;
-            case AbstractMultiPartBlock<?> ignored2 -> true;
-            case IHasMultiBlock ignored3 -> true;
-            default -> false;
-        };
+        if (switch (block) {
+                case MultiPartBlockEntity<?, ?> ignored1 -> true;
+                case AbstractMultiPartBlock<?> ignored2 -> true;
+                case IHasMultiBlock ignored3 -> true;
+                default -> false;
+            }) {
+            return true;
+        }
+        
+        // 检查原版多方块方块
+        // 床（BED）：由两个方块组成
+        if (block instanceof net.minecraft.world.level.block.BedBlock) {
+            return true;
+        }
+        
+        // 门（DOOR）：由上下两个方块组成
+        return block instanceof net.minecraft.world.level.block.DoorBlock;
     }
 }


### PR DESCRIPTION
- 忽略活塞方块的推出状态EXTENDED
- 忽略侦测器的红石信号POWERED属性
- 忽略方块的含水状态WATERLOGGED属性
- 忽略信标的点亮状态LIT属性
- 移除旧代码中对部分状态的单独处理逻辑
- 蓝图状态获取时纳入状态过滤处理以统一状态清理

修正放置器预览朝向为固定朝北

- 放置器预览中固定使用NORTH方向作为前向参数
- 预览结构旋转计算保持和服务端放置逻辑一致

支持结构磁盘预览的朝向自动旋转

- 根据扫描器朝向计算旋转步数和旋转类型
- 对结构磁盘中的方块状态进行旋转应用
- 使磁盘预览中的方块朝向符合扫描器视角