### PR TITLE
Fix direction of model of redstone computer 修复红石计算机模型的显示方向

### DIFF
--- a/src/main/resources/assets/anvilcraft/models/block/redstone_computer.json
+++ b/src/main/resources/assets/anvilcraft/models/block/redstone_computer.json
@@ -53,34 +53,34 @@
 			"scale": [1.5, 1.5, 1.5]
 		},
 		"gui": {
-			"rotation": [ 30, 45, 0 ],
-			"translation": [ 0, 0, 0],
-			"scale":[ 0.625, 0.625, 0.625 ]
+			"rotation": [30, 45, 0],
+			"translation": [0, 0, 0],
+			"scale":[0.625, 0.625, 0.625]
 		},
 		"ground": {
-			"rotation": [ 0, 180, 0 ],
-			"translation": [ 0, 3, 0],
-			"scale":[ 0.25, 0.25, 0.25 ]
+			"rotation": [0, 180, 0],
+			"translation": [0, 3, 0],
+			"scale":[0.25, 0.25, 0.25]
 		},
 		"fixed": {
-			"rotation": [ 0, 180, 0 ],
-			"translation": [ 0, 0, 0],
-			"scale":[ 0.5, 0.5, 0.5 ]
+			"rotation": [0, 180, 0],
+			"translation": [0, 0, 0],
+			"scale":[0.5, 0.5, 0.5]
 		},
 		"thirdperson_righthand": {
-			"rotation": [ 75, 225, 0 ],
-			"translation": [ 0, 2.5, 0],
-			"scale": [ 0.375, 0.375, 0.375 ]
+			"rotation": [75, 225, 0],
+			"translation": [0, 2.5, 0],
+			"scale": [0.375, 0.375, 0.375]
 		},
 		"firstperson_righthand": {
-			"rotation": [ 0, 45, 0 ],
-			"translation": [ 0, 0, 0 ],
-			"scale": [ 0.40, 0.40, 0.40 ]
+			"rotation": [0, 45, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.40, 0.40, 0.40]
 		},
 		"firstperson_lefthand": {
-			"rotation": [ 0, 225, 0 ],
-			"translation": [ 0, 0, 0 ],
-			"scale": [ 0.40, 0.40, 0.40 ]
+			"rotation": [0, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.40, 0.40, 0.40]
 		}
 	}
 }

--- a/src/main/resources/assets/anvilcraft/models/block/redstone_computer.json
+++ b/src/main/resources/assets/anvilcraft/models/block/redstone_computer.json
@@ -55,17 +55,17 @@
 		"gui": {
 			"rotation": [30, 45, 0],
 			"translation": [0, 0, 0],
-			"scale":[0.625, 0.625, 0.625]
+			"scale": [0.625, 0.625, 0.625]
 		},
 		"ground": {
 			"rotation": [0, 180, 0],
 			"translation": [0, 3, 0],
-			"scale":[0.25, 0.25, 0.25]
+			"scale": [0.25, 0.25, 0.25]
 		},
 		"fixed": {
 			"rotation": [0, 180, 0],
 			"translation": [0, 0, 0],
-			"scale":[0.5, 0.5, 0.5]
+			"scale": [0.5, 0.5, 0.5]
 		},
 		"thirdperson_righthand": {
 			"rotation": [75, 225, 0],

--- a/src/main/resources/assets/anvilcraft/models/block/redstone_computer.json
+++ b/src/main/resources/assets/anvilcraft/models/block/redstone_computer.json
@@ -51,6 +51,36 @@
 		"head": {
 			"translation": [0, 6, 0],
 			"scale": [1.5, 1.5, 1.5]
+		},
+		"gui": {
+			"rotation": [ 30, 45, 0 ],
+			"translation": [ 0, 0, 0],
+			"scale":[ 0.625, 0.625, 0.625 ]
+		},
+		"ground": {
+			"rotation": [ 0, 180, 0 ],
+			"translation": [ 0, 3, 0],
+			"scale":[ 0.25, 0.25, 0.25 ]
+		},
+		"fixed": {
+			"rotation": [ 0, 180, 0 ],
+			"translation": [ 0, 0, 0],
+			"scale":[ 0.5, 0.5, 0.5 ]
+		},
+		"thirdperson_righthand": {
+			"rotation": [ 75, 225, 0 ],
+			"translation": [ 0, 2.5, 0],
+			"scale": [ 0.375, 0.375, 0.375 ]
+		},
+		"firstperson_righthand": {
+			"rotation": [ 0, 45, 0 ],
+			"translation": [ 0, 0, 0 ],
+			"scale": [ 0.40, 0.40, 0.40 ]
+		},
+		"firstperson_lefthand": {
+			"rotation": [ 0, 225, 0 ],
+			"translation": [ 0, 0, 0 ],
+			"scale": [ 0.40, 0.40, 0.40 ]
 		}
 	}
 }


### PR DESCRIPTION
- 修复了红石计算机模型的显示方向，使之在GUI、物品展示框中能看到正面，加强辨识度。
<img width="1182" height="1033" alt="image" src="https://github.com/user-attachments/assets/c3f44804-09e5-4761-b0d5-1de4057790a7" />
