### PR TITLE
Added Advancements to Smart Block Placer 添加智能方块放置器进度及触发器

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -71,6 +71,8 @@
   "advancements.anvilcraft.overseer.title": "ʎꞁpnoꞁ pǝʇnoɥs uɐɯǝɹoɟ ǝɥ⟘",
   "advancements.anvilcraft.placer.description": "ɹǝɔɐꞁd ʞɔoꞁq ǝɥʇ ǝɔɐꞁd oʇ ɹǝɔɐꞁd ʞɔoꞁq ǝɥʇ ǝs∩",
   "advancements.anvilcraft.placer.title": "ɹǝɔɐꞁd ǝɔɐꞁd ɹǝɔɐꞁԀ",
+  "advancements.anvilcraft.placer_shuttle.description": "ɥʇɹoɟ puɐ ʞɔɐq ʞɔoꞁq ɐ ǝʌoɯ sɹǝɔɐꞁd ʞɔoꞁq ʇɹɐɯs oʍʇ ǝʞɐW",
+  "advancements.anvilcraft.placer_shuttle.title": "ʇɔǝɟɟƎ ᵷuoԀ ᵷuᴉԀ",
   "advancements.anvilcraft.real_looting.description": "ɯǝʇᴉ doɹp ǝɹoɯ uᴉɐʇqo puɐ qoɯ ɥsɐɯs oʇ ꞁᴉʌuɐ uɐ ǝs∩",
   "advancements.anvilcraft.real_looting.title": "ᵷuᴉʇooꞁ ꞁɐǝɹ ǝɥ⟘",
   "advancements.anvilcraft.recycling_diamonds.description": "ɯɹoɟʇɐꞁd ᵷuᴉɥsnɹɔ ǝɥʇ uo spuoɯɐᴉp ᵷuᴉɥsɐɯs ɹoɟ ʇuǝɯdᴉnbǝ puɐ sꞁoo⟘",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -71,6 +71,8 @@
   "advancements.anvilcraft.overseer.title": "The foreman shouted loudly",
   "advancements.anvilcraft.placer.description": "Use the block placer to place the block placer",
   "advancements.anvilcraft.placer.title": "Placer place placer",
+  "advancements.anvilcraft.placer_shuttle.description": "Make two smart block placers move a block back and forth",
+  "advancements.anvilcraft.placer_shuttle.title": "Ping Pong Effect",
   "advancements.anvilcraft.real_looting.description": "Use an anvil to smash mob and obtain more drop item",
   "advancements.anvilcraft.real_looting.title": "The real looting",
   "advancements.anvilcraft.recycling_diamonds.description": "Tools and equipment for smashing diamonds on the crushing platform",

--- a/src/generated/resources/data/anvilcraft/advancement/anvilcraft/placer_shuttle.json
+++ b/src/generated/resources/data/anvilcraft/advancement/anvilcraft/placer_shuttle.json
@@ -1,0 +1,27 @@
+{
+  "parent": "anvilcraft:anvilcraft/block_devourer",
+  "criteria": {
+    "placer_shuttle": {
+      "trigger": "anvilcraft:placer_shuttle"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "advancements.anvilcraft.placer_shuttle.description"
+    },
+    "frame": "goal",
+    "icon": {
+      "count": 1,
+      "id": "anvilcraft:smart_block_placer"
+    },
+    "title": {
+      "translate": "advancements.anvilcraft.placer_shuttle.title"
+    }
+  },
+  "requirements": [
+    [
+      "placer_shuttle"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/src/main/java/dev/dubhe/anvilcraft/advancements/criterion/PlacerShuttleTrigger.java
+++ b/src/main/java/dev/dubhe/anvilcraft/advancements/criterion/PlacerShuttleTrigger.java
@@ -1,0 +1,39 @@
+package dev.dubhe.anvilcraft.advancements.criterion;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.dubhe.anvilcraft.init.ModCriterionTriggers;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.critereon.ContextAwarePredicate;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Optional;
+
+public class PlacerShuttleTrigger extends SimpleCriterionTrigger<PlacerShuttleTrigger.TriggerInstance> {
+    @Override
+    public Codec<TriggerInstance> codec() {
+        return TriggerInstance.CODEC;
+    }
+
+    public void trigger(ServerPlayer player) {
+        this.trigger(player, TriggerInstance::matches);
+    }
+
+    public record TriggerInstance(Optional<ContextAwarePredicate> player) implements SimpleInstance {
+        public static final Codec<TriggerInstance> CODEC = RecordCodecBuilder.create((instance) -> instance.group(
+            EntityPredicate.ADVANCEMENT_CODEC.optionalFieldOf("player").forGetter(TriggerInstance::player)
+        ).apply(instance, TriggerInstance::new));
+
+        public static Criterion<TriggerInstance> shuttle() {
+            return ModCriterionTriggers.PLACER_SHUTTLE.get().createCriterion(
+                new TriggerInstance(Optional.empty())
+            );
+        }
+
+        public boolean matches() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/advancement/AdvancementLineHelper.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/advancement/AdvancementLineHelper.java
@@ -17,6 +17,7 @@ import dev.dubhe.anvilcraft.advancements.criterion.MagnetLiftingAnvilTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.MilkTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.MineralFountainCreateTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.PlacerPlaceTrigger;
+import dev.dubhe.anvilcraft.advancements.criterion.PlacerShuttleTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.PlayerKilledEntityByAnvilHammerTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.PlayerWearAnvilHammerTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.UseItemTrigger;
@@ -358,6 +359,10 @@ public class AdvancementLineHelper {
 
         public AdvancementHelper mineralFountainCreate(String key) {
             return this.addCriterion(key, MineralFountainCreateTrigger.TriggerInstance.create());
+        }
+
+        public AdvancementHelper placerShuttle(String key) {
+            return this.addCriterion(key, PlacerShuttleTrigger.TriggerInstance.shuttle());
         }
 
         public AdvancementHolder build(String id) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/SmartBlockPlacerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/SmartBlockPlacerBlockEntity.java
@@ -26,6 +26,7 @@ import dev.dubhe.anvilcraft.inventory.SmartBlockPlacerMenu;
 import dev.dubhe.anvilcraft.item.property.component.StructureDiskData;
 import dev.dubhe.anvilcraft.util.StructureBookUtil;
 import dev.dubhe.anvilcraft.util.StructureLoadUtil;
+import dev.dubhe.anvilcraft.util.TriggerUtil;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.core.BlockPos;
@@ -248,6 +249,10 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
 
     // 比较器信号状态
     private int lastComparatorSignal = 0;
+
+    // 穿梭进度：记录预期邻居放置到的目标位置，邻居完成放置后触发进度
+    @Nullable
+    private BlockPos expectedShuttleTarget = null;
 
 
     @SuppressWarnings("checkstyle:EmptyLineSeparator")
@@ -905,6 +910,9 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
             if (shutdownIndexReset) {
                 this.currentPlacementIndex = 0;
             }
+
+            // 停止工作时清除穿梭预期标记
+            this.expectedShuttleTarget = null;
 
             // 断电时也更新缺失方块信息（清空显示）
             if (!level.isClientSide) {
@@ -1728,10 +1736,87 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
                 // 在目标位置发送方块更新通知，让红石灯等方块根据新位置的红石信号更新状态
                 level.neighborChanged(targetPos, stateToPlace.getBlock(), targetPos);
 
+                // 检查是否是穿梭进度的回程：放置到了预期的穿梭目标位置
+                if (targetPos.equals(this.expectedShuttleTarget)) {
+                    TriggerUtil.placerShuttle(level, targetPos);
+                    this.expectedShuttleTarget = null;
+                }
+
+                // 检测穿梭行为：当前放置器的目标位置是否是另一个放置器的源位置
+                checkAndTriggerShuttle(level, targetPos);
+
                 this.currentHeldBlock = ItemStack.EMPTY;
                 return false;
             }
         );
+    }
+
+    /**
+     * 检测并触发穿梭进度：双向判定两个放置器是否在来回移动同一个方块
+     * 条件1：邻居放置器的源位置 == 当前放置器的目标位置
+     * 条件2：当前放置器的源位置在邻居放置器的目标点位中
+     */
+    private void checkAndTriggerShuttle(Level level, BlockPos targetPos) {
+        // 计算当前放置器的源位置
+        BlockPos myPos = this.getBlockPos();
+        BlockState myState = level.getBlockState(myPos);
+        Direction myFacing = myState.getValue(HorizontalDirectionalBlock.FACING);
+        BlockPos mySource = myPos.relative(myFacing.getOpposite());
+
+        for (Direction dir : Direction.values()) {
+            BlockPos neighborPos = targetPos.relative(dir);
+            BlockEntity neighborEntity = level.getBlockEntity(neighborPos);
+            if (neighborEntity instanceof SmartBlockPlacerBlockEntity neighborPlacer) {
+                // 邻居放置器必须处于MOVE模式（非蓝图、非pickup）且已设置点位
+                boolean isBlueprint = neighborPlacer.loadedStructure != null
+                    && !neighborPlacer.loadedStructure.isEmpty();
+                if (isBlueprint || neighborPlacer.isPickupMode
+                    || neighborPlacer.layerPositions.isEmpty()) {
+                    continue;
+                }
+                BlockState neighborState = level.getBlockState(neighborPos);
+                Direction neighborFacing = neighborState.getValue(HorizontalDirectionalBlock.FACING);
+                BlockPos neighborSource = neighborPos.relative(neighborFacing.getOpposite());
+
+                // 条件1：邻居的源位置 == 当前的目标位置
+                if (!neighborSource.equals(targetPos)) {
+                    continue;
+                }
+
+                // 条件2：当前放置器的源位置在邻居的目标点位中
+                if (!isMySourceInNeighborTargets(level, neighborPlacer,
+                    neighborPos, neighborFacing, mySource)) {
+                    continue;
+                }
+
+                // 双向匹配，在邻居放置器上设置预期目标，等邻居完成放置时触发
+                neighborPlacer.expectedShuttleTarget = mySource;
+                return;
+            }
+        }
+    }
+
+    /**
+     * 检查指定位置是否在邻居放置器的目标点位中
+     */
+    private boolean isMySourceInNeighborTargets(Level level,
+                                                 SmartBlockPlacerBlockEntity neighborPlacer,
+                                                 BlockPos neighborPos, Direction neighborFacing,
+                                                 BlockPos mySource) {
+        BlockPos basePos = neighborPos.relative(neighborFacing.getOpposite(), -4);
+        boolean upsideDown = level.getBlockState(neighborPos).getValue(SmartBlockPlacerBlock.UPSIDE_DOWN);
+
+        for (var entry : neighborPlacer.layerPositions.entrySet()) {
+            int layer = entry.getKey();
+            for (int position : entry.getValue()) {
+                BlockPos neighborTarget = calculateTargetPosition(
+                    basePos, neighborFacing, position / 5, position % 5, layer, upsideDown);
+                if (neighborTarget.equals(mySource)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -3563,6 +3648,7 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
 
     public void setPickupMode(boolean pickupMode) {
         this.isPickupMode = pickupMode;
+        this.expectedShuttleTarget = null;
         this.onChanged();
     }
 
@@ -3572,6 +3658,7 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
     }
 
     public void togglePosition(int layer, int position, boolean selected) {
+        this.expectedShuttleTarget = null;
         Set<Integer> positions = layerPositions.computeIfAbsent(layer, k -> new HashSet<>());
         if (selected) {
             positions.add(position);
@@ -3672,6 +3759,7 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity implements IPowerCo
         this.currentPlacementIndex = tag.getInt("currentPlacementIndex");
         this.isPickupMode = tag.getBoolean("isPickupMode");
         this.loadLayerPositions(tag);
+        this.expectedShuttleTarget = null;
         this.onChanged();
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/AdvancementLang.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/AdvancementLang.java
@@ -19,6 +19,9 @@ public class AdvancementLang {
 
         provider.add("advancements.anvilcraft.devourer.title", "Too many tongue twisters");
         provider.add("advancements.anvilcraft.devourer.description", "Use the block devourer to devour the block devourer");
+
+        provider.add("advancements.anvilcraft.placer_shuttle.title", "Ping Pong Effect");
+        provider.add("advancements.anvilcraft.placer_shuttle.description", "Make two smart block placers move a block back and forth");
         // endregion
 
         // region geode line

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModAdvancements.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModAdvancements.java
@@ -24,6 +24,7 @@ public class ModAdvancements {
     public static final AdvancementHolder CRAB_CLAW;
     public static final AdvancementHolder PLACER;
     public static final AdvancementHolder DEVOURER;
+    public static final AdvancementHolder PLACER_SHUTTLE;
 
     public static final AdvancementHolder GEODE;
     public static final AdvancementHolder AMETHYST_PICKAXE;
@@ -137,6 +138,19 @@ public class ModAdvancements {
             )
             .devourerDevour("devourer_devour_devourer", ModBlocks.BLOCK_DEVOURER)
             .build("block_devourer");
+        PLACER_SHUTTLE = clawLine.next()
+            .display(
+                ModBlocks.SMART_BLOCK_PLACER.asItem(),
+                Component.translatable("advancements.anvilcraft.placer_shuttle.title"),
+                Component.translatable("advancements.anvilcraft.placer_shuttle.description"),
+                null,
+                AdvancementType.GOAL,
+                true,
+                true,
+                false
+            )
+            .placerShuttle("placer_shuttle")
+            .build("placer_shuttle");
 
         AdvancementLineHelper geodeLine = mainLine.createBranch();
         GEODE = geodeLine.next()

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModCriterionTriggers.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModCriterionTriggers.java
@@ -16,6 +16,7 @@ import dev.dubhe.anvilcraft.advancements.criterion.MagnetLiftingAnvilTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.MilkTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.MineralFountainCreateTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.PlacerPlaceTrigger;
+import dev.dubhe.anvilcraft.advancements.criterion.PlacerShuttleTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.PlayerKilledEntityByAnvilHammerTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.PlayerWearAnvilHammerTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.UseItemTrigger;
@@ -102,6 +103,11 @@ public class ModCriterionTriggers {
     public static final DeferredHolder<CriterionTrigger<?>, HeatCollectorTrigger> HEAT_COLLECTOR_COLLECT = REGISTER.register(
         "heat_collector_collect",
         HeatCollectorTrigger::new
+    );
+
+    public static final DeferredHolder<CriterionTrigger<?>, PlacerShuttleTrigger> PLACER_SHUTTLE = REGISTER.register(
+        "placer_shuttle",
+        PlacerShuttleTrigger::new
     );
 
     public static final DeferredHolder<CriterionTrigger<?>, MineralFountainCreateTrigger> MINERAL_FOUNTAIN_CREATE = REGISTER.register(

--- a/src/main/java/dev/dubhe/anvilcraft/util/TriggerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/TriggerUtil.java
@@ -152,4 +152,12 @@ public class TriggerUtil {
             }
         }
     }
+
+    public static void placerShuttle(Level level, BlockPos pos) {
+        if (!level.isClientSide) {
+            for (ServerPlayer player : PlayerUtil.searchPlayerByPos(level, pos, 7)) {
+                ModCriterionTriggers.PLACER_SHUTTLE.get().trigger(player);
+            }
+        }
+    }
 }


### PR DESCRIPTION
- 新增placer_shuttle成就，描述智能方块放置器来回移动方块的效果
- 实现PlacerShuttleTrigger触发器和对应的判定逻辑
- 在SmartBlockPlacerBlockEntity中新增穿梭目标位置记录与检测方法
- 增加穿梭完成时触发成就进度的机制
- 更新语言文件，添加穿梭成就的标题与描述
- 在ModAdvancements注册并构建穿梭成就实例
- 修改TriggerUtil以支持穿梭触发逻辑
- 在Json资源中添加穿梭成就配置文件