### PR TITLE
Fix display for models of mark blocks 修复标记方块的模型展示

### DIFF
--- a/src/main/resources/assets/anvilcraft/models/block/arrow.json
+++ b/src/main/resources/assets/anvilcraft/models/block/arrow.json
@@ -112,16 +112,20 @@
 	],
 	"display": {
 		"thirdperson_righthand": {
+			"rotation": [0, 90, 0],
 			"translation": [0, -2, -5]
 		},
 		"thirdperson_lefthand": {
+			"rotation": [0, 90, 0],
 			"translation": [0, -2, -5]
 		},
 		"firstperson_righthand": {
+			"rotation": [0, 90, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
+			"rotation": [0, 90, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
@@ -130,13 +134,14 @@
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"gui": {
-			"rotation": [30, 135, 0]
+			"rotation": [0, 90, 0]
 		},
 		"head": {
 			"translation": [0, 3, -9.5]
 		},
 		"fixed": {
-			"rotation": [90, 0, -90]
+			"rotation": [90, -90, -90],
+			"translation": [0, 0, -1.25]
 		}
 	},
 	"groups": [

--- a/src/main/resources/assets/anvilcraft/models/block/arrow.json
+++ b/src/main/resources/assets/anvilcraft/models/block/arrow.json
@@ -116,7 +116,7 @@
 			"translation": [0, -2, -5]
 		},
 		"thirdperson_lefthand": {
-			"rotation": [0, 90, 0],
+			"rotation": [0, -90, 0],
 			"translation": [0, -2, -5]
 		},
 		"firstperson_righthand": {
@@ -125,7 +125,7 @@
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
-			"rotation": [0, 90, 0],
+			"rotation": [0, -90, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},

--- a/src/main/resources/assets/anvilcraft/models/block/check_mark.json
+++ b/src/main/resources/assets/anvilcraft/models/block/check_mark.json
@@ -86,16 +86,20 @@
 	],
 	"display": {
 		"thirdperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"thirdperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"firstperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
@@ -104,13 +108,14 @@
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"gui": {
-			"rotation": [30, 135, 0]
+			"rotation": [0, 180, 0]
 		},
 		"head": {
 			"translation": [0, 3, -9.5]
 		},
 		"fixed": {
-			"rotation": [90, 0, -90]
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, -1.25]
 		}
 	},
 	"groups": [

--- a/src/main/resources/assets/anvilcraft/models/block/cross_mark.json
+++ b/src/main/resources/assets/anvilcraft/models/block/cross_mark.json
@@ -134,16 +134,20 @@
 	],
 	"display": {
 		"thirdperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"thirdperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"firstperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
@@ -152,13 +156,14 @@
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"gui": {
-			"rotation": [30, 135, 0]
+			"rotation": [0, 180, 0]
 		},
 		"head": {
 			"translation": [0, 3, -9.5]
 		},
 		"fixed": {
-			"rotation": [90, 0, -90]
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, -1.25]
 		}
 	},
 	"groups": [

--- a/src/main/resources/assets/anvilcraft/models/block/exclamation_mark.json
+++ b/src/main/resources/assets/anvilcraft/models/block/exclamation_mark.json
@@ -66,16 +66,20 @@
 	],
 	"display": {
 		"thirdperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"thirdperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"firstperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
@@ -84,13 +88,14 @@
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"gui": {
-			"rotation": [30, 135, 0]
+			"rotation": [0, 180, 0]
 		},
 		"head": {
 			"translation": [0, 3, -9.5]
 		},
 		"fixed": {
-			"rotation": [90, 0, -90]
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, -1.25]
 		}
 	},
 	"groups": [

--- a/src/main/resources/assets/anvilcraft/models/block/question_mark.json
+++ b/src/main/resources/assets/anvilcraft/models/block/question_mark.json
@@ -178,16 +178,20 @@
 	],
 	"display": {
 		"thirdperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"thirdperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [0, -2, -5]
 		},
 		"firstperson_righthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
+			"rotation": [0, 180, 0],
 			"translation": [1.25, 0, 0],
 			"scale": [0.5, 0.5, 0.5]
 		},
@@ -196,13 +200,14 @@
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"gui": {
-			"rotation": [30, 135, 0]
+			"rotation": [0, 180, 0]
 		},
 		"head": {
 			"translation": [0, 3, -9.5]
 		},
 		"fixed": {
-			"rotation": [90, 0, -90]
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, -1.25]
 		}
 	},
 	"groups": [


### PR DESCRIPTION
- 修复了 #3783 的问题。
- fixed #3783

<img width="1077" height="499" alt="image" src="https://github.com/user-attachments/assets/cdcf59b5-b942-4aa1-82bc-16acc27718a5" />
