### PR TITLE
Fix bug 修复问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/UnpackCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/anvil/UnpackCategory.java
@@ -47,12 +47,13 @@ public class UnpackCategory extends AbstractProgressCategory<UnpackRecipe> {
         double mouseY
     ) {
         final UnpackRecipe recipe = recipeHolder.value();
-        int anvilYOffset = JeiRenderHelper.getAnvilAnimationOffset(this.timer);
-        RenderSupport.renderBlock(graphics, Blocks.ANVIL.defaultBlockState(), 81, 22 + anvilYOffset, 20);
-        RenderSupport.renderBlock(graphics, Blocks.IRON_TRAPDOOR.defaultBlockState().setValue(TrapDoorBlock.HALF, Half.TOP), 81, 40, 20);
 
         this.arrowIn.draw(graphics, 54, 30);
         this.arrowOutFromBelow.draw(graphics, 92, 29);
+
+        RenderSupport.renderBlock(graphics, Blocks.IRON_TRAPDOOR.defaultBlockState().setValue(TrapDoorBlock.HALF, Half.TOP), 71, 35, 20);
+        int anvilYOffset = JeiRenderHelper.getAnvilAnimationOffset(this.timer);
+        RenderSupport.renderBlock(graphics, Blocks.ANVIL.defaultBlockState(), 71, 17 + anvilYOffset, 20);
 
         JeiSlotUtil.drawInputSlots(graphics, this.slotDefault, recipe.getInputItems().size());
         if (JeiRecipeUtil.isChance(recipe.getResultItems())) {


### PR DESCRIPTION
## 问题描述

在 JEI 拆解配方（Unpack）类别中，有两个视觉问题：

### 1. 渲染层级错误导致动画被遮挡

原代码中铁砧先于铁活板门绘制，而两者使用相同的 z 层级（z=20）。由于 JEI 中同层元素后绘制的在上，铁活板门会绘制在铁砧之上。当铁砧下落动画触发时（`anvilYOffset` 偏移），铁砧会被铁活板门部分遮挡，视觉效果异常。

### 2. 方块图标未居中于输入/输出箭头

输入箭头位于 x=54，输出箭头位于 x=92，两者的中心点为 x=73。原代码中方块（铁砧、铁活板门）位于 x=81，向右偏移了 8px，视觉上不居中。更新为 x=71 后，仅偏移 2px，接近完全居中。

## 变更内容

- 调整渲染顺序：先绘制铁活板门，再绘制铁砧，确保下落动画时铁砧正确显示在上层
- 方块水平位置：x=81 → x=71，更居中于输入/输出箭头
- 方块垂直位置：铁砧 y=22→17、铁活板门 y=40→35，配合水平移动维持合理的视觉间距
- 调整 `anvilYOffset` 声明位置，使其紧邻铁砧渲染调用

## 效果对比

**修正前：**
- 铁砧下落动画时被铁活板门遮挡
- 铁砧和铁活板门图标整体偏右，未居中于箭头

**修正后：**
- 动画时铁砧正确显示在铁活板门上层
- 方块图标居中于输入/输出箭头之间