### PR TITLE
Optimize the rendering of ground-shaking bouncing blocks and add blocks to the blacklist. 优化26.1的弹跳方块渲染并添加黑名单

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/event/SeismicBounceRenderEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/SeismicBounceRenderEventListener.java
@@ -2,8 +2,7 @@ package dev.dubhe.anvilcraft.client.event;
 
 import dev.dubhe.anvilcraft.client.support.SeismicBounceManager;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.ModelBlockRenderer;
-import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.client.renderer.block.MovingBlockRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
@@ -11,16 +10,16 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.SubmitCustomGeometryEvent;
-import org.jetbrains.annotations.Nullable;
 
 /**
- * 震波弹跳渲染 —— ModelBlockRenderer.tesselateBlock 直通 SectionCompiler 的光照管线。
+ * 震波弹跳渲染 —— 直接获取原版光照管线。
+ *
+ * <p>
+ * 因为 {@code submitMovingBlock} 会把模型里的 quad 按材质层 (SOLID / CUTOUT / TRANSLUCENT)
+ * 分发到正确的 RenderPipeline，所以同时支持实体方块、裁剪方块以及透明方块。
  */
 @EventBusSubscriber(modid = "anvilcraft", value = Dist.CLIENT)
 public class SeismicBounceRenderEventListener {
-
-    @Nullable
-    private static ModelBlockRenderer blockRenderer;
 
     @SubscribeEvent
     public static void onRender(SubmitCustomGeometryEvent event) {
@@ -31,10 +30,6 @@ public class SeismicBounceRenderEventListener {
         double camY = event.getLevelRenderState().cameraRenderState.pos.y();
         double camZ = event.getLevelRenderState().cameraRenderState.pos.z();
         float partialTick = mc.getDeltaTracker().getGameTimeDeltaPartialTick(false);
-
-        if (blockRenderer == null) {
-            blockRenderer = new ModelBlockRenderer(true, false, mc.getBlockColors());
-        }
 
         var poseStack = event.getPoseStack();
         var nodeCollector = event.getSubmitNodeCollector();
@@ -49,8 +44,14 @@ public class SeismicBounceRenderEventListener {
             BlockState state = mc.level.getBlockState(pos);
             if (state.isAir() || state.getRenderShape() != RenderShape.MODEL) continue;
 
-            var model = mc.getModelManager().getBlockStateModelSet().get(state);
-            long seed = state.getSeed(pos);
+            // 构造 MovingBlockRenderState
+            MovingBlockRenderState renderState = new MovingBlockRenderState();
+            renderState.randomSeedPos = pos;
+            renderState.blockPos = pos;
+            renderState.blockState = state;
+            renderState.biome = mc.level.getBiome(pos);
+            renderState.cardinalLighting = mc.level.cardinalLighting();
+            renderState.lightEngine = mc.level.getLightEngine();
 
             poseStack.pushPose();
             poseStack.translate(pos.getX() - camX, pos.getY() - camY + offsetY, pos.getZ() - camZ);
@@ -58,16 +59,7 @@ public class SeismicBounceRenderEventListener {
             poseStack.scale(1.0005f, 1.000f, 1.0005f);
             poseStack.translate(-0.5, -0.5, -0.5);
 
-            final var finalModel = model;
-            final long finalSeed = seed;
-
-            nodeCollector.submitCustomGeometry(poseStack, RenderTypes.solidMovingBlock(), (pose, consumer) ->
-                blockRenderer.tesselateBlock(
-                    (x, y, z, quad, instance) -> consumer.putBakedQuad(pose, quad, instance),
-                    0, 0, 0,
-                    mc.level, pos, state, finalModel, finalSeed
-                )
-            );
+            nodeCollector.submitMovingBlock(poseStack, renderState);
 
             poseStack.popPose();
         }

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/SeismicBounceManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/SeismicBounceManager.java
@@ -50,8 +50,8 @@ public class SeismicBounceManager {
             || state.is(BlockTags.CANDLE_CAKES)
             || state.is(BlockTags.ANVIL)
             || state.is(Blocks.BEDROCK)
-            || state.is(Blocks.REDSTONE_BLOCK)
-            || state.getBlock() instanceof RedStoneWireBlock;
+            || state.is(Blocks.REDSTONE_WIRE)
+            || state.is(Blocks.REPEATER);
     }
 
     @Getter

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/SeismicBounceManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/SeismicBounceManager.java
@@ -4,8 +4,11 @@ import dev.dubhe.anvilcraft.client.event.SeismicBounceRenderEventListener;
 import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RedStoneWireBlock;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -24,6 +27,32 @@ public class SeismicBounceManager {
     private static final int BOUNCE_DURATION_TICKS = 16;
     private static final float MAX_AMPLITUDE = 0.85f;
     private static final int CENTER_EXCLUSION_RADIUS = 1;
+
+    /**
+     * 黑名单方块
+     */
+    private static boolean isAttachmentBlock(BlockState state) {
+        return state.is(BlockTags.BUTTONS)
+            || state.is(BlockTags.PRESSURE_PLATES)
+            || state.is(BlockTags.ALL_SIGNS)
+            || state.is(BlockTags.BANNERS)
+            || state.is(BlockTags.FLOWERS)
+            || state.is(BlockTags.SAPLINGS)
+            || state.is(BlockTags.CROPS)
+            || state.is(BlockTags.RAILS)
+            || state.is(BlockTags.CLIMBABLE)
+            || state.is(BlockTags.CANDLES)
+            || state.is(BlockTags.WOOL_CARPETS)
+            || state.is(BlockTags.FIRE)
+            || state.is(BlockTags.WALL_POST_OVERRIDE)
+            || state.is(BlockTags.CAVE_VINES)
+            || state.is(BlockTags.FLOWER_POTS)
+            || state.is(BlockTags.CANDLE_CAKES)
+            || state.is(BlockTags.ANVIL)
+            || state.is(Blocks.BEDROCK)
+            || state.is(Blocks.REDSTONE_BLOCK)
+            || state.getBlock() instanceof RedStoneWireBlock;
+    }
 
     @Getter
     private final Map<BlockPos, BounceData> activeBounces = new ConcurrentHashMap<>();
@@ -51,7 +80,8 @@ public class SeismicBounceManager {
                 if (!state.isAir()
                     && state.getRenderShape() == RenderShape.MODEL
                     && level.isEmptyBlock(pos.above())
-                    && level.getBlockEntity(pos) == null) {
+                    && level.getBlockEntity(pos) == null
+                    && !isAttachmentBlock(state)) {
                     float amplitude = MAX_AMPLITUDE * (1.0f - (float) dist / radius)
                         * (0.8f + this.tesselateRandom.nextFloat() * 0.4f);
                     amplitude = Math.max(amplitude, 0.15f);


### PR DESCRIPTION
- 添加黑名单方块判断以过滤不适合弹跳效果的附属方块
- 修正弹跳管理器，仅对非黑名单方块进行震波弹跳计算
- 替换震波渲染逻辑，使用原版光照管线的MovingBlockRenderState
- 移除对ModelBlockRenderer的依赖，支持实体、裁剪及透明方块的渲染
- 简化震波渲染事件的代码结构，提高可维护性