### PR TITLE
fix: add chunk load guard for commands and network packets / 为命令和网络包添加区块加载保护

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/command/MultiBlockCommand.java
+++ b/src/main/java/dev/dubhe/anvilcraft/command/MultiBlockCommand.java
@@ -36,6 +36,10 @@ public class MultiBlockCommand {
         CommandSourceStack source = ctx.getSource();
         ServerLevel level = source.getLevel();
         BlockPos pos = ctx.getArgument("pos", WorldCoordinates.class).getBlockPos(source);
+        if (!level.isLoaded(pos)) {
+            source.sendFailure(Component.translatable("argument.pos.unloaded").withStyle(ChatFormatting.RED));
+            return 1;
+        }
         BlockState blockState = level.getBlockState(pos);
         if (blockState.getBlock() instanceof AbstractMultiPartBlock<?> multiPartBlock) {
             BlockPos mainPartPos = multiPartBlock.getMainPartPos(pos, blockState);

--- a/src/main/java/dev/dubhe/anvilcraft/command/PowergridCommand.java
+++ b/src/main/java/dev/dubhe/anvilcraft/command/PowergridCommand.java
@@ -26,6 +26,10 @@ public class PowergridCommand {
     private static int showInfo(CommandContext<CommandSourceStack> ctx) {
         BlockPos pos = ctx.getArgument("pos", WorldCoordinates.class).getBlockPos(ctx.getSource());
         ServerLevel level = ctx.getSource().getLevel();
+        if (!level.isLoaded(pos)) {
+            ctx.getSource().sendFailure(Component.translatable("argument.pos.unloaded").withStyle(ChatFormatting.RED));
+            return 1;
+        }
         AtomicInteger returnValue = new AtomicInteger(0);
         Runnable notFound =  () -> ctx.getSource().sendFailure(Component.translatable(
             "command.anvilcraft.powergrid.info.not_found",

--- a/src/main/java/dev/dubhe/anvilcraft/network/BatchCutterSelectPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/BatchCutterSelectPacket.java
@@ -32,8 +32,13 @@ public record BatchCutterSelectPacket(int selecting, BlockPos pos) implements II
     @Override
     public void handleOnBothSide(Player player) {
         Level level = player.level();
+        if (!level.isLoaded(this.pos)) {
+            return;
+        }
         Optional<BatchCutterBlockEntity> be = level.getBlockEntity(this.pos, ModBlockEntities.BATCH_CUTTER.get());
-        if (be.isEmpty()) return;
+        if (be.isEmpty()) {
+            return;
+        }
         be.get().setSelecting(this.selecting);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/network/DragonRodDevourPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/DragonRodDevourPacket.java
@@ -36,6 +36,9 @@ public record DragonRodDevourPacket(InteractionHand hand, BlockPos pos, Directio
     public void handleOnServer(Player player) {
         ServerPlayer serverside = Util.cast(player);
         ServerLevel level = serverside.serverLevel();
+        if (!level.isLoaded(this.pos)) {
+            return;
+        }
         DragonRodItem.devourBlock(
             level,
             player,

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -35,7 +35,9 @@ public record HammerChangeBlockPacket(BlockPos pos, BlockState state) implements
     @Override
     public void handleOnServer(Player player) {
         Level level = player.level();
-        if (!level.isLoaded(this.pos)) return;
+        if (!level.isLoaded(this.pos)) {
+            return;
+        }
         BlockState blockState = level.getBlockState(this.pos);
         boolean stateVerified = StateUtil.verifyPossibleStatesForProperty(blockState, this.state);
         boolean hasHammer = player.getMainHandItem().getItem() instanceof AnvilHammerItem

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeFlexibleMultiPartBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeFlexibleMultiPartBlockPacket.java
@@ -37,7 +37,9 @@ public record HammerChangeFlexibleMultiPartBlockPacket(BlockPos pos, BlockState 
     @Override
     public void handleOnServer(Player player) {
         Level level = player.level();
-        if (!level.isLoaded(this.pos)) return;
+        if (!level.isLoaded(this.pos)) {
+            return;
+        }
         if (!(this.state.getBlock() instanceof FlexibleMultiPartBlock<?, ?, ?> block)) return;
         if (this.direction == null) return;
         block.change(

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerUsePacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerUsePacket.java
@@ -36,6 +36,9 @@ public record HammerUsePacket(BlockPos pos, InteractionHand hand, BlockHitResult
     @Override
     public void handleOnServer(Player player) {
         ServerPlayer serverside = Util.cast(player);
+        if (!serverside.serverLevel().isLoaded(this.pos)) {
+            return;
+        }
         ItemStack itemInHand = serverside.getItemInHand(this.hand);
         AnvilHammerItem.useBlock(serverside, this.pos, serverside.serverLevel(), itemInHand, this.hand, this.result);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/network/HeliostatsIrradiationPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HeliostatsIrradiationPacket.java
@@ -47,6 +47,9 @@ public record HeliostatsIrradiationPacket(BlockPos pos, @Nullable BlockPos irrit
 
     @Override
     public void handleOnServer(Player player) {
+        if (!player.level().isLoaded(this.pos)) {
+            return;
+        }
         if (!(player.level().getBlockEntity(this.pos) instanceof HeliostatsBlockEntity heliostats)) return;
         PacketDistributor.sendToPlayer(
             Util.cast(player),

--- a/src/main/java/dev/dubhe/anvilcraft/network/SilencerSyncPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/SilencerSyncPacket.java
@@ -32,6 +32,9 @@ public record SilencerSyncPacket(BlockPos pos, List<ResourceLocation> sounds) im
 
     @Override
     public void handleOnBothSide(Player player) {
+        if (!player.level().isLoaded(this.pos)) {
+            return;
+        }
         BlockEntity entity = player.level().getBlockEntity(this.pos);
         if (entity instanceof ActiveSilencerBlockEntity silencer) {
             silencer.sync(player, this.sounds);


### PR DESCRIPTION
## Changes

### fix: add chunk load guard for command files
为 `MultiBlockCommand` 和 `PowergridCommand` 在访问方块前增加 `level.isLoaded(pos)` 检查，防止操作未加载区块时触发加载。

### fix: add chunk load guard for network packets
在 7 个网络包处理器（`BatchCutterSelectPacket`, `DragonRodDevourPacket`, `HammerChangeBlockPacket`, `HammerChangeFlexibleMultiPartBlockPacket`, `HammerUsePacket`, `HeliostatsIrradiationPacket`, `SilencerSyncPacket`）中添加 `level.isLoaded(pos)` 保护，防止对未加载区块的操作引起加载区块。

## 文件变更
- 9 files, +32/-3