### PR TITLE
Enhance block state verification and add utility methods

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
@@ -1,0 +1,44 @@
+package dev.dubhe.anvilcraft.api.event;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.level.BlockEvent;
+
+public class HammerChangeBlockEvent extends BlockEvent {
+    @Getter
+    private final BlockState oldState;
+    @Getter
+    @Setter
+    private boolean isVerified;
+
+    public HammerChangeBlockEvent(
+        LevelAccessor level,
+        Player player,
+        BlockPos pos,
+        BlockState state,
+        BlockState oldState,
+        boolean isVerified
+    ) {
+        super(level, pos, state);
+        this.oldState = oldState;
+        this.isVerified = isVerified;
+    }
+
+    public static boolean invoke(
+        LevelAccessor level,
+        Player player,
+        BlockPos pos,
+        BlockState state,
+        BlockState oldState,
+        boolean isVerified
+    ) {
+        HammerChangeBlockEvent event = new HammerChangeBlockEvent(level, player, pos, state, oldState, isVerified);
+        NeoForge.EVENT_BUS.post(event);
+        return event.isVerified();
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
@@ -11,6 +11,8 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 
 public class HammerChangeBlockEvent extends BlockEvent {
     @Getter
+    private final Player player;
+    @Getter
     private final BlockState oldState;
     @Getter
     @Setter
@@ -25,6 +27,7 @@ public class HammerChangeBlockEvent extends BlockEvent {
         boolean isVerified
     ) {
         super(level, pos, state);
+        this.player = player;
         this.oldState = oldState;
         this.isVerified = isVerified;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -4,10 +4,14 @@ import dev.anvilcraft.lib.v2.codec.StreamCodecUtil;
 import dev.anvilcraft.lib.v2.network.packet.IPacket;
 import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.event.HammerChangeBlockEvent;
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
 import dev.dubhe.anvilcraft.util.StateUtil;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -33,7 +37,20 @@ public record HammerChangeBlockPacket(BlockPos pos, BlockState state) implements
         Level level = player.level();
         if (!level.isLoaded(this.pos)) return;
         BlockState blockState = level.getBlockState(this.pos);
-        if (!StateUtil.verifyPossibleStatesForProperty(blockState, this.state)) {
+        boolean stateVerified = StateUtil.verifyPossibleStatesForProperty(blockState, this.state);
+        boolean hasHammer = player.getMainHandItem().getItem() instanceof AnvilHammerItem
+                            || player.getOffhandItem().getItem() instanceof AnvilHammerItem;
+        AttributeInstance attribute = player.getAttribute(Attributes.BLOCK_INTERACTION_RANGE);
+        double value = attribute == null ? 5.0 : attribute.getValue();
+        boolean distanceVerified = this.pos.getCenter().distanceToSqr(player.getEyePosition()) <= value * value + 2;
+        if (!HammerChangeBlockEvent.invoke(
+            level,
+            player,
+            this.pos,
+            this.state,
+            blockState,
+            hasHammer && stateVerified && distanceVerified
+        )) {
             return;
         }
         level.setBlock(this.pos, this.state, Block.UPDATE_ALL_IMMEDIATE);

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -4,6 +4,7 @@ import dev.anvilcraft.lib.v2.codec.StreamCodecUtil;
 import dev.anvilcraft.lib.v2.network.packet.IPacket;
 import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.util.StateUtil;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.codec.StreamCodec;
@@ -31,6 +32,10 @@ public record HammerChangeBlockPacket(BlockPos pos, BlockState state) implements
     public void handleOnServer(Player player) {
         Level level = player.level();
         if (!level.isLoaded(this.pos)) return;
+        BlockState blockState = level.getBlockState(this.pos);
+        if (!StateUtil.verifyPossibleStatesForProperty(blockState, this.state)) {
+            return;
+        }
         level.setBlock(this.pos, this.state, Block.UPDATE_ALL_IMMEDIATE);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -49,7 +49,11 @@ public record HammerChangeBlockPacket(BlockPos pos, BlockState state) implements
             this.pos,
             this.state,
             blockState,
-            hasHammer && stateVerified && distanceVerified
+            hasHammer
+            && stateVerified
+            && distanceVerified
+            && level.mayInteract(player, this.pos)
+            && player.getAbilities().mayBuild
         )) {
             return;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
@@ -1,5 +1,8 @@
 package dev.dubhe.anvilcraft.util;
 
+import dev.anvilcraft.lib.v2.util.Util;
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateHolder;
 import net.minecraft.world.level.block.state.properties.Property;
 
@@ -8,18 +11,41 @@ import java.util.Comparator;
 import java.util.List;
 
 public class StateUtil {
-    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>>
-    List<T> findPossibleStatesForProperty(T initialState, Property<E> property) {
+    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> List<T> findPossibleStatesForProperty(
+        T initialState,
+        Property<E> property
+    ) {
         List<T> result = new ArrayList<>();
         T currentIterating = initialState;
         while (!result.contains(currentIterating)) {
             result.add(currentIterating);
             currentIterating = currentIterating.cycle(property);
         }
-        result.sort(
-            Comparator.<T, E>comparing(it -> it.getValue(property))
-                .reversed()
-        );
+        result.sort(Comparator.<T, E>comparing(it -> it.getValue(property)).reversed());
         return result;
+    }
+
+    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsState(T state1, T state2) {
+        for (Property<?> property : state1.getProperties()) {
+            E value1 = Util.cast(state1.getValue(property));
+            E value2 = Util.cast(state2.getValue(property));
+            // noinspection ConstantValue
+            if (value1 == null || value2 == null || value1.compareTo(value2) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean verifyPossibleStatesForProperty(BlockState initialState, BlockState targetState) {
+        Property<?> property = AnvilHammerItem.findModifyableProperty(initialState);
+        if (property == null || !initialState.is(targetState.getBlock())) return false;
+        List<BlockState> stateList = StateUtil.findPossibleStatesForProperty(initialState, property);
+        for (BlockState state : stateList) {
+            if (StateUtil.equalsState(state, targetState)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
@@ -1,6 +1,5 @@
 package dev.dubhe.anvilcraft.util;
 
-import dev.anvilcraft.lib.v2.util.Util;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateHolder;
@@ -32,14 +31,20 @@ public class StateUtil {
         properties.addAll(state1.getProperties());
         properties.addAll(state2.getProperties());
         for (Property<?> property : properties) {
-            E value1 = Util.cast(state1.getValue(property));
-            E value2 = Util.cast(state2.getValue(property));
-            // noinspection ConstantValue
-            if (value1 == null || value2 == null || value1.compareTo(value2) != 0) {
-                return false;
-            }
+            if (!StateUtil.equalsProperty(property, state1, state2)) return false;
         }
         return true;
+    }
+
+    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsProperty(
+        Property<E> property,
+        T state1,
+        T state2
+    ) {
+        if (state1.hasProperty(property) != state2.hasProperty(property)) return false;
+        E value1 = state1.getValue(property);
+        E value2 = state2.getValue(property);
+        return value1.compareTo(value2) == 0;
     }
 
     public static boolean verifyPossibleStatesForProperty(BlockState initialState, BlockState targetState) {

--- a/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
@@ -8,7 +8,9 @@ import net.minecraft.world.level.block.state.properties.Property;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class StateUtil {
     public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> List<T> findPossibleStatesForProperty(
@@ -26,7 +28,10 @@ public class StateUtil {
     }
 
     public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsState(T state1, T state2) {
-        for (Property<?> property : state1.getProperties()) {
+        Set<Property<?>> properties = new HashSet<>();
+        properties.addAll(state1.getProperties());
+        properties.addAll(state2.getProperties());
+        for (Property<?> property : properties) {
             E value1 = Util.cast(state1.getValue(property));
             E value2 = Util.cast(state2.getValue(property));
             // noinspection ConstantValue


### PR DESCRIPTION
This pull request introduces a server-side validation for block state changes triggered by the hammer tool and adds utility methods to support robust state comparison and validation. The main goal is to prevent invalid or unintended block state changes by ensuring only legitimate state transitions are allowed.

**Server-side validation and utility enhancements:**

*Hammer block state change validation:*
- The `HammerChangeBlockPacket` now checks, before applying a block state change, that the requested new state is a valid possible state for the block and property being modified. This prevents clients from forcing illegal or unintended state transitions.

*State utility methods:*
- Added a `verifyPossibleStatesForProperty` method in `StateUtil` to determine if a target `BlockState` is a valid state transition from the initial state for the property being modified, leveraging the hammer tool logic.
- Implemented an `equalsState` method in `StateUtil` for deep comparison of two block states' properties, ensuring accurate validation.

*Refactoring and imports:*
- Updated imports in both `HammerChangeBlockPacket.java` and `StateUtil.java` to support the new utility methods and maintain code clarity. [[1]](diffhunk://#diff-139fcfa4d6461e4dabcd0632ca94fd5b80b9acac5329d671086d40bb37fc0033R7) [[2]](diffhunk://#diff-6adb4d37a54b2aa285725a8b125b7b8459d2b9ba257e771dbb94a0535250ce4cR3-R5)