### PR TITLE
refactor(jade): 重构Jade集成以支持创意模式存储容器

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             versions.minecraft
             versions.neoForge
             versions.anvillib
+            versions.jade
 
       - name: Setup Java ${{ steps.properties.outputs.java_version }}
         uses: actions/setup-java@v3.6.0
@@ -85,7 +86,9 @@ jobs:
           minecraft_version: ${{ steps.lib_version.outputs.versions_minecraft }}
           mod_loader: 'neoforge'
           loader_version: ${{ steps.lib_version.outputs.versions_neoForge }}
-          extra-mods: "anvil-lib:${{ steps.lib_version.outputs.versions_anvillib }}"
+          extra-mods: |
+            anvil-lib:${{ steps.lib_version.outputs.versions_anvillib }}
+            jade:${{ steps.lib_version.outputs.versions_jade }}
           quiet-setup: 'True'
 
       - name: publish neoforge mc mod

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,6 +38,7 @@ jobs:
             versions.minecraft
             versions.neoForge
             versions.anvillib
+            versions.jade
 
       - name: Setup Java ${{ steps.properties.outputs.java_version }}
         uses: actions/setup-java@v3.6.0
@@ -75,5 +76,7 @@ jobs:
           minecraft_version: ${{ steps.lib_version.outputs.versions_minecraft }}
           mod_loader: 'neoforge'
           loader_version: ${{ steps.lib_version.outputs.versions_neoForge }}
-          extra-mods: "anvil-lib:${{ steps.lib_version.outputs.versions_anvillib }}"
+          extra-mods: |
+            anvil-lib:${{ steps.lib_version.outputs.versions_anvillib }}
+            jade:${{ steps.lib_version.outputs.versions_jade }}
           quiet-setup: 'True'

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/AnvilCraftJadePlugin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/AnvilCraftJadePlugin.java
@@ -20,9 +20,12 @@ import dev.dubhe.anvilcraft.integration.jade.provider.SpaceOvercompressorProvide
 import dev.dubhe.anvilcraft.integration.jade.provider.client.BurningHeaterClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.ChargerClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.CrabTrapStorageClientProvider;
+import dev.dubhe.anvilcraft.integration.jade.provider.client.CreativeCrateClientProvider;
+import dev.dubhe.anvilcraft.integration.jade.provider.client.CreativeFluidTankClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.DischargerClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.HeatableBlockClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.ItemDetectorClientProvider;
+import dev.dubhe.anvilcraft.integration.jade.provider.client.LargeFluidTankClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.PowerBlockClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.RubyPrismClientProvider;
 import dev.dubhe.anvilcraft.integration.jade.provider.client.SmartBlockPlacerClientProvider;
@@ -66,8 +69,8 @@ public class AnvilCraftJadePlugin implements IWailaPlugin {
         registration.registerBlockComponent(ChargerClientProvider.INSTANCE, Block.class);
         registration.registerBlockComponent(DischargerClientProvider.INSTANCE, Block.class);
         registration.registerBlockComponent(SmartBlockPlacerClientProvider.INSTANCE, Block.class);
-        registration.registerItemStorageClient(CreativeCrateProvider.INSTANCE);
-        registration.registerFluidStorageClient(CreativeFluidTankProvider.INSTANCE);
-        registration.registerFluidStorageClient(LargeFluidTankProvider.INSTANCE);
+        registration.registerItemStorageClient(CreativeCrateClientProvider.INSTANCE);
+        registration.registerFluidStorageClient(CreativeFluidTankClientProvider.INSTANCE);
+        registration.registerFluidStorageClient(LargeFluidTankClientProvider.INSTANCE);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/CreativeCrateProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/CreativeCrateProvider.java
@@ -1,60 +1,34 @@
 package dev.dubhe.anvilcraft.integration.jade.provider;
 
-import com.google.common.collect.ImmutableList;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import org.jspecify.annotations.Nullable;
-import snownee.jade.addon.universal.ItemStorageProvider;
 import snownee.jade.api.Accessor;
 import snownee.jade.api.BlockAccessor;
-import snownee.jade.api.view.ClientViewGroup;
-import snownee.jade.api.view.ItemView;
+import snownee.jade.api.view.IServerExtensionProvider;
 import snownee.jade.api.view.ViewGroup;
 
-import java.util.Collections;
 import java.util.List;
 
-public class CreativeCrateProvider extends ItemStorageProvider.Extension {
-    public static final CreativeCrateProvider INSTANCE = new CreativeCrateProvider();
-
-    private CreativeCrateProvider() {
-    }
+public enum CreativeCrateProvider implements IServerExtensionProvider<ItemStack> {
+    INSTANCE;
+    public static final Identifier UID = AnvilCraft.of("creative_crate");
 
     @Override
     public @Nullable List<ViewGroup<ItemStack>> getGroups(Accessor<?> accessor) {
         if (!(accessor instanceof BlockAccessor blockAccessor)) return null;
-        return Collections.singletonList(new ViewGroup<>(Collections.singletonList(
-            accessor.getLevel().getCapability(
-                Capabilities.Item.BLOCK,
-                blockAccessor.getHitResult().getBlockPos(),
-                null
-            ).getResource(0).toStack()
-        )));
-    }
-
-    @Override
-    public List<ClientViewGroup<ItemView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<ItemStack>> groups) {
-        ItemStack item = groups.getFirst().views.getFirst();
-        if (item.isEmpty()) return ImmutableList.of();
-        ItemView view = new ItemView(item);
-        view.amountText = "∞";
-        return Collections.singletonList(new ClientViewGroup<>(Collections.singletonList(view)));
-    }
-
-    @Override
-    public boolean shouldRequestData(Accessor<?> accessor) {
-        return true;
+        ItemStack stack = accessor.getLevel().getCapability(
+            Capabilities.Item.BLOCK,
+            blockAccessor.getHitResult().getBlockPos(),
+            null
+        ).getResource(0).toStack();
+        return List.of(new ViewGroup<>(List.of(stack)));
     }
 
     @Override
     public Identifier getUid() {
-        return AnvilCraft.of("creative_crate");
-    }
-
-    @Override
-    public int getDefaultPriority() {
-        return 1;
+        return CreativeCrateProvider.UID;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/CreativeFluidTankProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/CreativeFluidTankProvider.java
@@ -1,68 +1,36 @@
 package dev.dubhe.anvilcraft.integration.jade.provider;
 
-import com.google.common.collect.ImmutableList;
 import dev.dubhe.anvilcraft.AnvilCraft;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import org.jspecify.annotations.Nullable;
-import snownee.jade.addon.universal.FluidStorageProvider;
 import snownee.jade.api.Accessor;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.fluid.JadeFluidObject;
-import snownee.jade.api.ui.JadeUI;
-import snownee.jade.api.ui.NarratableComponent;
-import snownee.jade.api.view.ClientViewGroup;
 import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.IServerExtensionProvider;
 import snownee.jade.api.view.ViewGroup;
 
-import java.util.Collections;
 import java.util.List;
 
-public class CreativeFluidTankProvider extends FluidStorageProvider.Extension {
-    public static final CreativeFluidTankProvider INSTANCE = new CreativeFluidTankProvider();
-
-    private CreativeFluidTankProvider() {
-    }
+public enum CreativeFluidTankProvider implements IServerExtensionProvider<FluidView.Data> {
+    INSTANCE;
+    public static final Identifier UID = AnvilCraft.of("creative_fluid_tank");
 
     @Override
     public @Nullable List<ViewGroup<FluidView.Data>> getGroups(Accessor<?> accessor) {
         if (!(accessor instanceof BlockAccessor blockAccessor)) return null;
-        return Collections.singletonList(new ViewGroup<>(Collections.singletonList(
-            new FluidView.Data(
-                JadeFluidObject.of(
-                    accessor.getLevel().getCapability(
-                        Capabilities.Fluid.BLOCK,
-                        blockAccessor.getHitResult().getBlockPos(),
-                        null
-                    ).getResource(0).getFluid()
-                ),
-                Integer.MAX_VALUE
-            )
-        )));
-    }
-
-    @Override
-    public List<ClientViewGroup<FluidView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<FluidView.Data>> groups) {
-        JadeFluidObject fluid = groups.getFirst().views.getFirst().fluids().getFirst();
-        if (fluid.isEmpty()) return ImmutableList.of();
-        FluidView view = new FluidView(
-            JadeUI.fluid(fluid),
-            Component.translatable("tooltip.anvilcraft.jade.infinity").withStyle(ChatFormatting.GRAY),
-            Component.translatable("tooltip.anvilcraft.jade.infinity").withStyle(ChatFormatting.GRAY)
+        FluidView.Data data = new FluidView.Data(
+            JadeFluidObject.of(
+                accessor.getLevel().getCapability(
+                    Capabilities.Fluid.BLOCK,
+                    blockAccessor.getHitResult().getBlockPos(),
+                    null
+                ).getResource(0).getFluid()
+            ),
+            Integer.MAX_VALUE
         );
-        view.fluidName = fluid.getDisplayName();
-        view.ratio = 1.0F;
-        if (fluid.is(Fluids.EMPTY)) {
-            view.overrideText = NarratableComponent.translatable(
-                "jade.fluid",
-                FluidView.EMPTY_FLUID,
-                NarratableComponent.attach(Component.literal(view.max.getString()), view.max)
-            );
-        }
-        return Collections.singletonList(new ClientViewGroup<>(Collections.singletonList(view)));
+        return List.of(new ViewGroup<>(List.of(data)));
     }
 
     @Override
@@ -72,11 +40,6 @@ public class CreativeFluidTankProvider extends FluidStorageProvider.Extension {
 
     @Override
     public Identifier getUid() {
-        return AnvilCraft.of("creative_fluid_tank");
-    }
-
-    @Override
-    public int getDefaultPriority() {
-        return 1;
+        return CreativeFluidTankProvider.UID;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/LargeFluidTankProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/LargeFluidTankProvider.java
@@ -1,36 +1,25 @@
 package dev.dubhe.anvilcraft.integration.jade.provider;
 
-import com.google.common.collect.ImmutableList;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.fluid.InfinityFluidTank;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import org.jspecify.annotations.Nullable;
-import snownee.jade.addon.universal.FluidStorageProvider;
 import snownee.jade.api.Accessor;
 import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.fluid.JadeFluidObject;
-import snownee.jade.api.ui.JadeUI;
-import snownee.jade.api.ui.NarratableComponent;
-import snownee.jade.api.view.ClientViewGroup;
 import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.IServerExtensionProvider;
 import snownee.jade.api.view.ViewGroup;
-import snownee.jade.util.FluidTextHelper;
 
 import java.util.Collections;
 import java.util.List;
 
-public class LargeFluidTankProvider extends FluidStorageProvider.Extension {
-    public static final LargeFluidTankProvider INSTANCE = new LargeFluidTankProvider();
-
-    private LargeFluidTankProvider() {
-    }
+public enum LargeFluidTankProvider implements IServerExtensionProvider<FluidView.Data> {
+    INSTANCE;
+    public static final Identifier UID = AnvilCraft.of("large_fluid_tank");
 
     @Override
     public @Nullable List<ViewGroup<FluidView.Data>> getGroups(Accessor<?> accessor) {
@@ -56,41 +45,12 @@ public class LargeFluidTankProvider extends FluidStorageProvider.Extension {
     }
 
     @Override
-    public List<ClientViewGroup<FluidView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<FluidView.Data>> groups) {
-        if (groups.isEmpty() || groups.getFirst().views.isEmpty()) return ImmutableList.of();
-        FluidView.Data data = groups.getFirst().views.getFirst();
-        JadeFluidObject fluid = data.fluids().getFirst();
-        if (fluid.isEmpty()) return ImmutableList.of();
-        long amount = fluid.getAmount();
-        long capacity = data.capacity();
-        MutableComponent infinity = Component.translatable("tooltip.anvilcraft.jade.infinity").withStyle(ChatFormatting.GRAY);
-        Component current = capacity == Integer.MAX_VALUE ? infinity : FluidTextHelper.getMillibuckets(amount, true);
-        Component max = capacity == Integer.MAX_VALUE ? infinity : FluidTextHelper.getMillibuckets(capacity, true);
-        FluidView view = new FluidView(JadeUI.fluid(fluid), current, max);
-        view.fluidName = fluid.getDisplayName();
-        view.ratio = capacity == Integer.MAX_VALUE ? 1.0F : Math.clamp((float) amount / capacity, 0.0F, 1.0F);
-        if (fluid.is(Fluids.EMPTY)) {
-            view.overrideText = NarratableComponent.translatable(
-                "jade.fluid",
-                FluidView.EMPTY_FLUID,
-                NarratableComponent.attach(Component.literal(view.max.getString()), view.max)
-            );
-        }
-        return Collections.singletonList(new ClientViewGroup<>(Collections.singletonList(view)));
-    }
-
-    @Override
     public boolean shouldRequestData(Accessor<?> accessor) {
         return true;
     }
 
     @Override
     public Identifier getUid() {
-        return AnvilCraft.of("large_fluid_tank");
-    }
-
-    @Override
-    public int getDefaultPriority() {
-        return 1;
+        return LargeFluidTankProvider.UID;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/client/CreativeCrateClientProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/client/CreativeCrateClientProvider.java
@@ -1,0 +1,37 @@
+package dev.dubhe.anvilcraft.integration.jade.provider.client;
+
+import dev.dubhe.anvilcraft.integration.jade.provider.CreativeCrateProvider;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.ItemStack;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.view.ClientViewGroup;
+import snownee.jade.api.view.IClientExtensionProvider;
+import snownee.jade.api.view.ItemView;
+import snownee.jade.api.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum CreativeCrateClientProvider implements IClientExtensionProvider<ItemStack, ItemView> {
+    INSTANCE;
+
+    @Override
+    public List<ClientViewGroup<ItemView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<ItemStack>> groups) {
+        List<ClientViewGroup<ItemView>> list = new ArrayList<>();
+        for (ViewGroup<ItemStack> itemStackViewGroup : groups) {
+            List<ItemView> itemViewList = new ArrayList<>();
+            for (ItemStack view : itemStackViewGroup.views) {
+                ItemView itemView = new ItemView(view);
+                itemView.amountText = "∞";
+                itemViewList.add(itemView);
+            }
+            list.add(new ClientViewGroup<>(itemViewList));
+        }
+        return list;
+    }
+
+    @Override
+    public Identifier getUid() {
+        return CreativeCrateProvider.UID;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/client/CreativeFluidTankClientProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/client/CreativeFluidTankClientProvider.java
@@ -1,0 +1,49 @@
+package dev.dubhe.anvilcraft.integration.jade.provider.client;
+
+import com.google.common.collect.ImmutableList;
+import dev.dubhe.anvilcraft.integration.jade.provider.CreativeFluidTankProvider;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.material.Fluids;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.fluid.JadeFluidObject;
+import snownee.jade.api.ui.JadeUI;
+import snownee.jade.api.ui.NarratableComponent;
+import snownee.jade.api.view.ClientViewGroup;
+import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.IClientExtensionProvider;
+import snownee.jade.api.view.ViewGroup;
+
+import java.util.Collections;
+import java.util.List;
+
+public enum CreativeFluidTankClientProvider implements IClientExtensionProvider<FluidView.Data, FluidView> {
+    INSTANCE;
+
+    @Override
+    public List<ClientViewGroup<FluidView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<FluidView.Data>> groups) {
+        JadeFluidObject fluid = groups.getFirst().views.getFirst().fluids().getFirst();
+        if (fluid.isEmpty()) return ImmutableList.of();
+        FluidView view = new FluidView(
+            JadeUI.fluid(fluid),
+            Component.translatable("tooltip.anvilcraft.jade.infinity").withStyle(ChatFormatting.GRAY),
+            Component.translatable("tooltip.anvilcraft.jade.infinity").withStyle(ChatFormatting.GRAY)
+        );
+        view.fluidName = fluid.getDisplayName();
+        view.ratio = 1.0F;
+        if (fluid.is(Fluids.EMPTY)) {
+            view.overrideText = NarratableComponent.translatable(
+                "jade.fluid",
+                FluidView.EMPTY_FLUID,
+                NarratableComponent.attach(Component.literal(view.max.getString()), view.max)
+            );
+        }
+        return Collections.singletonList(new ClientViewGroup<>(Collections.singletonList(view)));
+    }
+
+    @Override
+    public Identifier getUid() {
+        return CreativeFluidTankProvider.UID;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/client/LargeFluidTankClientProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jade/provider/client/LargeFluidTankClientProvider.java
@@ -1,0 +1,54 @@
+package dev.dubhe.anvilcraft.integration.jade.provider.client;
+
+import com.google.common.collect.ImmutableList;
+import dev.dubhe.anvilcraft.integration.jade.provider.LargeFluidTankProvider;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.material.Fluids;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.fluid.JadeFluidObject;
+import snownee.jade.api.ui.JadeUI;
+import snownee.jade.api.ui.NarratableComponent;
+import snownee.jade.api.view.ClientViewGroup;
+import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.IClientExtensionProvider;
+import snownee.jade.api.view.ViewGroup;
+import snownee.jade.util.FluidTextHelper;
+
+import java.util.Collections;
+import java.util.List;
+
+public enum LargeFluidTankClientProvider implements IClientExtensionProvider<FluidView.Data, FluidView> {
+    INSTANCE;
+
+    @Override
+    public List<ClientViewGroup<FluidView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<FluidView.Data>> groups) {
+        if (groups.isEmpty() || groups.getFirst().views.isEmpty()) return ImmutableList.of();
+        FluidView.Data data = groups.getFirst().views.getFirst();
+        JadeFluidObject fluid = data.fluids().getFirst();
+        if (fluid.isEmpty()) return ImmutableList.of();
+        long amount = fluid.getAmount();
+        long capacity = data.capacity();
+        MutableComponent infinity = Component.translatable("tooltip.anvilcraft.jade.infinity").withStyle(ChatFormatting.GRAY);
+        Component current = capacity == Integer.MAX_VALUE ? infinity : FluidTextHelper.getMillibuckets(amount, true);
+        Component max = capacity == Integer.MAX_VALUE ? infinity : FluidTextHelper.getMillibuckets(capacity, true);
+        FluidView view = new FluidView(JadeUI.fluid(fluid), current, max);
+        view.fluidName = fluid.getDisplayName();
+        view.ratio = capacity == Integer.MAX_VALUE ? 1.0F : Math.clamp((float) amount / capacity, 0.0F, 1.0F);
+        if (fluid.is(Fluids.EMPTY)) {
+            view.overrideText = NarratableComponent.translatable(
+                "jade.fluid",
+                FluidView.EMPTY_FLUID,
+                NarratableComponent.attach(Component.literal(view.max.getString()), view.max)
+            );
+        }
+        return Collections.singletonList(new ClientViewGroup<>(Collections.singletonList(view)));
+    }
+
+    @Override
+    public Identifier getUid() {
+        return LargeFluidTankProvider.UID;
+    }
+}


### PR DESCRIPTION
- 将CreativeCrateProvider重构为服务端提供者并创建对应的客户端提供者
- 将CreativeFluidTankProvider重构为服务端提供者并创建对应的客户端提供者
- 将LargeFluidTankProvider重构为服务端提供者并创建对应的客户端提供者
- 在CI工作流中添加Jade依赖版本配置
- 更新工作流配置以包含Jade作为额外模组依赖
- 实现创意模式物品箱的无限数量显示功能
- 实现创意模式流体罐的无限容量显示功能
- 优化流体罐的容量和数量显示逻辑