### PR TITLE
Add the 1.21.1 version of “Earth-Shaking Bouncing Blocks” to the blocklist. 添加1.21.1版本的撼地弹跳方块黑名单

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/support/SeismicBounceManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/SeismicBounceManager.java
@@ -7,8 +7,10 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.RenderTypeHelper;
@@ -24,6 +26,32 @@ public class SeismicBounceManager {
     private static final int BOUNCE_DURATION_TICKS = 16;
     private static final float MAX_AMPLITUDE = 0.85f;
     private static final int CENTER_EXCLUSION_RADIUS = 1;
+
+    /**
+     * 黑名单方块
+     */
+    private static boolean isAttachmentBlock(BlockState state) {
+        return state.is(BlockTags.BUTTONS)
+            || state.is(BlockTags.PRESSURE_PLATES)
+            || state.is(BlockTags.ALL_SIGNS)
+            || state.is(BlockTags.BANNERS)
+            || state.is(BlockTags.FLOWERS)
+            || state.is(BlockTags.SAPLINGS)
+            || state.is(BlockTags.CROPS)
+            || state.is(BlockTags.RAILS)
+            || state.is(BlockTags.CLIMBABLE)
+            || state.is(BlockTags.CANDLES)
+            || state.is(BlockTags.WOOL_CARPETS)
+            || state.is(BlockTags.FIRE)
+            || state.is(BlockTags.WALL_POST_OVERRIDE)
+            || state.is(BlockTags.CAVE_VINES)
+            || state.is(BlockTags.FLOWER_POTS)
+            || state.is(BlockTags.CANDLE_CAKES)
+            || state.is(BlockTags.ANVIL)
+            || state.is(Blocks.BEDROCK)
+            || state.is(Blocks.REDSTONE_WIRE)
+            || state.is(Blocks.REPEATER);
+    }
 
     private final Map<BlockPos, BounceData> activeBounces = new ConcurrentHashMap<>();
     private final RandomSource tesselateRandom = RandomSource.create();
@@ -49,6 +77,7 @@ public class SeismicBounceManager {
                 BlockState state = level.getBlockState(pos);
 
                 if (!state.isAir()
+                    && !isAttachmentBlock(state)
                     && state.getRenderShape() == RenderShape.MODEL
                     && level.isEmptyBlock(pos.above())
                     && level.getBlockEntity(pos) == null) {


### PR DESCRIPTION
- 添加 isAttachmentBlock 方法判断黑名单中的方块类型
- 黑名单包含按钮、压力板、标牌、横幅、花卉、树苗、作物、轨道、可攀爬方块、蜡烛等
- 将床岩、红石线和红石中继器加入黑名单过滤
- 在方块弹跳逻辑中排除黑名单方块，避免异常渲染和处理