### PR TITLE
Reverse facing of question mark and arrow blocks when shift-placing 按shift放置问号和箭头方块时反转方向

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/ArrowBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/ArrowBlock.java
@@ -40,7 +40,9 @@ public class ArrowBlock extends DirectionalBlock implements IHammerRemovable {
 
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
+        boolean isSneaking = context.getPlayer() != null && context.getPlayer().isShiftKeyDown();
+        Direction facing = context.getNearestLookingDirection();
         return this.defaultBlockState()
-            .setValue(FACING, context.getNearestLookingDirection().getOpposite());
+            .setValue(FACING, isSneaking ? facing : facing.getOpposite());
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/InstructBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/InstructBlock.java
@@ -40,7 +40,9 @@ public class InstructBlock extends HorizontalDirectionalBlock implements IHammer
 
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
+        boolean isSneaking = context.getPlayer() != null && context.getPlayer().isShiftKeyDown();
+        Direction facing = context.getHorizontalDirection();
         return this.defaultBlockState()
-            .setValue(FACING, context.getHorizontalDirection().getOpposite());
+            .setValue(FACING, isSneaking ? facing : facing.getOpposite());
     }
 }


### PR DESCRIPTION
### Reverse facing of question mark and arrow blocks when shift-placing 按shift放置问号和箭头方块时反转方向

## Summary

When the question mark block (`InstructBlock`) or the arrow block (`ArrowBlock`) is placed while the player is sneaking, the resulting `FACING` now points the opposite way from a normal placement, so the indicated direction can be flipped without re-aiming. Non-sneaking placement is unchanged.

## Why

These blocks are guide markers used to annotate builds and multiblock layouts. The default placement always orients them one way, which forces the player to re-aim to point a marker the other direction. The issue (`#3767`, carrying the maintainer `💡 Accept` label) asks for a sneak-to-reverse shortcut, matching the sneak-to-reverse placement pattern already used by `PumpBlock`.

## Changes

- `InstructBlock.getStateForPlacement`: when sneaking, use `getHorizontalDirection()` directly instead of `.getOpposite()`.
- `ArrowBlock.getStateForPlacement`: when sneaking, use `getNearestLookingDirection()` directly instead of `.getOpposite()`.
- Sneaking is detected via `context.getPlayer() != null && context.getPlayer().isShiftKeyDown()`, so automated placement with a null player falls back to the default facing and does not throw.
- 按住 shift 放置问号方块和箭头方块时，方块朝向相对于正常放置反转；不潜行放置保持原有行为，无玩家的自动放置回退到默认朝向。

## Testing

- Reviewed the placement logic for both blocks: sneaking yields the reversed direction, not sneaking yields the original result, and the null-player branch keeps the default facing.
- A full Gradle build was not run in this environment because no JDK was available.

Resolves #3767
