### PR TITLE
Enhance block state verification and add utility methods

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
@@ -1,0 +1,44 @@
+package dev.dubhe.anvilcraft.api.event;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.level.BlockEvent;
+
+public class HammerChangeBlockEvent extends BlockEvent {
+    @Getter
+    private final BlockState oldState;
+    @Getter
+    @Setter
+    private boolean isVerified;
+
+    public HammerChangeBlockEvent(
+        LevelAccessor level,
+        Player player,
+        BlockPos pos,
+        BlockState state,
+        BlockState oldState,
+        boolean isVerified
+    ) {
+        super(level, pos, state);
+        this.oldState = oldState;
+        this.isVerified = isVerified;
+    }
+
+    public static boolean invoke(
+        LevelAccessor level,
+        Player player,
+        BlockPos pos,
+        BlockState state,
+        BlockState oldState,
+        boolean isVerified
+    ) {
+        HammerChangeBlockEvent event = new HammerChangeBlockEvent(level, player, pos, state, oldState, isVerified);
+        NeoForge.EVENT_BUS.post(event);
+        return event.isVerified();
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/HammerChangeBlockEvent.java
@@ -11,6 +11,8 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 
 public class HammerChangeBlockEvent extends BlockEvent {
     @Getter
+    private final Player player;
+    @Getter
     private final BlockState oldState;
     @Getter
     @Setter
@@ -25,6 +27,7 @@ public class HammerChangeBlockEvent extends BlockEvent {
         boolean isVerified
     ) {
         super(level, pos, state);
+        this.player = player;
         this.oldState = oldState;
         this.isVerified = isVerified;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.network;
 
 import dev.anvilcraft.lib.util.CodecUtil;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.util.StateUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -34,9 +35,12 @@ public record HammerChangeBlockPacket(
     public  void handle(IPayloadContext context) {
         context.enqueueWork(() -> {
             Level level = context.player().level();
-            if (level.isLoaded(pos)) {
-                level.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
+            if (!level.isLoaded(this.pos)) return;
+            BlockState blockState = level.getBlockState(this.pos);
+            if (!StateUtil.verifyPossibleStatesForProperty(blockState, this.state)) {
+                return;
             }
+            level.setBlock(this.pos, this.state, Block.UPDATE_ALL_IMMEDIATE);
         });
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -2,11 +2,16 @@ package dev.dubhe.anvilcraft.network;
 
 import dev.anvilcraft.lib.util.CodecUtil;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.event.HammerChangeBlockEvent;
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
 import dev.dubhe.anvilcraft.util.StateUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -32,12 +37,26 @@ public record HammerChangeBlockPacket(
         return TYPE;
     }
 
-    public  void handle(IPayloadContext context) {
+    public void handle(IPayloadContext context) {
         context.enqueueWork(() -> {
-            Level level = context.player().level();
+            Player player = context.player();
+            Level level = player.level();
             if (!level.isLoaded(this.pos)) return;
             BlockState blockState = level.getBlockState(this.pos);
-            if (!StateUtil.verifyPossibleStatesForProperty(blockState, this.state)) {
+            boolean stateVerified = StateUtil.verifyPossibleStatesForProperty(blockState, this.state);
+            boolean hasHammer = player.getMainHandItem().getItem() instanceof AnvilHammerItem
+                                || player.getOffhandItem().getItem() instanceof AnvilHammerItem;
+            AttributeInstance attribute = player.getAttribute(Attributes.BLOCK_INTERACTION_RANGE);
+            double value = attribute == null ? 5.0 : attribute.getValue();
+            boolean distanceVerified = this.pos.getCenter().distanceToSqr(player.getEyePosition()) <= value * value + 2;
+            if (!HammerChangeBlockEvent.invoke(
+                level,
+                player,
+                this.pos,
+                this.state,
+                blockState,
+                hasHammer && stateVerified && distanceVerified
+            )) {
                 return;
             }
             level.setBlock(this.pos, this.state, Block.UPDATE_ALL_IMMEDIATE);

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -55,7 +55,11 @@ public record HammerChangeBlockPacket(
                 this.pos,
                 this.state,
                 blockState,
-                hasHammer && stateVerified && distanceVerified
+                hasHammer
+                && stateVerified
+                && distanceVerified
+                && level.mayInteract(player, this.pos)
+                && player.getAbilities().mayBuild
             )) {
                 return;
             }

--- a/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
@@ -7,7 +7,9 @@ import net.minecraft.world.level.block.state.properties.Property;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class StateUtil {
     public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> List<T> findPossibleStatesForProperty(
@@ -26,7 +28,10 @@ public class StateUtil {
 
     @SuppressWarnings("unchecked")
     public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsState(T state1, T state2) {
-        for (Property<?> property : state1.getProperties()) {
+        Set<Property<?>> properties = new HashSet<>();
+        properties.addAll(state1.getProperties());
+        properties.addAll(state2.getProperties());
+        for (Property<?> property : properties) {
             E value1 = (E) state1.getValue(property);
             E value2 = (E) state2.getValue(property);
             // noinspection ConstantValue

--- a/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
@@ -26,20 +26,25 @@ public class StateUtil {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
-    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsState(T state1, T state2) {
+    public static <O, T extends StateHolder<O, T>> boolean equalsState(T state1, T state2) {
         Set<Property<?>> properties = new HashSet<>();
         properties.addAll(state1.getProperties());
         properties.addAll(state2.getProperties());
         for (Property<?> property : properties) {
-            E value1 = (E) state1.getValue(property);
-            E value2 = (E) state2.getValue(property);
-            // noinspection ConstantValue
-            if (value1 == null || value2 == null || value1.compareTo(value2) != 0) {
-                return false;
-            }
+            if (!StateUtil.equalsProperty(property, state1, state2)) return false;
         }
         return true;
+    }
+
+    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsProperty(
+        Property<E> property,
+        T state1,
+        T state2
+    ) {
+        if (state1.hasProperty(property) != state2.hasProperty(property)) return false;
+        E value1 = state1.getValue(property);
+        E value2 = state2.getValue(property);
+        return value1.compareTo(value2) == 0;
     }
 
     public static boolean verifyPossibleStatesForProperty(BlockState initialState, BlockState targetState) {

--- a/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StateUtil.java
@@ -1,5 +1,7 @@
 package dev.dubhe.anvilcraft.util;
 
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateHolder;
 import net.minecraft.world.level.block.state.properties.Property;
 
@@ -8,18 +10,42 @@ import java.util.Comparator;
 import java.util.List;
 
 public class StateUtil {
-    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>>
-    List<T> findPossibleStatesForProperty(T initialState, Property<E> property) {
+    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> List<T> findPossibleStatesForProperty(
+        T initialState,
+        Property<E> property
+    ) {
         List<T> result = new ArrayList<>();
         T currentIterating = initialState;
         while (!result.contains(currentIterating)) {
             result.add(currentIterating);
             currentIterating = currentIterating.cycle(property);
         }
-        result.sort(
-            Comparator.<T, E>comparing(it -> it.getValue(property))
-                .reversed()
-        );
+        result.sort(Comparator.<T, E>comparing(it -> it.getValue(property)).reversed());
         return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <O, T extends StateHolder<O, T>, E extends Comparable<E>> boolean equalsState(T state1, T state2) {
+        for (Property<?> property : state1.getProperties()) {
+            E value1 = (E) state1.getValue(property);
+            E value2 = (E) state2.getValue(property);
+            // noinspection ConstantValue
+            if (value1 == null || value2 == null || value1.compareTo(value2) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean verifyPossibleStatesForProperty(BlockState initialState, BlockState targetState) {
+        Property<?> property = AnvilHammerItem.findModifyableProperty(initialState);
+        if (property == null || !initialState.is(targetState.getBlock())) return false;
+        List<BlockState> stateList = StateUtil.findPossibleStatesForProperty(initialState, property);
+        for (BlockState state : stateList) {
+            if (StateUtil.equalsState(state, targetState)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
This pull request introduces important validation to the block state change logic when using the hammer tool, ensuring that only valid state transitions are allowed. It does this by adding new utility methods for verifying possible block states and updating the network packet handler to use these checks.

### Block state validation improvements

* Added `StateUtil.verifyPossibleStatesForProperty` method to ensure that a requested block state change is valid for the given block and property. This prevents invalid or out-of-range state changes.
* Updated `HammerChangeBlockPacket.handle` to use the new validation method before applying a block state change, improving game stability and preventing illegal state transitions.
* Added `StateUtil.equalsState` helper to compare two block states for property equality, supporting the new validation logic.

### Utility and code organization

* Imported `StateUtil` in `HammerChangeBlockPacket` to access the new validation utilities.
* Added necessary imports and refactored `findPossibleStatesForProperty` for clarity and style in `StateUtil.java`. [[1]](diffhunk://#diff-6adb4d37a54b2aa285725a8b125b7b8459d2b9ba257e771dbb94a0535250ce4cR3-R4) [[2]](diffhunk://#diff-6adb4d37a54b2aa285725a8b125b7b8459d2b9ba257e771dbb94a0535250ce4cL11-R50)