### PR TITLE
Neoforge can be removed by hammer. 支持NeoforgeBlock通过锤子移除

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/NeoforgeBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/NeoforgeBlock.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.block;
 
 import com.mojang.serialization.MapCodec;
+import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.block.better.BetterAnvilBlock;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.inventory.NeoforgeMenu;
@@ -32,7 +33,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
-public class NeoforgeBlock extends BetterAnvilBlock {
+public class NeoforgeBlock extends BetterAnvilBlock implements IHammerRemovable {
     private static final VoxelShape BASE = Block.box(2.0, 0.0, 2.0, 14.0, 4.0, 14.0);
     private static final VoxelShape X_LEG1 = Block.box(4.0, 4.0, 5.0, 12.0, 10.0, 11.0);
     private static final VoxelShape X_TOP = Block.box(0.0, 10.0, 3.0, 16.0, 16.0, 13.0);


### PR DESCRIPTION
- 让NeoforgeBlock实现IHammerRemovable接口
- 添加锤子可移除功能以增强交互性
- 保持与BetterAnvilBlock的继承关系不变