### PR TITLE
Align SmartBlockPlacer and StructureScanner translations with RenderSupport

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -201,6 +201,8 @@
   "anvilcraft.configuration.render_bloom_effect.tooltip": "˙sǝuᴉꞁ ɹǝʇʇᴉɯsuɐɹʇ ɹǝʍod puɐ ɹǝsɐꞁ uo ʇɔǝɟɟǝ ɯooꞁᗺ",
   "anvilcraft.configuration.render_power_transmitter_lines": "sǝuᴉꞀ ɹǝʇʇᴉɯsuɐɹ⟘ ɹǝʍoԀ ɹǝpuǝᴚ",
   "anvilcraft.configuration.render_power_transmitter_lines.tooltip": "sɹǝʇʇᴉɯsuɐɹʇ ɹǝʍod uǝǝʍʇǝq sǝuᴉꞁ ɹǝpuǝᴚ",
+  "anvilcraft.configuration.render_scan_preview_effect": "ʇɔǝɟɟƎ ʍǝᴉʌǝɹԀ uɐɔS ɹǝpuǝᴚ",
+  "anvilcraft.configuration.render_scan_preview_effect.tooltip": "˙sʍǝᴉʌǝɹd ǝɹnʇɔnɹʇs ᗡƐ uo ʇɔǝɟɟǝ ᵷuᴉssǝɔoɹd-ʇsod ǝuᴉꞁuɐɔS",
   "anvilcraft.configuration.royal_anvil_beyond_max_level": "ꞁǝʌǝꞀ xɐW puoʎǝᗺ ꞁᴉʌuⱯ ꞁɐʎoᴚ",
   "anvilcraft.configuration.royal_anvil_beyond_max_level.tooltip": "ꞁᴉʌuⱯ ꞁɐʎoᴚ uᴉ ꞁǝʌǝꞁ xɐɯ puoʎǝq sʞooᗺ pǝʇuɐɥɔuƎ ɥʇᴉʍ sɯǝʇᴉ ᵷuᴉuᴉqɯoƆ",
   "anvilcraft.configuration.section.anvilcraft.client.toml": "uoᴉʇɐɹnᵷᴉɟuoƆ ʇuǝᴉꞁƆ ʇɟɐɹɔꞁᴉʌuⱯ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -201,6 +201,8 @@
   "anvilcraft.configuration.render_bloom_effect.tooltip": "Bloom effect on laser and power transmitter lines.",
   "anvilcraft.configuration.render_power_transmitter_lines": "Render Power Transmitter Lines",
   "anvilcraft.configuration.render_power_transmitter_lines.tooltip": "Render lines between power transmitters",
+  "anvilcraft.configuration.render_scan_preview_effect": "Render Scan Preview Effect",
+  "anvilcraft.configuration.render_scan_preview_effect.tooltip": "Scanline post-processing effect on 3D structure previews.",
   "anvilcraft.configuration.royal_anvil_beyond_max_level": "Royal Anvil Beyond Max Level",
   "anvilcraft.configuration.royal_anvil_beyond_max_level.tooltip": "Combining items with Enchanted Books beyond max level in Royal Anvil",
   "anvilcraft.configuration.section.anvilcraft.client.toml": "Anvilcraft Client Configuration",

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
@@ -16,6 +16,7 @@ import dev.dubhe.anvilcraft.api.tooltip.TooltipRenderHelper;
 import dev.dubhe.anvilcraft.client.gui.component.ToggleButton;
 import dev.dubhe.anvilcraft.client.gui.component.TriStateButton;
 import dev.dubhe.anvilcraft.client.init.ModShaders;
+import dev.dubhe.anvilcraft.client.renderer.RenderState;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
 import dev.dubhe.anvilcraft.constant.Constant;
 import dev.dubhe.anvilcraft.constant.SharedTextures;
@@ -931,17 +932,6 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
 
         LevelLike previewLevelLike = this.getOrCreateCachedPreviewLevelLike();
 
-        int guiScale = (int) this.minecraft.getWindow().getGuiScale();
-        int fbWidth = this.previewWindowWidth * guiScale;
-        int fbHeight = this.previewWindowHeight * guiScale;
-
-        // 创建/重建离屏帧缓冲
-        if (this.previewFbo == null) {
-            this.previewFbo = new TextureTarget(fbWidth, fbHeight, true, Minecraft.ON_OSX);
-        } else if (this.previewFbo.width != fbWidth || this.previewFbo.height != fbHeight) {
-            this.previewFbo.resize(fbWidth, fbHeight, Minecraft.ON_OSX);
-        }
-
         // 阶段1: 正常渲染 3D 预览到主帧缓冲
         final double guiScaleD = this.minecraft.getWindow().getGuiScale();
         RenderSystem.enableScissor(
@@ -962,64 +952,75 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
 
         RenderSystem.disableScissor();
 
-        // 阶段2: 将预览区域从主帧缓冲复制到离屏帧缓冲
-        final RenderTarget mainTarget = this.minecraft.getMainRenderTarget();
-        int srcX = (int) (this.previewWindowX * guiScaleD);
-        int srcY = (int) ((this.minecraft.getWindow().getGuiScaledHeight()
-            - this.previewWindowY - this.previewWindowHeight) * guiScaleD);
+        // 阶段2&3: 扫描着色器后处理（仅在配置启用时）
+        if (RenderState.isScanPreviewEffectEnabled()) {
+            int guiScale = (int) this.minecraft.getWindow().getGuiScale();
+            int fbWidth = this.previewWindowWidth * guiScale;
+            int fbHeight = this.previewWindowHeight * guiScale;
 
-        GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, mainTarget.frameBufferId);
-        GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, this.previewFbo.frameBufferId);
-        GL30.glBlitFramebuffer(
-            srcX, srcY, srcX + fbWidth, srcY + fbHeight,
-            0, 0, fbWidth, fbHeight,
-            GL11.GL_COLOR_BUFFER_BIT, GL11.GL_NEAREST
-        );
-        GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
-        GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
+            if (this.previewFbo == null) {
+                this.previewFbo = new TextureTarget(fbWidth, fbHeight, true, Minecraft.ON_OSX);
+            } else if (this.previewFbo.width != fbWidth || this.previewFbo.height != fbHeight) {
+                this.previewFbo.resize(fbWidth, fbHeight, Minecraft.ON_OSX);
+            }
 
-        mainTarget.bindWrite(false);
+            final RenderTarget mainTarget = this.minecraft.getMainRenderTarget();
+            int srcX = (int) (this.previewWindowX * guiScaleD);
+            int srcY = (int) ((this.minecraft.getWindow().getGuiScaledHeight()
+                - this.previewWindowY - this.previewWindowHeight) * guiScaleD);
 
-        // 阶段3: 使用扫描着色器 blit 回主帧缓冲
-        float fbW = this.previewFbo.width;
-        float fbH = this.previewFbo.height;
-        float screenX = this.previewWindowX * guiScale;
-        float screenY = (this.minecraft.getWindow().getGuiScaledHeight()
-            - this.previewWindowY - this.previewWindowHeight) * guiScale;
-
-        ShaderInstance shader = ModShaders.getScanPreviewShader();
-        if (shader != null) {
-            RenderSystem.enableBlend();
-            RenderSystem.defaultBlendFunc();
-            RenderSystem.viewport(0, 0,
-                this.minecraft.getWindow().getWidth(),
-                this.minecraft.getWindow().getHeight());
-
-            shader.setSampler("DiffuseSampler", this.previewFbo);
-            shader.safeGetUniform("ProjMat").set(ModShaders.getOrthoMatrix());
-            shader.safeGetUniform("InSize").set(fbW, fbH);
-            shader.safeGetUniform("OutPos").set(screenX, screenY);
-            shader.safeGetUniform("OutSize").set(fbW, fbH);
-            shader.safeGetUniform("GameTime").set(
-                (float) (System.currentTimeMillis() % 100000) / 1000.0f
+            GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, mainTarget.frameBufferId);
+            GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, this.previewFbo.frameBufferId);
+            GL30.glBlitFramebuffer(
+                srcX, srcY, srcX + fbWidth, srcY + fbHeight,
+                0, 0, fbWidth, fbHeight,
+                GL11.GL_COLOR_BUFFER_BIT, GL11.GL_NEAREST
             );
+            GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
+            GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
 
-            RenderSystem.depthFunc(GL11.GL_ALWAYS);
-            shader.apply();
+            mainTarget.bindWrite(false);
 
-            BufferBuilder bufferbuilder = Tesselator.getInstance()
-                .begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION);
-            bufferbuilder.addVertex(0.0F, 0.0F, 0.0F);
-            bufferbuilder.addVertex(fbW, 0.0F, 0.0F);
-            bufferbuilder.addVertex(fbW, fbH, 0.0F);
-            bufferbuilder.addVertex(0.0F, fbH, 0.0F);
-            BufferUploader.draw(bufferbuilder.buildOrThrow());
+            float fbW = this.previewFbo.width;
+            float fbH = this.previewFbo.height;
+            float screenX = this.previewWindowX * guiScale;
+            float screenY = (this.minecraft.getWindow().getGuiScaledHeight()
+                - this.previewWindowY - this.previewWindowHeight) * guiScale;
 
-            RenderSystem.depthFunc(GL11.GL_LEQUAL);
-            ProgramManager.glUseProgram(0);
-            RenderSystem.disableBlend();
+            ShaderInstance shader = ModShaders.getScanPreviewShader();
+            if (shader != null) {
+                RenderSystem.enableBlend();
+                RenderSystem.defaultBlendFunc();
+                RenderSystem.viewport(0, 0,
+                    this.minecraft.getWindow().getWidth(),
+                    this.minecraft.getWindow().getHeight());
 
-            this.previewFbo.unbindRead();
+                shader.setSampler("DiffuseSampler", this.previewFbo);
+                shader.safeGetUniform("ProjMat").set(ModShaders.getOrthoMatrix());
+                shader.safeGetUniform("InSize").set(fbW, fbH);
+                shader.safeGetUniform("OutPos").set(screenX, screenY);
+                shader.safeGetUniform("OutSize").set(fbW, fbH);
+                shader.safeGetUniform("GameTime").set(
+                    (float) (System.currentTimeMillis() % 100000) / 1000.0f
+                );
+
+                RenderSystem.depthFunc(GL11.GL_ALWAYS);
+                shader.apply();
+
+                BufferBuilder bufferbuilder = Tesselator.getInstance()
+                    .begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION);
+                bufferbuilder.addVertex(0.0F, 0.0F, 0.0F);
+                bufferbuilder.addVertex(fbW, 0.0F, 0.0F);
+                bufferbuilder.addVertex(fbW, fbH, 0.0F);
+                bufferbuilder.addVertex(0.0F, fbH, 0.0F);
+                BufferUploader.draw(bufferbuilder.buildOrThrow());
+
+                RenderSystem.depthFunc(GL11.GL_LEQUAL);
+                ProgramManager.glUseProgram(0);
+                RenderSystem.disableBlend();
+
+                this.previewFbo.unbindRead();
+            }
         }
 
         // 如果没有配置选区位置且不在蓝图模式下，显示提示文本（在裁剪区域外渲染，确保在最上层）

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/SmartBlockPlacerScreen.java
@@ -1208,16 +1208,16 @@ public class SmartBlockPlacerScreen extends AbstractContainerScreen<SmartBlockPl
         float scale = Math.min(scaleY, scaleX);
         poseStack.scale(-scale, -scale, -scale);
         
-        // 3. 平移到中心
-        poseStack.translate(-(float) 5 / 2, -(float) 5 / 2, 0);
-        
+        // 3. 平移到中心（5为奇数，加0.5与RenderSupport保持一致）
+        poseStack.translate(-(float) 5 / 2 + 0.5f, -(float) 5 / 2, 0);
+
         // 4. 先应用X轴旋转
         poseStack.mulPose(com.mojang.math.Axis.XP.rotationDegrees(this.previewRotationX));
-        
+
         // 5. Y轴旋转的中心点 - 固定基于5x5范围计算，忽略放置器
         // 与RenderSupport.renderLevelLikeWithFixedSize保持一致
-        float offsetX = (float) -5 / 2 + 0.05f;
-        float offsetZ = (float) -5 / 2 + 1;
+        float offsetX = (float) -5 / 2 + 0.05f + 0.5f;
+        float offsetZ = (float) -5 / 2 + 1 + 0.5f;
         poseStack.translate(-offsetX, 0, -offsetZ);
         poseStack.mulPose(com.mojang.math.Axis.YP.rotationDegrees(this.previewRotationY + 45));
         poseStack.translate(offsetX, 0, offsetZ);

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
@@ -19,6 +19,7 @@ import dev.dubhe.anvilcraft.client.gui.component.TextWidget;
 import dev.dubhe.anvilcraft.client.gui.component.TexturedButton;
 import dev.dubhe.anvilcraft.client.gui.component.ToggleButton;
 import dev.dubhe.anvilcraft.client.init.ModShaders;
+import dev.dubhe.anvilcraft.client.renderer.RenderState;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
 import dev.dubhe.anvilcraft.constant.Constant;
 import dev.dubhe.anvilcraft.constant.SharedTextures;
@@ -621,17 +622,6 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
             return;
         }
 
-        int guiScale = (int) this.minecraft.getWindow().getGuiScale();
-        int fbWidth = this.previewWindowWidth * guiScale;
-        int fbHeight = this.previewWindowHeight * guiScale;
-
-        // 创建/重建离屏帧缓冲
-        if (this.previewFbo == null) {
-            this.previewFbo = new TextureTarget(fbWidth, fbHeight, true, Minecraft.ON_OSX);
-        } else if (this.previewFbo.width != fbWidth || this.previewFbo.height != fbHeight) {
-            this.previewFbo.resize(fbWidth, fbHeight, Minecraft.ON_OSX);
-        }
-
         // 阶段1: 正常渲染 3D 预览到主帧缓冲
         final double guiScaleD = this.minecraft.getWindow().getGuiScale();
         RenderSystem.enableScissor(
@@ -649,7 +639,19 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
 
         RenderSystem.disableScissor();
 
-        // 阶段2: 将预览区域从主帧缓冲复制到离屏帧缓冲
+        // 阶段2&3: 扫描着色器后处理（仅在配置启用时）
+        if (!RenderState.isScanPreviewEffectEnabled()) return;
+
+        int guiScale = (int) this.minecraft.getWindow().getGuiScale();
+        int fbWidth = this.previewWindowWidth * guiScale;
+        int fbHeight = this.previewWindowHeight * guiScale;
+
+        if (this.previewFbo == null) {
+            this.previewFbo = new TextureTarget(fbWidth, fbHeight, true, Minecraft.ON_OSX);
+        } else if (this.previewFbo.width != fbWidth || this.previewFbo.height != fbHeight) {
+            this.previewFbo.resize(fbWidth, fbHeight, Minecraft.ON_OSX);
+        }
+
         final RenderTarget mainTarget = this.minecraft.getMainRenderTarget();
         int srcX = (int) (this.previewWindowX * guiScaleD);
         int srcY = (int) ((this.minecraft.getWindow().getGuiScaledHeight()
@@ -665,13 +667,9 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
         GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
         GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
 
-        // 恢复主帧缓冲绑定
         mainTarget.bindWrite(false);
 
-        // 阶段3: 使用扫描着色器 blit 回主帧缓冲
-
         ShaderInstance shader = ModShaders.getScanPreviewShader();
-        // noinspection ConstantValue
         if (shader == null) return;
 
         RenderSystem.enableBlend();

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
@@ -913,15 +913,16 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
         float scale = Math.min(scaleY, scaleX);
         poseStack.scale(-scale, -scale, -scale);
             
-        // 3. 平移到中心
-        poseStack.translate(-(float) sizeX / 2, -(float) sizeY / 2, 0);
-            
+        // 3. 平移到中心（奇数尺寸加0.5，与RenderSupport保持一致）
+        float centerOffset = (sizeX % 2 != 0) ? 0.5f : 0.0f;
+        poseStack.translate(-(float) sizeX / 2 + centerOffset, -(float) sizeY / 2, 0);
+
         // 4. 应用X轴旋转
         poseStack.mulPose(com.mojang.math.Axis.XP.rotationDegrees(this.previewRotationX));
-            
+
         // 5. Y轴旋转
-        float offsetX = (float) -sizeX / 2 + 0.05f;
-        float offsetZ = (float) -sizeX / 2 + 1;
+        float offsetX = (float) -sizeX / 2 + 0.05f + centerOffset;
+        float offsetZ = (float) -sizeX / 2 + 1 + centerOffset;
         poseStack.translate(-offsetX, 0, -offsetZ);
         // 应用朝向旋转偏移
         float yawOffset = getFacingYawOffset(facing);

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/RenderState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/RenderState.java
@@ -34,4 +34,8 @@ public class RenderState {
     public static boolean isBloomEffectEnabled() {
         return AnvilCraftClient.CONFIG.renderBloomEffect;
     }
+
+    public static boolean isScanPreviewEffectEnabled() {
+        return AnvilCraftClient.CONFIG.renderScanPreviewEffect;
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/StructureDiskPreviewSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/StructureDiskPreviewSupport.java
@@ -11,6 +11,7 @@ import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import dev.dubhe.anvilcraft.client.init.ModShaders;
+import dev.dubhe.anvilcraft.client.renderer.RenderState;
 import dev.dubhe.anvilcraft.util.LevelLike;
 import dev.dubhe.anvilcraft.util.StructureLoadUtil;
 import net.minecraft.client.Minecraft;
@@ -139,72 +140,74 @@ public class StructureDiskPreviewSupport {
         // 恢复Z轴层级
         guiGraphics.pose().popPose();
 
-        // 扫描预览后处理: 复制预览区域 → 着色器回写
-        int guiScale = (int) minecraft.getWindow().getGuiScale();
-        int fbWidth = previewSize * guiScale;
-        int fbHeight = previewSize * guiScale;
+        // 扫描预览后处理: 复制预览区域 → 着色器回写（仅在配置启用时）
+        if (RenderState.isScanPreviewEffectEnabled()) {
+            int guiScale = (int) minecraft.getWindow().getGuiScale();
+            int fbWidth = previewSize * guiScale;
+            int fbHeight = previewSize * guiScale;
 
-        if (lastFboGuiScale != guiScale) {
-            if (previewFbo != null) previewFbo.destroyBuffers();
-            previewFbo = null;
-            lastFboGuiScale = guiScale;
-        }
-        if (previewFbo == null) {
-            previewFbo = new TextureTarget(fbWidth, fbHeight, true, Minecraft.ON_OSX);
-        }
+            if (lastFboGuiScale != guiScale) {
+                if (previewFbo != null) previewFbo.destroyBuffers();
+                previewFbo = null;
+                lastFboGuiScale = guiScale;
+            }
+            if (previewFbo == null) {
+                previewFbo = new TextureTarget(fbWidth, fbHeight, true, Minecraft.ON_OSX);
+            }
 
-        final RenderTarget mainTarget = minecraft.getMainRenderTarget();
-        int srcX = (int) (previewX * guiScale);
-        int srcY = (int) ((minecraft.getWindow().getGuiScaledHeight() - previewY - previewSize) * guiScale);
+            final RenderTarget mainTarget = minecraft.getMainRenderTarget();
+            int srcX = (int) (previewX * guiScale);
+            int srcY = (int) ((minecraft.getWindow().getGuiScaledHeight() - previewY - previewSize) * guiScale);
 
-        GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, mainTarget.frameBufferId);
-        GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, previewFbo.frameBufferId);
-        GL30.glBlitFramebuffer(
-            srcX, srcY, srcX + fbWidth, srcY + fbHeight,
-            0, 0, fbWidth, fbHeight,
-            GL11.GL_COLOR_BUFFER_BIT, GL11.GL_NEAREST
-        );
-        GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
-        GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
-
-        mainTarget.bindWrite(false);
-
-        ShaderInstance shader = ModShaders.getScanPreviewShader();
-        if (shader != null) {
-            final float fbW = previewFbo.width;
-            final float fbH = previewFbo.height;
-            final float screenX = previewX * guiScale;
-            final float screenY = (minecraft.getWindow().getGuiScaledHeight() - previewY - previewSize) * guiScale;
-
-            RenderSystem.defaultBlendFunc();
-            RenderSystem.viewport(0, 0,
-                minecraft.getWindow().getWidth(),
-                minecraft.getWindow().getHeight());
-
-            shader.setSampler("DiffuseSampler", previewFbo);
-            shader.safeGetUniform("ProjMat").set(ModShaders.getOrthoMatrix());
-            shader.safeGetUniform("InSize").set(fbW, fbH);
-            shader.safeGetUniform("OutPos").set(screenX, screenY);
-            shader.safeGetUniform("OutSize").set(fbW, fbH);
-            shader.safeGetUniform("GameTime").set(
-                (float) (System.currentTimeMillis() % 100000) / 1000.0f
+            GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, mainTarget.frameBufferId);
+            GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, previewFbo.frameBufferId);
+            GL30.glBlitFramebuffer(
+                srcX, srcY, srcX + fbWidth, srcY + fbHeight,
+                0, 0, fbWidth, fbHeight,
+                GL11.GL_COLOR_BUFFER_BIT, GL11.GL_NEAREST
             );
+            GlStateManager._glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
+            GlStateManager._glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
 
-            RenderSystem.depthFunc(GL11.GL_ALWAYS);
-            shader.apply();
+            mainTarget.bindWrite(false);
 
-            BufferBuilder bufferbuilder = Tesselator.getInstance()
-                .begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION);
-            bufferbuilder.addVertex(0.0F, 0.0F, 0.0F);
-            bufferbuilder.addVertex(fbW, 0.0F, 0.0F);
-            bufferbuilder.addVertex(fbW, fbH, 0.0F);
-            bufferbuilder.addVertex(0.0F, fbH, 0.0F);
-            BufferUploader.draw(bufferbuilder.buildOrThrow());
+            ShaderInstance shader = ModShaders.getScanPreviewShader();
+            if (shader != null) {
+                final float fbW = previewFbo.width;
+                final float fbH = previewFbo.height;
+                final float screenX = previewX * guiScale;
+                final float screenY = (minecraft.getWindow().getGuiScaledHeight() - previewY - previewSize) * guiScale;
 
-            RenderSystem.depthFunc(GL11.GL_LEQUAL);
-            ProgramManager.glUseProgram(0);
+                RenderSystem.defaultBlendFunc();
+                RenderSystem.viewport(0, 0,
+                    minecraft.getWindow().getWidth(),
+                    minecraft.getWindow().getHeight());
 
-            previewFbo.unbindRead();
+                shader.setSampler("DiffuseSampler", previewFbo);
+                shader.safeGetUniform("ProjMat").set(ModShaders.getOrthoMatrix());
+                shader.safeGetUniform("InSize").set(fbW, fbH);
+                shader.safeGetUniform("OutPos").set(screenX, screenY);
+                shader.safeGetUniform("OutSize").set(fbW, fbH);
+                shader.safeGetUniform("GameTime").set(
+                    (float) (System.currentTimeMillis() % 100000) / 1000.0f
+                );
+
+                RenderSystem.depthFunc(GL11.GL_ALWAYS);
+                shader.apply();
+
+                BufferBuilder bufferbuilder = Tesselator.getInstance()
+                    .begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION);
+                bufferbuilder.addVertex(0.0F, 0.0F, 0.0F);
+                bufferbuilder.addVertex(fbW, 0.0F, 0.0F);
+                bufferbuilder.addVertex(fbW, fbH, 0.0F);
+                bufferbuilder.addVertex(0.0F, fbH, 0.0F);
+                BufferUploader.draw(bufferbuilder.buildOrThrow());
+
+                RenderSystem.depthFunc(GL11.GL_LEQUAL);
+                ProgramManager.glUseProgram(0);
+
+                previewFbo.unbindRead();
+            }
         }
 
         // 禁用深度测试

--- a/src/main/java/dev/dubhe/anvilcraft/config/AnvilCraftClientConfig.java
+++ b/src/main/java/dev/dubhe/anvilcraft/config/AnvilCraftClientConfig.java
@@ -28,6 +28,9 @@ public class AnvilCraftClientConfig {
     @Comment("Bloom effect on laser and power transmitter lines.")
     public boolean renderBloomEffect = false;
 
+    @Comment("Scanline post-processing effect on 3D structure previews.")
+    public boolean renderScanPreviewEffect = true;
+
     @Comment("A vertical item frame vertically displays items")
     public boolean verticalItemFrame = false;
 


### PR DESCRIPTION
This pull request updates the rendering logic in both `SmartBlockPlacerScreen` and `StructureScannerScreen` to improve the centering and rotation of preview elements, especially for odd-sized areas. The changes ensure that rendering is consistent with `RenderSupport` and that previews are visually centered regardless of size.

**Rendering and Alignment Improvements:**

* Adjusted the translation logic in `SmartBlockPlacerScreen` to add a 0.5 offset when centering, ensuring odd-sized previews are accurately centered and consistent with `RenderSupport`. Also updated the Y-axis rotation center calculations to include this offset.
* Updated `StructureScannerScreen` to dynamically add a 0.5 offset for odd-sized areas when centering and during Y-axis rotation calculations, matching the behavior of `RenderSupport` and improving visual alignment.