### PR TITLE
Cardboard blacklist for new Multiblock，allow the two types of rings to use optimized placement methods on each other，fix bugs for fish tank、corrupted beacon、advanced comparator、sliding rail and overseer command. 给新增的多方块添加mek纸箱黑名单，使加速环和偏转环能互相使用优化的放置方式，修bug。

### DIFF
--- a/src/generated/resources/data/mekanism/tags/block/cardboard_blacklist.json
+++ b/src/generated/resources/data/mekanism/tags/block/cardboard_blacklist.json
@@ -6,6 +6,12 @@
     "anvilcraft:tesla_tower",
     "anvilcraft:overseer",
     "anvilcraft:acceleration_ring",
-    "anvilcraft:deflection_ring"
+    "anvilcraft:deflection_ring",
+    "anvilcraft:shulker_container",
+    "anvilcraft:large_fluid_tank",
+    "anvilcraft:large_laser",
+    "anvilcraft:celestial_forging_anvil",
+    "anvilcraft:celestial_forging_anvil_amplifier",
+    "anvilcraft:trading_station"
   ]
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/AccelerationRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/AccelerationRingBlock.java
@@ -9,6 +9,7 @@ import dev.dubhe.anvilcraft.block.multipart.FlexibleMultiPartBlock;
 import dev.dubhe.anvilcraft.block.multipart.MultiPartBlockEntity;
 import dev.dubhe.anvilcraft.block.state.DirectionCube3x3PartHalf;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.player.Player;
@@ -118,7 +119,7 @@ public class AccelerationRingBlock extends FlexibleMultiPartBlock<DirectionCube3
 
     @Override
     protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        if (context.isHoldingItem(state.getBlock().asItem())) {
+        if (context.isHoldingItem(state.getBlock().asItem()) || context.isHoldingItem(ModBlocks.DEFLECTION_RING.asItem())) {
             return Shapes.block();
         }
         return switch (state.getValue(FACING).getAxis()) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/DeflectionRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/DeflectionRingBlock.java
@@ -10,6 +10,7 @@ import dev.dubhe.anvilcraft.block.multipart.FlexibleMultiPartBlock;
 import dev.dubhe.anvilcraft.block.multipart.MultiPartBlockEntity;
 import dev.dubhe.anvilcraft.block.state.DirectionCube3x3PartHalf;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.player.Player;
@@ -121,7 +122,7 @@ public class DeflectionRingBlock extends FlexibleMultiPartBlock<DirectionCube3x3
         BlockPos pos,
         CollisionContext context
     ) {
-        if (context.isHoldingItem(state.getBlock().asItem())) {
+        if (context.isHoldingItem(state.getBlock().asItem()) || context.isHoldingItem(ModBlocks.ACCELERATION_RING.asItem())) {
             return Shapes.block();
         }
         return switch (state.getValue(FACING).getAxis()) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/AdvancedComparatorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/AdvancedComparatorBlockEntity.java
@@ -70,7 +70,9 @@ public class AdvancedComparatorBlockEntity extends BlockEntity implements MenuPr
     @Override
     public void saveToItem(ItemStack stack, HolderLookup.Provider registries) {
         CompoundTag data = this.constructDataNbt();
-        BlockItem.setBlockEntityData(stack, this.getType(), data);
+        CompoundTag wrapped = new CompoundTag();
+        wrapped.put("ExtraData", data);
+        BlockItem.setBlockEntityData(stack, this.getType(), wrapped);
         stack.applyComponents(this.collectComponents());
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/CorruptedBeaconBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/CorruptedBeaconBlockEntity.java
@@ -146,8 +146,10 @@ public class CorruptedBeaconBlockEntity extends BlockEntity {
             if (!level.isClientSide) {
                 boolean lastHasLevel = lastLevel > 0;
                 boolean shouldLit = blockEntity.levels > 0 && !blockEntity.beamSections.isEmpty();
-                // 根据信标状态变化播放相应的音效和更新方块状态
-                if (!lastHasLevel && shouldLit) {
+                // 获取当前方块状态里实际存储的 LIT 属性值
+                boolean isCurrentlyLit = state.hasProperty(CorruptedBeaconBlock.LIT) && state.getValue(CorruptedBeaconBlock.LIT);
+                // 只有在“应当亮起但目前没亮”，或者“应当熄灭但目前还亮着”的状态切换时才调用 setBeaconStatus
+                if (shouldLit && !isCurrentlyLit) {
                     CorruptedBeaconBlockEntity.setBeaconStatus(level, pos, state, blockEntity, true);
                 } else if (lastHasLevel && !shouldLit) {
                     blockEntity.levels = 0;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -267,26 +267,6 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
         private boolean autoOutputting = false;
 
         @Override
-        public boolean isItemValid(int slot, ItemStack stack) {
-            boolean hasSame = false;
-            int sameSlot = -1;
-            for (int i = 0; i < this.getSlots(); i++) {
-                if (!ItemStack.isSameItemSameComponents(this.getStackInSlot(i), stack)) {
-                    continue;
-                }
-
-                if (hasSame) {
-                    return false;
-                } else {
-                    hasSame = true;
-                    sameSlot = i;
-                }
-            }
-            if (!hasSame) return this.getStackInSlot(slot).isEmpty();
-            return sameSlot == slot;
-        }
-
-        @Override
         public int getSlotLimit(int slot) {
             ItemStack stack = this.getStackInSlot(slot);
             int stackMax = stack.getMaxStackSize();

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/heatable/HeatableBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/heatable/HeatableBlockEntity.java
@@ -63,7 +63,7 @@ public abstract class HeatableBlockEntity extends BlockEntity {
     @Override
     protected void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.loadAdditional(tag, registries);
-        this.duration = tag.getInt("duration");
+        this.duration = 200;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/ActivatorSlidingRailBlock.java
@@ -282,7 +282,9 @@ public class ActivatorSlidingRailBlock extends BaseSlidingRailBlock implements I
 
     @Override
     public void onSlidingAbove(Level level, BlockPos pos, BlockState state, SlidingBlockEntity entity) {
-        if (entity.getStartPos().equals(pos.above())) return;
+        if (entity.getStartPos().equals(pos.above()) && entity.tickCount <= 2) {
+            return;
+        }
         level.setBlockAndUpdate(pos, state.setValue(FACING, entity.getMoveDirection()));
         if (!state.getValue(POWERED)) return;
         level.getBlockEntity(pos, ModBlockEntities.ACTIVATOR_SLIDING_RAIL.get()).ifPresent(ActivatorSlidingRailBlockEntity::startPulse);

--- a/src/main/java/dev/dubhe/anvilcraft/command/OverseerCommand.java
+++ b/src/main/java/dev/dubhe/anvilcraft/command/OverseerCommand.java
@@ -74,7 +74,7 @@ public class OverseerCommand {
                 continue;
             }
             OverseerBlockEntity overseerBlockEntity = overseerBlockEntityOptional.get();
-            if (!includeInactive && overseerBlockEntity.getLoadLevel() <= 0) continue;
+            if (!includeInactive && overseerBlockEntity.getLoadLevel() < 0) continue;
             MutableComponent component = Component.translatable(
                 "command.anvilcraft.overseer.entry",
                 Component.translatable("chat.coordinates", pos.getX(), pos.getY(), pos.getZ())

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -218,7 +218,13 @@ public class BlockTagLoader {
             .add(ModBlocks.TESLA_TOWER.getKey())
             .add(ModBlocks.OVERSEER_BLOCK.getKey())
             .add(ModBlocks.ACCELERATION_RING.getKey())
-            .add(ModBlocks.DEFLECTION_RING.getKey());
+            .add(ModBlocks.DEFLECTION_RING.getKey())
+            .add(ModBlocks.SHULKER_CONTAINER.getKey())
+            .add(ModBlocks.LARGE_FLUID_TANK.getKey())
+            .add(ModBlocks.LARGE_LASER.getKey())
+            .add(ModBlocks.CELESTIAL_FORGING_ANVIL.getKey())
+            .add(ModBlocks.CELESTIAL_FORGING_ANVIL_AMPLIFIER.getKey())
+            .add(ModBlocks.TRADING_STATION.getKey());
 
         provider.addTag(ModBlockTags.ANVIL_HAMMER_BLACKLIST)
             .add(findResourceKey(Blocks.NETHER_PORTAL))


### PR DESCRIPTION
- 给新增的多方块添加mek纸箱黑名单
- 使加速环和偏转环能互相使用优化的放置方式
- 使overseer指令能查找0级监督者
- fixed #3745 
- 移除鱼缸输出槽单种物品限制
- fixed #3631 
- 修复腐化信标光柱生成问题
- fixed #2890 
- fixed #2950 
- 使高级比较器被ctrl中键选择时保存配置到物品
- 使高温方块被滑轨移动后时长设为10s，与活塞表现同步
- fixed #3279 
- 使滑动方块能被经过的第一个激活滑轨重复触发
- fixed #2279 