### PR TITLE
Modify the text in the smart block placer placement mode 修改玉（Jade）的智能方块放置器模式文本

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -1414,7 +1414,7 @@
   "tooltip.anvilcraft.smart_block_placer.jade.missing.stop": "doʇS",
   "tooltip.anvilcraft.smart_block_placer.jade.missing_mode": "%s :ǝpoW ᵷuᴉssᴉW",
   "tooltip.anvilcraft.smart_block_placer.jade.mode.blueprint": "ʇuᴉɹdǝnꞁᗺ",
-  "tooltip.anvilcraft.smart_block_placer.jade.mode.normal": "ꞁɐɯɹoN",
+  "tooltip.anvilcraft.smart_block_placer.jade.mode.normal": "ʇuᴉoԀ",
   "tooltip.anvilcraft.smart_block_placer.jade.operation_mode": "%s :ǝpoW uoᴉʇɐɹǝdO",
   "tooltip.anvilcraft.smart_block_placer.jade.placement.move": "ǝʌoW",
   "tooltip.anvilcraft.smart_block_placer.jade.placement.pickup": "dnʞɔᴉԀ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -1414,7 +1414,7 @@
   "tooltip.anvilcraft.smart_block_placer.jade.missing.stop": "Stop",
   "tooltip.anvilcraft.smart_block_placer.jade.missing_mode": "Missing Mode: %s",
   "tooltip.anvilcraft.smart_block_placer.jade.mode.blueprint": "Blueprint",
-  "tooltip.anvilcraft.smart_block_placer.jade.mode.normal": "Normal",
+  "tooltip.anvilcraft.smart_block_placer.jade.mode.normal": "Point",
   "tooltip.anvilcraft.smart_block_placer.jade.operation_mode": "Operation Mode: %s",
   "tooltip.anvilcraft.smart_block_placer.jade.placement.move": "Move",
   "tooltip.anvilcraft.smart_block_placer.jade.placement.pickup": "Pickup",

--- a/src/generated/resources/data/anvilcraft/tags/item/heaters.json
+++ b/src/generated/resources/data/anvilcraft/tags/item/heaters.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "anvilcraft:burning_heater"
-  ]
-}

--- a/src/generated/resources/data/c/tags/item/heaters.json
+++ b/src/generated/resources/data/c/tags/item/heaters.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "anvilcraft:burning_heater"
-  ]
-}

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/JadeLang.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/JadeLang.java
@@ -26,7 +26,7 @@ public class JadeLang {
         provider.add("tooltip.anvilcraft.burning_heater.jade.can_smelt.no", "No");
 
         provider.add("tooltip.anvilcraft.smart_block_placer.jade.operation_mode", "Operation Mode: %s");
-        provider.add("tooltip.anvilcraft.smart_block_placer.jade.mode.normal", "Normal");
+        provider.add("tooltip.anvilcraft.smart_block_placer.jade.mode.normal", "Point");
         provider.add("tooltip.anvilcraft.smart_block_placer.jade.mode.blueprint", "Blueprint");
         provider.add("tooltip.anvilcraft.smart_block_placer.jade.placement_mode", "Placement Mode: %s");
         provider.add("tooltip.anvilcraft.smart_block_placer.jade.placement.pickup", "Pickup");


### PR DESCRIPTION
- 将英文语言文件中“normal”模式文本由“Normal”改为“Point”
- 修改en_ud语言文件中对应文本，由倒置的“Normal”改为倒置的“Point”
- 更新Java代码中对应的语言提供器文本，保持一致
- 删除两个位置的heaters.json标签文件，移除相关条目