### PR TITLE
Unify processing and render all tooltips on the screens of the Smart Block Placer and Structure Scanner 统一处理和渲染智能方块放置器和结构扫描仪屏幕中的所有tooltip

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
@@ -514,99 +514,6 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
 
         PacketDistributor.sendToServer(new SmartBlockPlacerActionPacket("position", positionIndex, this.currentViewLayer + ":" + positionIndex + ":" + newState));
     }
-    
-    /**
-     * 渲染Disk槽位的tooltip
-     */
-    private void renderDiskSlotTooltip(GuiGraphics guiGraphics, int mouseX, int mouseY) {
-        // Disk槽位的位置（与Menu中一致）
-        int diskSlotX = this.leftPos + 8;
-        int diskSlotY = this.topPos + 119;
-        int diskSlotWidth = 16;
-        int diskSlotHeight = 16;
-        
-        // 检查鼠标是否在Disk槽位上
-        if (mouseX >= diskSlotX && mouseX < diskSlotX + diskSlotWidth
-            && mouseY >= diskSlotY && mouseY < diskSlotY + diskSlotHeight) {
-            // 渲染tooltip，确保在所有元素上方
-            guiGraphics.pose().pushPose();
-            guiGraphics.pose().translate(0, 0, 1500);
-            guiGraphics.renderTooltip(
-                this.font,
-                List.of(Component.translatable("screen.anvilcraft.smart_block_placer.disk_slot")),
-                java.util.Optional.empty(),
-                mouseX,
-                mouseY
-            );
-            guiGraphics.pose().popPose();
-        }
-    }
-    
-    /**
-     * 渲染书槽位的tooltip
-     */
-    private void renderBookSlotTooltip(GuiGraphics guiGraphics, int mouseX, int mouseY) {
-        // 书槽位的位置（与Menu中一致）
-        int bookSlotX = this.leftPos + 8;
-        int bookSlotY = this.topPos + 101;
-        int bookSlotWidth = 16;
-        int bookSlotHeight = 16;
-        
-        // 检查鼠标是否在书槽位上
-        if (mouseX >= bookSlotX && mouseX < bookSlotX + bookSlotWidth
-            && mouseY >= bookSlotY && mouseY < bookSlotY + bookSlotHeight) {
-            // 渲染tooltip，确保在所有元素上方
-            guiGraphics.pose().pushPose();
-            guiGraphics.pose().translate(0, 0, 1500);
-            guiGraphics.renderTooltip(
-                this.font,
-                List.of(Component.translatable("screen.anvilcraft.smart_block_placer.book_slot")),
-                java.util.Optional.empty(),
-                mouseX,
-                mouseY
-            );
-            guiGraphics.pose().popPose();
-        }
-    }
-    
-    /**
-     * 渲染缺失方块图标的tooltip
-     */
-    private void renderMissingBlockTooltip(GuiGraphics guiGraphics, int mouseX, int mouseY) {
-        var blockEntity = this.menu.getBlockEntity();
-        if (blockEntity == null) {
-            return;
-        }
-        
-        ItemStack missingItem = blockEntity.getMissingBlockItem();
-        if (missingItem.isEmpty()) {
-            return;
-        }
-        
-        // 计算缺失方块图标的位置（与渲染位置一致）
-        int textX = this.structureInfoBaseX + 4;  // 相对于基础位置偏移
-        int textY = this.structureInfoBaseY;
-        Component missingText = Component.translatable("screen.anvilcraft.smart_block_placer.missing.block");
-        int iconX = textX + this.font.width(missingText) + 4;
-        int iconY = textY + 18;  // 与渲染位置一致
-        int iconWidth = 16;
-        int iconHeight = 16;
-        
-        // 检查鼠标是否在图标上
-        if (mouseX >= iconX && mouseX < iconX + iconWidth
-            && mouseY >= iconY && mouseY < iconY + iconHeight) {
-            // 渲染物品的tooltip
-            guiGraphics.pose().pushPose();
-            guiGraphics.pose().translate(0, 0, 1500);
-            guiGraphics.renderTooltip(
-                this.font,
-                missingItem,
-                mouseX,
-                mouseY
-            );
-            guiGraphics.pose().popPose();
-        }
-    }
 
     @Override
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
@@ -802,7 +709,11 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
 
         // 渲染3D预览
         this.renderPreview(guiGraphics);
-
+        
+        // 最后统一渲染所有tooltip，确保在所有元素上方
+        // 收集所有需要渲染的tooltip
+        List<TooltipRenderInfo> tooltipsToRender = new ArrayList<>();
+        
         // 检查鼠标是否在Disk槽位上
         int diskSlotX = this.leftPos + 8;
         int diskSlotY = this.topPos + 119;
@@ -811,21 +722,84 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
         boolean isMouseOnDiskSlot = mouseX >= diskSlotX && mouseX < diskSlotX + diskSlotWidth
             && mouseY >= diskSlotY && mouseY < diskSlotY + diskSlotHeight;
         
-        // 如果鼠标在Disk槽位上，不渲染默认tooltip
+        // 如果鼠标不在Disk槽位上，添加默认tooltip
         if (!isMouseOnDiskSlot) {
-            this.renderTooltip(guiGraphics, mouseX, mouseY);
+            // 获取鼠标悬停位置的slot的tooltip
+            if (this.hoveredSlot != null && this.hoveredSlot.hasItem()) {
+                tooltipsToRender.add(new TooltipRenderInfo(
+                    this.font,
+                    this.getTooltipFromContainerItem(this.hoveredSlot.getItem()),
+                    mouseX,
+                    mouseY
+                ));
+            }
         }
         
-        // 渲染Disk槽位的tooltip
-        this.renderDiskSlotTooltip(guiGraphics, mouseX, mouseY);
+        // 检查Disk槽位tooltip
+        if (isMouseOnDiskSlot) {
+            tooltipsToRender.add(new TooltipRenderInfo(
+                this.font,
+                List.of(Component.translatable("screen.anvilcraft.smart_block_placer.disk_slot")),
+                mouseX,
+                mouseY
+            ));
+        }
         
-        // 渲染书槽位的tooltip（仅在蓝图模式下）
+        // 检查书槽位tooltip（仅在蓝图模式下）
         if (this.isBlueprintMode) {
-            this.renderBookSlotTooltip(guiGraphics, mouseX, mouseY);
+            int bookSlotX = this.leftPos + 8;
+            int bookSlotY = this.topPos + 101;
+            int bookSlotWidth = 16;
+            int bookSlotHeight = 16;
+            
+            if (mouseX >= bookSlotX && mouseX < bookSlotX + bookSlotWidth
+                && mouseY >= bookSlotY && mouseY < bookSlotY + bookSlotHeight) {
+                tooltipsToRender.add(new TooltipRenderInfo(
+                    this.font,
+                    List.of(Component.translatable("screen.anvilcraft.smart_block_placer.book_slot")),
+                    mouseX,
+                    mouseY
+                ));
+            }
         }
         
-        // 渲染缺失方块图标的tooltip
-        this.renderMissingBlockTooltip(guiGraphics, mouseX, mouseY);
+        // 检查缺失方块图标的tooltip
+        if (blockEntity != null) {
+            ItemStack missingItem = blockEntity.getMissingBlockItem();
+            if (!missingItem.isEmpty()) {
+                int textX = this.structureInfoBaseX + 4;
+                int textY = this.structureInfoBaseY;
+                Component missingText = Component.translatable("screen.anvilcraft.smart_block_placer.missing.block");
+                int iconX = textX + this.font.width(missingText) + 4;
+                int iconY = textY + 18;
+                int iconWidth = 16;
+                int iconHeight = 16;
+                
+                if (mouseX >= iconX && mouseX < iconX + iconWidth
+                    && mouseY >= iconY && mouseY < iconY + iconHeight) {
+                    tooltipsToRender.add(new TooltipRenderInfo(
+                        this.font,
+                        this.getTooltipFromContainerItem(missingItem),
+                        mouseX,
+                        mouseY
+                    ));
+                }
+            }
+        }
+        
+        // 统一渲染所有tooltip，使用高Z轴确保在最上层
+        for (TooltipRenderInfo tooltipInfo : tooltipsToRender) {
+            guiGraphics.pose().pushPose();
+            guiGraphics.pose().translate(0, 0, 2000);  // 使用更高的Z轴层级
+            guiGraphics.renderTooltip(
+                tooltipInfo.font,
+                tooltipInfo.tooltip,
+                java.util.Optional.empty(),
+                tooltipInfo.x,
+                tooltipInfo.y
+            );
+            guiGraphics.pose().popPose();
+        }
     }
     
     /**
@@ -1351,5 +1325,15 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
         
         return rotatedBlocks;
     }
+    
+    /**
+     * Tooltip渲染信息记录类
+     */
+    private record TooltipRenderInfo(
+        net.minecraft.client.gui.Font font,
+        java.util.List<Component> tooltip,
+        int x,
+        int y
+    ) {}
 
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
@@ -35,6 +35,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class StructureScannerScreen extends AbstractContainerScreen<StructureScannerMenu> {
@@ -296,8 +297,8 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
         // 渲染3D预览
         this.renderPreview(guiGraphics);
         
-        // 渲染信息栏
-        this.renderInfoPanel(guiGraphics, mouseX, mouseY);
+        // 渲染信息栏（不渲染tooltip）
+        this.renderInfoPanelWithoutTooltip(guiGraphics);
         
         // 渲染STRUCTURE_TOOL_LOCKED贴图（一直显示）
         guiGraphics.blit(STRUCTURE_TOOL_LOCKED_TEXTURE, this.leftPos + 6, this.topPos + 18, 0, 0, 126, 26, 126, 26);
@@ -305,7 +306,38 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
         // 渲染文本输入框（参考铁砧的实现）
         this.nameInput.render(guiGraphics, mouseX, mouseY, partialTick);
         
-        this.renderTooltip(guiGraphics, mouseX, mouseY);
+        // 最后统一渲染所有tooltip，确保在所有元素上方
+        List<TooltipRenderInfo> tooltipsToRender = new ArrayList<>();
+        
+        // 收集默认slot tooltip
+        if (this.hoveredSlot != null && this.hoveredSlot.hasItem()) {
+            tooltipsToRender.add(new TooltipRenderInfo(
+                this.font,
+                this.getTooltipFromContainerItem(this.hoveredSlot.getItem()),
+                mouseX,
+                mouseY
+            ));
+        }
+        
+        // 收集信息栏叹号tooltip
+        TooltipRenderInfo infoPanelTooltip = this.collectInfoPanelTooltip(mouseX, mouseY);
+        if (infoPanelTooltip != null) {
+            tooltipsToRender.add(infoPanelTooltip);
+        }
+        
+        // 统一渲染所有tooltip，使用高Z轴确保在最上层
+        for (TooltipRenderInfo tooltipInfo : tooltipsToRender) {
+            guiGraphics.pose().pushPose();
+            guiGraphics.pose().translate(0, 0, 2000);  // 使用更高的Z轴层级
+            guiGraphics.renderTooltip(
+                tooltipInfo.font,
+                tooltipInfo.tooltip,
+                java.util.Optional.empty(),
+                tooltipInfo.x,
+                tooltipInfo.y
+            );
+            guiGraphics.pose().popPose();
+        }
     }
     
     @Override
@@ -395,23 +427,23 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
     }
     
     /**
-     * 渲染信息栏
+     * 渲染信息栏（不渲染tooltip）
      */
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
-    private void renderInfoPanel(GuiGraphics guiGraphics, int mouseX, int mouseY) {
+    private void renderInfoPanelWithoutTooltip(GuiGraphics guiGraphics) {
         // 使用缓存数据
         if (this.cachedBlockEntity == null) return;
-            
+                
         // 检查是否有磁盘
         if (!this.cachedHasDisk) return;
-            
+                
         // 获取信息状态
         StructureScannerBlockEntity.InfoStatus status = this.cachedInfoStatus;
-            
+                
         // 信息栏位置（在磁盘槽位上方）
         int infoX = this.leftPos + 9;
         int infoY = this.topPos + 52;
-            
+                
         // 渲染标题（使用缩放）
         com.mojang.blaze3d.vertex.PoseStack poseStack = guiGraphics.pose();
         poseStack.pushPose();
@@ -421,16 +453,16 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
             net.minecraft.network.chat.Component.translatable("screen.anvilcraft.structure_scanner.info_title"),
             0, 0, 0xFFFFFF, false);
         poseStack.popPose();
-            
+                
         // 状态信息位置（标题下方）
         int statusY = infoY + 10;
-            
+                
         // 根据状态渲染
         switch (status) {
             case READY -> {
-                // 只在扫描完成后显示"结构扫描就绪"
+                // 只在扫描完成后显示“结构扫描就绪”
                 if (this.cachedIsScanComplete) {
-                    // 显示"结构扫描就绪"（使用缩放）
+                    // 显示“结构扫描就绪”（使用缩放）
                     poseStack.pushPose();
                     poseStack.translate(infoX, statusY, 0);
                     poseStack.scale(0.5f, 0.5f, 1.0f);
@@ -445,10 +477,10 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
                 boolean isWarning = status == StructureScannerBlockEntity.InfoStatus.LARGE_STRUCTURE 
                     || status == StructureScannerBlockEntity.InfoStatus.MULTIBLOCK_BLOCKS;
                 int iconColor = isWarning ? 0xFFFF55 : 0xFF5555;
-                                        
+                                            
                 // 叹号图标单独设置位置和大小
                 float iconScale = 1.5f;  // 叹号图标缩放比例
-                                        
+                                            
                 // 绘制叹号（使用缩放）
                 poseStack.pushPose();
                 poseStack.translate(infoX, statusY, 0);
@@ -456,32 +488,68 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
                 int textOffsetX = 18;  // 叹号文本的X偏移量
                 guiGraphics.drawString(this.font, "!", textOffsetX, 0, iconColor, false);
                 poseStack.popPose();
-                                        
-                // 检查鼠标是否在叹号上（考虑缩放后的实际尺寸和偏移量）
-                int scaledWidth = (int) (8 * iconScale);
-                int scaledHeight = (int) (10 * iconScale);
-                int hoverStartX = infoX + (int) (textOffsetX * iconScale);  // 考虑文本偏移量的悬停起始X
-                if (mouseX >= hoverStartX && mouseX < hoverStartX + scaledWidth && mouseY >= statusY && mouseY < statusY + scaledHeight) {
-                    // 显示tooltip
-                    Component tooltip = switch (status) {
-                        case LARGE_STRUCTURE -> net.minecraft.network.chat.Component.translatable(
-                            "screen.anvilcraft.structure_scanner.tooltip.large_structure");
-                        case UNKNOWN_BLOCKS -> net.minecraft.network.chat.Component.translatable(
-                            "screen.anvilcraft.structure_scanner.tooltip.unknown_blocks");
-                        case TOO_LARGE -> net.minecraft.network.chat.Component.translatable(
-                            "screen.anvilcraft.structure_scanner.tooltip.too_large");
-                        case MULTIBLOCK_BLOCKS -> net.minecraft.network.chat.Component.translatable(
-                            "screen.anvilcraft.structure_scanner.tooltip.multiblock_blocks");
-                        default -> Component.empty();
-                    };
-                                
-                    guiGraphics.renderTooltip(this.font, tooltip, mouseX, mouseY);
-                }
             }
             default -> {
                 // 未知状态，不渲染任何内容
             }
         }
+    }
+        
+    /**
+     * 收集信息栏叹号tooltip（不渲染）
+     */
+    @Nullable
+    private TooltipRenderInfo collectInfoPanelTooltip(int mouseX, int mouseY) {
+        // 使用缓存数据
+        if (this.cachedBlockEntity == null) return null;
+                
+        // 检查是否有磁盘
+        if (!this.cachedHasDisk) return null;
+                
+        // 获取信息状态
+        StructureScannerBlockEntity.InfoStatus status = this.cachedInfoStatus;
+            
+        // 只有特定状态才有tooltip
+        if (status != StructureScannerBlockEntity.InfoStatus.LARGE_STRUCTURE 
+            && status != StructureScannerBlockEntity.InfoStatus.UNKNOWN_BLOCKS 
+            && status != StructureScannerBlockEntity.InfoStatus.TOO_LARGE 
+            && status != StructureScannerBlockEntity.InfoStatus.MULTIBLOCK_BLOCKS) {
+            return null;
+        }
+                
+        // 信息栏位置（在磁盘槽位上方）
+        int infoX = this.leftPos + 9;
+        int infoY = this.topPos + 52;
+        int statusY = infoY + 10;
+            
+        // 叹号图标缩放比例
+        float iconScale = 1.5f;
+        int textOffsetX = 18;
+            
+        // 检查鼠标是否在叹号上（考虑缩放后的实际尺寸和偏移量）
+        int scaledWidth = (int) (8 * iconScale);
+        int scaledHeight = (int) (10 * iconScale);
+        int hoverStartX = infoX + (int) (textOffsetX * iconScale);
+            
+        if (mouseX >= hoverStartX && mouseX < hoverStartX + scaledWidth 
+            && mouseY >= statusY && mouseY < statusY + scaledHeight) {
+            // 收集tooltip
+            Component tooltip = switch (status) {
+                case LARGE_STRUCTURE -> net.minecraft.network.chat.Component.translatable(
+                    "screen.anvilcraft.structure_scanner.tooltip.large_structure");
+                case UNKNOWN_BLOCKS -> net.minecraft.network.chat.Component.translatable(
+                    "screen.anvilcraft.structure_scanner.tooltip.unknown_blocks");
+                case TOO_LARGE -> net.minecraft.network.chat.Component.translatable(
+                    "screen.anvilcraft.structure_scanner.tooltip.too_large");
+                case MULTIBLOCK_BLOCKS -> net.minecraft.network.chat.Component.translatable(
+                    "screen.anvilcraft.structure_scanner.tooltip.multiblock_blocks");
+                default -> Component.empty();
+            };
+                
+            return new TooltipRenderInfo(this.font, List.of(tooltip), mouseX, mouseY);
+        }
+            
+        return null;
     }
     
     /**
@@ -934,4 +1002,14 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
         
         return super.keyPressed(keyCode, scanCode, modifiers);
     }
+    
+    /**
+     * Tooltip渲染信息记录类
+     */
+    private record TooltipRenderInfo(
+        net.minecraft.client.gui.Font font,
+        java.util.List<Component> tooltip,
+        int x,
+        int y
+    ) {}
 }


### PR DESCRIPTION
- 将SmartBlockPlacerScreen中分散的tooltip渲染方法合并为统一逻辑
- 实现TooltipRenderInfo记录类，集中管理tooltip信息和位置
- 收集Disk槽位、书槽位、缺失方块图标及item slot的tooltip，统一渲染
- 在StructureScannerScreen中分离信息栏渲染与tooltip渲染逻辑
- 通过collectInfoPanelTooltip方法收集叹号提示，延迟渲染
- 使用高Z轴值确保所有tooltip绘制在最上层
- 优化tooltip渲染流程，提升代码可维护性和扩展性