### PR TITLE
Solve the problem of heating block determination logic. 解决加热方块判定逻辑问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/SuperHeatingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/SuperHeatingRecipe.java
@@ -82,10 +82,9 @@ public class SuperHeatingRecipe extends AbstractProcessRecipe<SuperHeatingRecipe
             .setBlockInputOffset(new Vec3i(0, -2, 0))
             .setInputBlocks(
                 BlockStatePredicate.builder()
-                    .of(ModBlocks.HEATER.get())
+                    .of(ModBlocks.HEATER.get(), ModBlocks.BURNING_HEATER.get())
                     .with(HeaterBlock.OVERLOAD, false)
                     .or()
-                    .of(ModBlocks.BURNING_HEATER.get())
                     .with(BurningHeaterBlock.LEVEL, 2)
                     .build()
             );


### PR DESCRIPTION
- 修改SuperHeatingRecipe中输入方块条件
- 同时支持 HEATER 和 BURNING_HEATER 两种方块
- 调整判断条件，合并两种方块的限制
- 避免重复分支，简化代码逻辑
- 修复了因判定不全导致的配方异常问题