### PR TITLE
Add clearIrradiateSelfLaserBlockSet method and update notifyMoved

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/RubyPrismBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/RubyPrismBlock.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.MapCodec;
 import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.HammerRotateBehavior;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
+import dev.dubhe.anvilcraft.block.entity.BaseLaserBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.RubyPrismBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
@@ -73,7 +74,8 @@ public class RubyPrismBlock extends BaseLaserBlock implements IHammerRemovable, 
         BlockState state,
         BlockGetter level,
         BlockPos pos,
-        CollisionContext context) {
+        CollisionContext context
+    ) {
         return switch (state.getValue(FACING)) {
             case UP -> UP_MODEL;
             case DOWN -> DOWN_MODEL;
@@ -116,5 +118,12 @@ public class RubyPrismBlock extends BaseLaserBlock implements IHammerRemovable, 
     @Override
     protected BlockState mirror(BlockState state, Mirror mirror) {
         return state.setValue(FACING, mirror.mirror(state.getValue(FACING)));
+    }
+
+    @Override
+    public void notifyMoved(Level level, BlockPos pos, BlockState state, BlockEntity be) {
+        if (be instanceof BaseLaserBlockEntity laserBlockEntity) {
+            laserBlockEntity.clearIrradiateSelfLaserBlockSet();
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
@@ -62,37 +62,41 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
     }
 
     private boolean canPassThrough(Direction direction, BlockPos blockPos) {
-        if (level == null) return false;
+        if (this.level == null) return false;
         BlockState blockState = level.getBlockState(blockPos);
-        if (blockState.is(ModBlockTags.LASER_CAN_PASS_THROUGH)
+        if (
+            blockState.is(ModBlockTags.LASER_CAN_PASS_THROUGH)
             || blockState.is(Tags.Blocks.GLASS_BLOCKS)
             || blockState.is(Tags.Blocks.GLASS_PANES)
-            || blockState.is(BlockTags.REPLACEABLE)) return true;
+            || blockState.is(BlockTags.REPLACEABLE)
+        ) {
+            return true;
+        }
         if (!AnvilCraft.CONFIG.isLaserDoImpactChecking) return false;
         AABB laseBoundingBox = switch (direction.getAxis()) {
             case X -> Block.box(0, 7, 7, 16, 9, 9).bounds();
             case Y -> Block.box(7, 0, 7, 9, 16, 9).bounds();
             case Z -> Block.box(7, 7, 0, 9, 9, 16).bounds();
         };
-        return blockState.getCollisionShape(level, blockPos).toAabbs().stream().noneMatch(laseBoundingBox::intersects);
+        return blockState.getCollisionShape(this.level, blockPos).toAabbs().stream().noneMatch(laseBoundingBox::intersects);
     }
 
     public void updateIrradiateBlockPos(@Nullable BlockPos newPos) {
-        if (irradiateBlockPos == null) {
+        if (this.irradiateBlockPos == null) {
             if (newPos != null) this.markChanged();
-            irradiateBlockPos = newPos;
+            this.irradiateBlockPos = newPos;
             return;
         }
-        if (!irradiateBlockPos.equals(newPos)) this.markChanged();
-        irradiateBlockPos = newPos;
+        if (!this.irradiateBlockPos.equals(newPos)) this.markChanged();
+        this.irradiateBlockPos = newPos;
     }
 
     public void resetState() {
-        changed = false;
+        this.changed = false;
     }
 
     public void markChanged() {
-        changed = true;
+        this.changed = true;
     }
 
     private BlockPos getIrradiateBlockPos(int expectedLength, Direction direction, BlockPos originPos) {
@@ -112,15 +116,15 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
 
     protected int calculateLaserLevel() {
         return getBaseLaserLevel()
-            + irradiateSelfLaserBlockSet.stream()
-            .mapToInt(BaseLaserBlockEntity::calculateLaserLevel)
-            .sum();
+               + this.irradiateSelfLaserBlockSet.stream()
+                   .mapToInt(BaseLaserBlockEntity::calculateLaserLevel)
+                   .sum();
     }
 
     public void syncTo(ServerPlayer player) {
         PacketDistributor.sendToPlayer(
             player,
-            new LaserEmitPacket(getLaserLevel(), getBlockPos(), irradiateBlockPos)
+            new LaserEmitPacket(getLaserLevel(), getBlockPos(), this.irradiateBlockPos)
         );
     }
 
@@ -130,7 +134,7 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
                 PacketDistributor.sendToPlayersTrackingChunk(
                     serverLevel,
                     level.getChunkAt(getBlockPos()).getPos(),
-                    new LaserEmitPacket(getLaserLevel(), getBlockPos(), irradiateBlockPos)
+                    new LaserEmitPacket(getLaserLevel(), getBlockPos(), this.irradiateBlockPos)
                 );
             }
         }
@@ -141,7 +145,7 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
         ) {
             HeaterManager.addProducer(this.getBlockPos(), serverLevel, ModHeaterInfos.LASER_EMITTER);
         }
-        tickCount++;
+        this.tickCount++;
     }
 
     /**
@@ -153,8 +157,7 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
         if (!tempIrradiateBlockPos.equals(this.irradiateBlockPos)) {
             if (
                 this.irradiateBlockPos != null
-                && this.level.getBlockEntity(this.irradiateBlockPos)
-                instanceof BaseLaserBlockEntity lastIrradiatedLaserBlockEntity
+                && this.level.getBlockEntity(this.irradiateBlockPos) instanceof BaseLaserBlockEntity lastIrradiatedLaserBlockEntity
             ) {
                 lastIrradiatedLaserBlockEntity.onCancelingIrradiation(this);
             }
@@ -208,7 +211,7 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
             if (irradiateBlock.is(Tags.Blocks.ORES)) {
                 List<ItemStack> drops = BreakBlockUtil.drop(
                     serverLevel,
-                    irradiateBlockPos
+                    this.irradiateBlockPos
                 );
                 this.deliverItem(drops, direction, this.irradiateBlockPos);
             }
@@ -246,7 +249,9 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
                 && downStreamBlockEntity.getFacing() == direction
             ) {
                 downStreamBlockEntity.deliverItem(drops, direction, sourceBlockPos);
-            } else this.level.addFreshEntity(new ItemEntity(this.level, blockPos.x, blockPos.y, blockPos.z, itemStack));
+            } else {
+                this.level.addFreshEntity(new ItemEntity(this.level, blockPos.x, blockPos.y, blockPos.z, itemStack));
+            }
         });
         if (this.level.getBlockEntity(downStreamPos) instanceof BaseLaserBlockEntity) return;
         if (sourceBlock.is(Blocks.ANCIENT_DEBRIS)) {
@@ -279,26 +284,30 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
      */
     public boolean isInIrradiateSelfLaserBlockSet(BaseLaserBlockEntity baseLaserBlockEntity) {
         return baseLaserBlockEntity == this
-            || irradiateSelfLaserBlockSet.contains(baseLaserBlockEntity)
-            || irradiateSelfLaserBlockSet.stream()
-            .anyMatch(baseLaserBlockEntity1 ->
-                baseLaserBlockEntity1.isInIrradiateSelfLaserBlockSet(baseLaserBlockEntity));
+               || irradiateSelfLaserBlockSet.contains(baseLaserBlockEntity)
+               || irradiateSelfLaserBlockSet.stream()
+                   .anyMatch(baseLaserBlockEntity1 ->
+                       baseLaserBlockEntity1.isInIrradiateSelfLaserBlockSet(baseLaserBlockEntity));
+    }
+
+    public void clearIrradiateSelfLaserBlockSet() {
+        this.irradiateSelfLaserBlockSet.clear();
     }
 
     public void onIrradiated(BaseLaserBlockEntity baseLaserBlockEntity) {
-        irradiateSelfLaserBlockSet.add(baseLaserBlockEntity);
+        this.irradiateSelfLaserBlockSet.add(baseLaserBlockEntity);
     }
 
     /**
      * 当方块被取消激光照射时调用
      */
     public void onCancelingIrradiation(BaseLaserBlockEntity baseLaserBlockEntity) {
-        irradiateSelfLaserBlockSet.remove(baseLaserBlockEntity);
+        this.irradiateSelfLaserBlockSet.remove(baseLaserBlockEntity);
         BlockPos tempIrradiateBlockPos = irradiateBlockPos;
-        updateIrradiateBlockPos(null);
-        if (level == null) return;
+        this.updateIrradiateBlockPos(null);
+        if (this.level == null) return;
         if (tempIrradiateBlockPos == null) return;
-        if (!(level.getBlockEntity(tempIrradiateBlockPos) instanceof BaseLaserBlockEntity irradiateBlockEntity)) return;
+        if (!(this.level.getBlockEntity(tempIrradiateBlockPos) instanceof BaseLaserBlockEntity irradiateBlockEntity)) return;
         irradiateBlockEntity.onCancelingIrradiation(this);
     }
 
@@ -307,12 +316,12 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
     @Override
     public void setRemoved() {
         super.setRemoved();
-        if (level == null) return;
-        if (irradiateBlockPos == null) return;
-        if (!level.isLoaded(irradiateBlockPos)) return;
-        if (!(level.getBlockEntity(irradiateBlockPos) instanceof BaseLaserBlockEntity irradiateBlockEntity)) return;
+        if (this.level == null) return;
+        if (this.irradiateBlockPos == null) return;
+        if (!this.level.isLoaded(this.irradiateBlockPos)) return;
+        if (!(this.level.getBlockEntity(this.irradiateBlockPos) instanceof BaseLaserBlockEntity irradiateBlockEntity)) return;
         irradiateBlockEntity.onCancelingIrradiation(this);
-        if (level.isClientSide()) {
+        if (this.level.isClientSide()) {
             CacheableBERenderingPipeline.getInstance().update(this);
         }
     }
@@ -335,7 +344,8 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
             Double.NEGATIVE_INFINITY,
             Double.POSITIVE_INFINITY,
             Double.POSITIVE_INFINITY,
-            Double.POSITIVE_INFINITY);
+            Double.POSITIVE_INFINITY
+        );
     }
 
     @Override
@@ -347,10 +357,10 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
     }
 
     public void updateLaserLevel(int value) {
-        if (laserLevel != value) {
+        if (this.laserLevel != value) {
             markChanged();
         }
-        laserLevel = value;
+        this.laserLevel = value;
     }
 
     public void clientUpdate(BlockPos irradiateBlockPos, int laserLevel) {


### PR DESCRIPTION
This pull request primarily refactors the `BaseLaserBlockEntity` class and related laser block logic to improve code consistency, maintainability, and correctness, especially around field access and state management. It also introduces a mechanism to clear laser irradiation links when a block is moved. The changes are grouped below by theme.

### Laser Block State Management and Consistency

* Refactored all field accesses in `BaseLaserBlockEntity` to use `this.` for clarity and consistency, reducing ambiguity and potential bugs when referencing instance variables. [[1]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL65-R99) [[2]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL115-R127) [[3]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL133-R137) [[4]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL144-R148) [[5]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL156-R160) [[6]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL211-R214) [[7]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL249-R254) [[8]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fR293-R310) [[9]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL310-R324) [[10]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL338-R348) [[11]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL350-R363)
* Improved code style by consistently using braces for single-line branches and aligning formatting in method calls and conditionals. [[1]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL249-R254) [[2]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL338-R348)

### Laser Irradiation Relationship Handling

* Added a `clearIrradiateSelfLaserBlockSet()` method to `BaseLaserBlockEntity` to clear irradiation relationships, and ensured all modifications to `irradiateSelfLaserBlockSet` use `this.` for clarity.
* Updated the `onIrradiated` and `onCancelingIrradiation` methods to use `this.` for all relevant field accesses, improving reliability in relationship management.

### Block Movement and Notification

* Implemented the `notifyMoved` method in `RubyPrismBlock` to clear irradiation links on laser block entities when the block is moved, preventing stale references and potential bugs. [[1]](diffhunk://#diff-d4b8f255c7cb0af5720c292d6f631219374760fa63a97f0429d73f005e2a84d1R7) [[2]](diffhunk://#diff-d4b8f255c7cb0af5720c292d6f631219374760fa63a97f0429d73f005e2a84d1R122-R128)

### Minor Fixes and Formatting

* Fixed minor formatting issues in method signatures and block structures for readability and consistency. [[1]](diffhunk://#diff-d4b8f255c7cb0af5720c292d6f631219374760fa63a97f0429d73f005e2a84d1L76-R78) [[2]](diffhunk://#diff-e70def0a50a248773216e396f14099782b01ce2d1e9e1597aab943fd01fbb37fL338-R348)

These changes collectively enhance the robustness and maintainability of laser block logic, especially in scenarios involving block movement and state synchronization.