### PR TITLE
421 amulets will not deactivate its subtypes when not equipped 修复四合一护符在未装备时，使得子类型护符失效的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/amulet/type/FourToOneAmuletType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/amulet/type/FourToOneAmuletType.java
@@ -40,8 +40,8 @@ public class FourToOneAmuletType extends AmuletType {
     @Override
     public void inventoryTick(ServerPlayer player, ItemStack amulet, boolean isEnabled) {
         for (AmuletType type : this.types) {
-            type.inventoryTick(player, amulet, isEnabled ||
-                AmuletManager.INSTANCE.getAmuletsFromInventory(player).entries().stream()
+            type.inventoryTick(player, amulet, isEnabled
+                || AmuletManager.INSTANCE.getAmuletsFromInventory(player).entries().stream()
                     .anyMatch(entry -> entry.getKey().value().equals(type)));
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/api/amulet/type/FourToOneAmuletType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/amulet/type/FourToOneAmuletType.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.api.amulet.type;
 
 import com.google.common.collect.Lists;
+import dev.dubhe.anvilcraft.api.amulet.AmuletManager;
 import dev.dubhe.anvilcraft.api.amulet.fromto.Effect;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
@@ -39,7 +40,9 @@ public class FourToOneAmuletType extends AmuletType {
     @Override
     public void inventoryTick(ServerPlayer player, ItemStack amulet, boolean isEnabled) {
         for (AmuletType type : this.types) {
-            type.inventoryTick(player, amulet, isEnabled);
+            type.inventoryTick(player, amulet, isEnabled ||
+                AmuletManager.INSTANCE.getAmuletsFromInventory(player).entries().stream()
+                    .anyMatch(entry -> entry.getKey().value().equals(type)));
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/api/amulet/type/FourToOneAmuletType.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/amulet/type/FourToOneAmuletType.java
@@ -40,6 +40,7 @@ public class FourToOneAmuletType extends AmuletType {
     @Override
     public void inventoryTick(ServerPlayer player, ItemStack amulet, boolean isEnabled) {
         for (AmuletType type : this.types) {
+            // 在这里要考虑到四合一护符未装备，但某个子类型护符已装备的可能性
             type.inventoryTick(player, amulet, isEnabled
                 || AmuletManager.INSTANCE.getAmuletsFromInventory(player).entries().stream()
                     .anyMatch(entry -> entry.getKey().value().equals(type)));


### PR DESCRIPTION
- 修复了 #2868 的问题。
   - 现在四合一护符在未装备时重置状态，会考虑玩家现有的子类型护符从而不重置对应状态。
 - fixed #2868