### PR TITLE
Code Review Action Version & Feature Mismatch 代码审查Actions版本和功能不匹配

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: DeepSeek Code Review
-        uses: hustcer/deepseek-review@v1.20
+        uses: hustcer/deepseek-review@main
         with:
           model: "deepseek-v4-flash"
           watch-mention: "@github-actions"


### PR DESCRIPTION
你的cr配置文件中deepseek-review用的版本是v1.20，但是又配置了`$watch-mention`和`$allowed-associations`变量。这是因为README和功能更新了但是没有新的发行版对应这些新功能。
这些新功能是在v1.20发布后添加的(现未发布)的，所以：
<img width="3096" height="1671" alt="Screenshot_20260602_210022" src="https://github.com/user-attachments/assets/d1b2998f-ef33-455f-97da-41de7784434e" />
含有他们的功能还没有发布(v1.21不存在)
可行的方法有（2选1）:
1. 将v1.20改成main，含有已验证可用的最新功能
2. 删除watch-mention等多余变量

我的建议：将其设为main，包括hustcer/deepseek-review仓库的cr也是这样配置的。main分支基本稳定，develop分支是不稳定的