### PR TITLE
Add HasMobBlockItemRenderer for GUI and item hand rendering

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java
@@ -9,6 +9,7 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.monster.Ghast;
 import net.minecraft.world.entity.monster.Guardian;
 import net.minecraft.world.level.Level;
 
@@ -41,6 +42,9 @@ public class HasMobBlockRenderer implements BlockEntityRenderer<HasMobBlockEntit
         if (entity instanceof Guardian) {
             size *= 0.8f;
             poseStack.translate(0.0f, 0.0f, 0.25f);
+        }
+        if (entity instanceof Ghast) {
+            poseStack.translate(0.0f, 0.25f, 0.0f);
         }
         poseStack.scale(size, size, size);
         Minecraft minecraft = Minecraft.getInstance();

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java
@@ -9,6 +9,8 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.monster.Guardian;
+import net.minecraft.world.level.Level;
 
 public class HasMobBlockRenderer implements BlockEntityRenderer<HasMobBlockEntity> {
     @SuppressWarnings("unused")
@@ -24,16 +26,22 @@ public class HasMobBlockRenderer implements BlockEntityRenderer<HasMobBlockEntit
         int packedLight,
         int packedOverlay
     ) {
-        Entity entity = blockEntity.getOrCreateDisplayEntity(blockEntity.getLevel());
+        Level level = blockEntity.getLevel();
+        if (level == null) return;
+        Entity entity = blockEntity.getOrCreateDisplayEntity(level);
         if (entity == null) return;
         poseStack.pushPose();
         poseStack.translate(0.5f, 0.0f, 0.5f);
-        float size = 0.73125f * 0.5f;
+        float size = 0.52943f * 0.8f;
         float max = Math.max(entity.getBbWidth(), entity.getBbHeight());
         if ((double) max > 1.0) {
             size /= max;
         }
         poseStack.translate(0.0f, 0.14f, 0.0f);
+        if (entity instanceof Guardian) {
+            size *= 0.8f;
+            poseStack.translate(0.0f, 0.0f, 0.25f);
+        }
         poseStack.scale(size, size, size);
         Minecraft minecraft = Minecraft.getInstance();
         EntityRenderDispatcher dispatcher = minecraft.getEntityRenderDispatcher();

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java
@@ -28,7 +28,7 @@ public class HasMobBlockRenderer implements BlockEntityRenderer<HasMobBlockEntit
         if (entity == null) return;
         poseStack.pushPose();
         poseStack.translate(0.5f, 0.0f, 0.5f);
-        float size = 0.73125f;
+        float size = 0.73125f * 0.5f;
         float max = Math.max(entity.getBbWidth(), entity.getBbHeight());
         if ((double) max > 1.0) {
             size /= max;

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/HasMobBlockItemRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/HasMobBlockItemRenderer.java
@@ -1,0 +1,111 @@
+package dev.dubhe.anvilcraft.client.renderer.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import dev.dubhe.anvilcraft.block.item.HasMobBlockItem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
+
+public class HasMobBlockItemRenderer extends AbstractItemInHandRenderer {
+    protected HasMobBlockItemRenderer(ItemRenderer itemRenderer, IItemRenderer renderer) {
+        super(itemRenderer, renderer);
+    }
+
+    public static void renderGuiItem(
+        PoseStack pose,
+        ItemStack stack,
+        int x,
+        int y
+    ) {
+        Entity mobFromItem = HasMobBlockItemRenderer.getMobFromItem(stack);
+        if (mobFromItem == null) {
+            return;
+        }
+        pose.pushPose();
+        pose.translate(x + 8, y + 8, 160.0f);
+        pose.scale(16.0f, -16.0f, 16.0f);
+        pose.mulPose(Axis.XP.rotationDegrees(30));
+        pose.mulPose(Axis.YP.rotationDegrees(-45));
+        float size = 0.73125f * 0.5f;
+        float max = Math.max(mobFromItem.getBbWidth(), mobFromItem.getBbHeight());
+        if ((double) max > 1.0) {
+            size /= max;
+        }
+        pose.translate(0.0f, -0.14f, 0.0f);
+        pose.scale(size, size, size);
+        EntityRenderer<? super Entity> renderer = Minecraft.getInstance().getEntityRenderDispatcher().getRenderer(mobFromItem);
+        renderer.render(
+            mobFromItem,
+            0,
+            0,
+            pose,
+            Minecraft.getInstance().renderBuffers().bufferSource(),
+            LightTexture.FULL_BRIGHT
+        );
+        pose.popPose();
+    }
+
+    @Override
+    public void render(
+        AbstractClientPlayer player,
+        float partialTicks,
+        float pitch,
+        InteractionHand hand,
+        float swingProgress,
+        ItemStack stack,
+        float equippedProgress,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int combinedLight,
+        CallbackInfo ci
+    ) {
+        Entity mobFromItem = HasMobBlockItemRenderer.getMobFromItem(stack);
+        if (mobFromItem == null) {
+            return;
+        }
+        poseStack.translate(0.0f, 0.14f, 0.0f);
+        poseStack.pushPose();
+        float size = 0.73125f * 0.4f * 0.5f;
+        float max = Math.max(mobFromItem.getBbWidth(), mobFromItem.getBbHeight());
+        if ((double) max > 1.0) {
+            size /= max;
+        }
+        poseStack.translate(0.0f, -0.14f, 0.0f);
+        poseStack.scale(size, size, size);
+        if (hand == InteractionHand.OFF_HAND) {
+            poseStack.mulPose(Axis.YP.rotationDegrees(45));
+        } else {
+            poseStack.mulPose(Axis.YP.rotationDegrees(-45));
+        }
+        EntityRenderer<? super Entity> renderer = Minecraft.getInstance().getEntityRenderDispatcher().getRenderer(mobFromItem);
+        renderer.render(
+            mobFromItem,
+            0,
+            0,
+            poseStack,
+            Minecraft.getInstance().renderBuffers().bufferSource(),
+            LightTexture.FULL_BRIGHT
+        );
+        poseStack.popPose();
+    }
+
+    public static @Nullable Entity getMobFromItem(ItemStack stack) {
+        if (!(stack.getItem() instanceof HasMobBlockItem)) {
+            return null;
+        }
+        if (Minecraft.getInstance().level == null) {
+            return null;
+        }
+        return HasMobBlockItem.getMobFromItem(Minecraft.getInstance().level, stack);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/HasMobBlockItemRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/HasMobBlockItemRenderer.java
@@ -36,12 +36,12 @@ public class HasMobBlockItemRenderer extends AbstractItemInHandRenderer {
         pose.scale(16.0f, -16.0f, 16.0f);
         pose.mulPose(Axis.XP.rotationDegrees(30));
         pose.mulPose(Axis.YP.rotationDegrees(-45));
-        float size = 0.73125f * 0.5f;
+        float size = 0.52943f * 0.8f;
         float max = Math.max(mobFromItem.getBbWidth(), mobFromItem.getBbHeight());
         if ((double) max > 1.0) {
             size /= max;
         }
-        pose.translate(0.0f, -0.14f, 0.0f);
+        pose.translate(0.0f, -0.19f, 0.0f);
         pose.scale(size, size, size);
         EntityRenderer<? super Entity> renderer = Minecraft.getInstance().getEntityRenderDispatcher().getRenderer(mobFromItem);
         renderer.render(
@@ -75,7 +75,7 @@ public class HasMobBlockItemRenderer extends AbstractItemInHandRenderer {
         }
         poseStack.translate(0.0f, 0.14f, 0.0f);
         poseStack.pushPose();
-        float size = 0.73125f * 0.4f * 0.5f;
+        float size = 0.52943f * 0.4f * 0.8f;
         float max = Math.max(mobFromItem.getBbWidth(), mobFromItem.getBbHeight());
         if ((double) max > 1.0) {
             size /= max;

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/ItemInHandRendererManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/ItemInHandRendererManager.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.client.renderer.item;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import dev.dubhe.anvilcraft.api.item.IExtraItemDisplay;
+import dev.dubhe.anvilcraft.block.item.HasMobBlockItem;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -17,6 +18,7 @@ public class ItemInHandRendererManager extends AbstractItemInHandRenderer {
     private final Set<AbstractItemInHandRenderer> renderers = new HashSet<>();
     public final CrabClawItemInHandRenderer crabClawItemRenderer;
     public final IExtraItemDisplayRenderer extraItemRenderer;
+    public final HasMobBlockItemRenderer hasMobBlockItemRenderer;
 
     public ItemInHandRendererManager(ItemRenderer itemRenderer, IItemRenderer renderer) {
         super(itemRenderer, renderer);
@@ -24,6 +26,8 @@ public class ItemInHandRendererManager extends AbstractItemInHandRenderer {
         this.renderers.add(this.crabClawItemRenderer);
         this.extraItemRenderer = new IExtraItemDisplayRenderer(itemRenderer, renderer);
         this.renderers.add(this.extraItemRenderer);
+        this.hasMobBlockItemRenderer = new HasMobBlockItemRenderer(itemRenderer, renderer);
+        this.renderers.add(this.hasMobBlockItemRenderer);
     }
 
     @Override
@@ -56,6 +60,21 @@ public class ItemInHandRendererManager extends AbstractItemInHandRenderer {
                 && !this.mainHandItem.is(ModItems.CRAB_CLAW.get())
         ) {
             this.crabClawItemRenderer.render(
+                player,
+                partialTicks,
+                pitch,
+                hand,
+                swingProgress,
+                stack,
+                equippedProgress,
+                poseStack,
+                buffer,
+                combinedLight,
+                ci
+            );
+        }
+        if (stack.getItem() instanceof HasMobBlockItem) {
+            this.hasMobBlockItemRenderer.render(
                 player,
                 partialTicks,
                 pitch,

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/GuiGraphicsMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/GuiGraphicsMixin.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import dev.dubhe.anvilcraft.client.renderer.item.HasMobBlockItemRenderer;
 import dev.dubhe.anvilcraft.client.renderer.item.IExtraItemDisplayRenderer;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.entity.LivingEntity;
@@ -29,7 +30,13 @@ public abstract class GuiGraphicsMixin {
 
     @Shadow
     protected abstract void renderItem(
-        @Nullable LivingEntity entity, @Nullable Level level, ItemStack stack, int x, int y, int seed, int guiOffset
+        @Nullable LivingEntity entity,
+        @Nullable Level level,
+        ItemStack stack,
+        int x,
+        int y,
+        int seed,
+        int guiOffset
     );
 
     @Inject(
@@ -57,5 +64,6 @@ public abstract class GuiGraphicsMixin {
             ANVILCRAFT$MAX_RECURSION,
             i -> ANVILCRAFT$RECURSION = i
         );
+        HasMobBlockItemRenderer.renderGuiItem(this.pose, stack, x, y);
     }
 }


### PR DESCRIPTION
This pull request introduces a new renderer for items that contain mobs, ensuring that both in-world and GUI rendering of these items display the mob entity correctly. It also integrates this renderer into the item rendering manager and updates the GUI rendering mixin to support mob display in item icons.

**New mob item rendering support:**

* Added `HasMobBlockItemRenderer`, a dedicated renderer for items containing mobs, with methods for rendering both in-hand and in the GUI, including proper scaling and orientation. (`src/main/java/dev/dubhe/anvilcraft/client/renderer/item/HasMobBlockItemRenderer.java`)
* Integrated `HasMobBlockItemRenderer` into `ItemInHandRendererManager`, registering it and ensuring that items of type `HasMobBlockItem` are rendered using the new renderer. (`src/main/java/dev/dubhe/anvilcraft/client/renderer/item/ItemInHandRendererManager.java`) [[1]](diffhunk://#diff-63b29f087a3119509a995a67d18065fd5b8dd7d93e2873a1509d2c717b8d17c6R5) [[2]](diffhunk://#diff-63b29f087a3119509a995a67d18065fd5b8dd7d93e2873a1509d2c717b8d17c6R21-R30) [[3]](diffhunk://#diff-63b29f087a3119509a995a67d18065fd5b8dd7d93e2873a1509d2c717b8d17c6R76-R90)

**GUI rendering improvements:**

* Updated `GuiGraphicsMixin` to call the new renderer's `renderGuiItem` method, allowing mob-containing items to display their mob entity in the GUI. (`src/main/java/dev/dubhe/anvilcraft/mixin/GuiGraphicsMixin.java`) [[1]](diffhunk://#diff-d1f381c1ae9dd475b81967afa0fef0bbc4d2432de98a0a66090115d56a8c5ee4R4) [[2]](diffhunk://#diff-d1f381c1ae9dd475b81967afa0fef0bbc4d2432de98a0a66090115d56a8c5ee4L32-R39) [[3]](diffhunk://#diff-d1f381c1ae9dd475b81967afa0fef0bbc4d2432de98a0a66090115d56a8c5ee4R67)

**Rendering consistency:**

* Adjusted the mob entity scale in `HasMobBlockRenderer` to match the new renderer's scaling logic, ensuring consistent appearance across different contexts. (`src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/HasMobBlockRenderer.java`)