### PR TITLE
Fixed the display issues with the creative tank and creative crate. 修复了创造储罐和创造板条箱的显示问题

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -129,6 +129,8 @@
   "anvilcraft.configuration.do_not_show_tooltip_when_jade_present.tooltip": "ʇuǝsǝɹd ǝpɐɾ uǝɥʍ dᴉʇꞁooʇ ʇuǝuodɯoɔ ɹǝʍod ɹǝpuǝɹ ʇou oᗡ",
   "anvilcraft.configuration.ember_anvil_beyond_max_level": "ꞁǝʌǝꞀ xɐW puoʎǝᗺ ꞁᴉʌuⱯ ɹǝqɯƎ",
   "anvilcraft.configuration.ember_anvil_beyond_max_level.tooltip": "ꞁᴉʌuⱯ ɹǝqɯƎ uᴉ ꞁǝʌǝꞁ xɐɯ puoʎǝq sʞooᗺ pǝʇuɐɥɔuƎ ɥʇᴉʍ sɯǝʇᴉ ᵷuᴉuᴉqɯoƆ",
+  "anvilcraft.configuration.exit_category_setting_behaviour": "ɹnoᴉʌɐɥǝᗺ ᵷuᴉʇʇǝS ʎɹoᵷǝʇɐƆ ʇᴉxƎ",
+  "anvilcraft.configuration.exit_category_setting_behaviour.tooltip": "nuǝɯ ᵷuᴉʇʇǝS ʎɹoᵷǝʇɐƆ ǝɥʇ ᵷuᴉʇᴉxǝ uǝɥʍ ɹnoᴉʌɐɥǝq ǝɥʇ ǝꞁᵷᵷo⟘",
   "anvilcraft.configuration.felling_block_per_level": "ꞁǝʌǝꞀ ɹǝԀ ʞɔoꞁᗺ ᵷuᴉꞁꞁǝℲ",
   "anvilcraft.configuration.felling_block_per_level.tooltip": "ʇuǝɯʇuɐɥɔuǝ ᵷuᴉꞁꞁǝℲ ɟo ꞁǝʌǝꞁ ɹǝd ʇnɔ ǝq uɐɔ ʇɐɥʇ sᵷoꞁ ɟo ɹǝqɯnu ɯnɯᴉxɐɯ ǝɥ⟘",
   "anvilcraft.configuration.frost_anvil_beyond_max_level": "ꞁǝʌǝꞀ xɐW puoʎǝᗺ ꞁᴉʌuⱯ ʇsoɹℲ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -129,6 +129,8 @@
   "anvilcraft.configuration.do_not_show_tooltip_when_jade_present.tooltip": "Do not render power component tooltip when jade present",
   "anvilcraft.configuration.ember_anvil_beyond_max_level": "Ember Anvil Beyond Max Level",
   "anvilcraft.configuration.ember_anvil_beyond_max_level.tooltip": "Combining items with Enchanted Books beyond max level in Ember Anvil",
+  "anvilcraft.configuration.exit_category_setting_behaviour": "Exit Category Setting Behaviour",
+  "anvilcraft.configuration.exit_category_setting_behaviour.tooltip": "Toggle the behaviour when exiting the Category Setting menu",
   "anvilcraft.configuration.felling_block_per_level": "Felling Block Per Level",
   "anvilcraft.configuration.felling_block_per_level.tooltip": "The maximum number of logs that can be cut per level of Felling enchantment",
   "anvilcraft.configuration.frost_anvil_beyond_max_level": "Frost Anvil Beyond Max Level",

--- a/src/main/java/dev/dubhe/anvilcraft/api/fluidtank/CreativeFluidHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluidtank/CreativeFluidHandler.java
@@ -35,4 +35,10 @@ public class CreativeFluidHandler extends FluidStacksResourceHandler {
         if (!FluidResource.of(existing).equals(resource)) return 0;
         return amount;
     }
+
+    @Override
+    public long getAmountAsLong(int index) {
+        // 创造模式储罐永远显示满箱
+        return this.capacity;
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/CreativeCrateBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/CreativeCrateBlockEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -37,7 +38,8 @@ public class CreativeCrateBlockEntity extends BlockEntity implements IItemResour
     @Override
     public void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
-        input.read("item", ItemStack.CODEC).ifPresent(this.itemHandler::setStack);
+        this.itemHandler.setStack(
+            input.read("item", ItemStack.CODEC).orElse(ItemStack.EMPTY));
     }
 
     @Override
@@ -59,6 +61,16 @@ public class CreativeCrateBlockEntity extends BlockEntity implements IItemResour
         return this.itemHandler;
     }
 
+    private void sendUpdate() {
+        if (this.level == null) return;
+        this.level.sendBlockUpdated(
+            this.getBlockPos(),
+            this.getBlockState(),
+            this.getBlockState(),
+            Block.UPDATE_CLIENTS
+        );
+    }
+
     /**
      * 获取当前显示的物品（用于渲染器）
      */
@@ -74,6 +86,7 @@ public class CreativeCrateBlockEntity extends BlockEntity implements IItemResour
                     player.getInventory().placeItemBackInInventory(this.itemHandler.getStack());
                     this.itemHandler.setStack(ItemStack.EMPTY);
                     setChanged();
+                    this.sendUpdate();
                 }
                 return true;
             }
@@ -82,6 +95,7 @@ public class CreativeCrateBlockEntity extends BlockEntity implements IItemResour
         if (!player.level().isClientSide()) {
             this.itemHandler.setStack(held.copyWithCount(1));
             setChanged();
+            this.sendUpdate();
         }
         return true;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CreativeCrateRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CreativeCrateRenderer.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import dev.dubhe.anvilcraft.block.entity.CreativeCrateBlockEntity;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.state.CreativeCrateRenderState;
-import dev.dubhe.anvilcraft.client.support.FeatureRendererSupport;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -13,6 +12,7 @@ import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.item.ItemModelResolver;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import org.jspecify.annotations.Nullable;
@@ -40,7 +40,11 @@ public class CreativeCrateRenderer implements BlockEntityRenderer<CreativeCrateB
         BlockEntityRenderer.super.extractRenderState(be, state, partialTicks, cameraPosition, breakProgress);
         ItemStack stack = be.getDisplayStack();
         if (!stack.isEmpty()) {
-            state.setItem(FeatureRendererSupport.initialize(stack, this.resolver));
+            ItemClusterRenderState cluster = new ItemClusterRenderState();
+            cluster.seed = ItemClusterRenderState.getSeedForItemStack(stack);
+            this.resolver.updateForTopItem(cluster.item, stack, ItemDisplayContext.FIXED, null, null, cluster.seed);
+            cluster.count = ItemClusterRenderState.getRenderedAmount(stack.getCount());
+            state.setItem(cluster);
         }
     }
 
@@ -55,38 +59,33 @@ public class CreativeCrateRenderer implements BlockEntityRenderer<CreativeCrateB
         if (cluster == null) return;
         int light = state.lightCoords;
 
-        // Render item on all 6 sides
+        // 在六个面的近表面渲染物品，参考 1.21.1 的渲染位置
         for (int side = 0; side < 6; side++) {
             poseStack.pushPose();
-            poseStack.translate(0.5, 0.5, 0.5);
-            float scale = 0.8f;
-            poseStack.scale(scale, scale, scale);
             switch (side) {
-                case 0 -> { // +Z (south)
-                    poseStack.translate(0, 0, 0.5);
-                }
-                case 1 -> { // -Z (north)
-                    poseStack.translate(0, 0, -0.5);
+                case 0 -> poseStack.translate(0.5, 0.5, 0.9);
+                case 1 -> {
+                    poseStack.translate(0.5, 0.5, 0.1);
                     poseStack.mulPose(Axis.YP.rotationDegrees(180));
                 }
-                case 2 -> { // +X (east)
-                    poseStack.translate(0.5, 0, 0);
+                case 2 -> {
+                    poseStack.translate(0.9, 0.5, 0.5);
                     poseStack.mulPose(Axis.YP.rotationDegrees(90));
                 }
-                case 3 -> { // -X (west)
-                    poseStack.translate(-0.5, 0, 0);
-                    poseStack.mulPose(Axis.YP.rotationDegrees(90));
+                case 3 -> {
+                    poseStack.translate(0.1, 0.5, 0.5);
+                    poseStack.mulPose(Axis.YP.rotationDegrees(270));
                 }
-                case 4 -> { // +Y (top)
-                    poseStack.translate(0, 0.5, 0);
+                case 4 -> {
+                    poseStack.translate(0.5, 0.9, 0.5);
                     poseStack.mulPose(Axis.XP.rotationDegrees(90));
                 }
-                case 5 -> { // -Y (bottom)
-                    poseStack.translate(0, -0.5, 0);
-                    poseStack.mulPose(Axis.XP.rotationDegrees(90));
+                case 5 -> {
+                    poseStack.translate(0.5, 0.1, 0.5);
+                    poseStack.mulPose(Axis.XP.rotationDegrees(270));
                 }
                 default -> {
-                    // Should not happen
+                    // This should never happen as side is always 0-5
                 }
             }
             cluster.item.submit(poseStack, submitNodeCollector, light, OverlayTexture.NO_OVERLAY, 0);


### PR DESCRIPTION
- 优化读取附加数据时，确保物品堆栈默认值为 EMPTY
- 添加 sendUpdate 方法，在物品更改后同步区块更新
- 在物品交互逻辑中调用 sendUpdate 保证客户端及时刷新
- 调整创造箱物品渲染位置，使用更合理的六面固定偏移和旋转
- 替换 FeatureRendererSupport 使用新的 ItemClusterRenderState 进行渲染初始化
- 创造模式流体储罐始终显示为满，重写 getAmountAsLong 方法返回容量
- 添加配置项“退出分类设置行为”的多语言支持，完善英美英之间的翻译一致性