### PR TITLE
Make wip models be displayed in JEI 使JEI能显示WIP方块模型

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/support/RenderSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/RenderSupport.java
@@ -109,7 +109,7 @@ public class RenderSupport {
         });
     };
 
-    public static BlockRenderFunction WIP_ENTITY(ResourceLocation recipeId) {
+    public static BlockRenderFunction wipEntity(ResourceLocation recipeId) {
         return (blockState, poseStack, buffers) -> {
             WipBlockEntity blockEntity = WipBlockEntity.createInstance(ModBlockEntities.WIP_BLOCK.get(),
                 BlockPos.ZERO, ModBlocks.WIP_BLOCK.getDefaultState());

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/RenderSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/RenderSupport.java
@@ -8,6 +8,9 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexMultiConsumer;
 import com.mojang.math.Axis;
 import com.mojang.math.MatrixUtil;
+import dev.dubhe.anvilcraft.block.entity.WipBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.util.LevelLike;
 import dev.dubhe.anvilcraft.util.VertexConsumerWithPose;
 import lombok.AccessLevel;
@@ -105,6 +108,16 @@ public class RenderSupport {
             renderBlockEntity(blockEntity, poseStack, buffers);
         });
     };
+
+    public static BlockRenderFunction WIP_ENTITY(ResourceLocation recipeId) {
+        return (blockState, poseStack, buffers) -> {
+            WipBlockEntity blockEntity = WipBlockEntity.createInstance(ModBlockEntities.WIP_BLOCK.get(),
+                BlockPos.ZERO, ModBlocks.WIP_BLOCK.getDefaultState());
+            blockEntity.setLevel(currentClientLevel);
+            blockEntity.setRecipeId(recipeId);
+            renderBlockEntity(blockEntity, poseStack, buffers);
+        };
+    }
 
     public static void renderBlockWithRotationNoTranslate(
         GuiGraphics guiGraphics,

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/ProceduralProcessCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/ProceduralProcessCategory.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.integration.jei.category;
 
 import dev.anvilcraft.lib.v2.util.predicate.BlockStatePredicate;
 import dev.anvilcraft.lib.v2.util.predicate.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.block.WipBlock;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.integration.jei.AnvilCraftJeiPlugin;
@@ -174,6 +175,17 @@ public class ProceduralProcessCategory implements IRecipeCategory<RecipeHolder<P
                 if (input.isEmpty()) continue;
                 BlockState renderedState = input.get((int) ((System.currentTimeMillis() / 1000) % input.size()));
                 if (renderedState == null) continue;
+                if (renderedState.getBlock() instanceof WipBlock) {
+                    RenderSupport.renderBlock(
+                        guiGraphics,
+                        renderedState,
+                        stepX + i * stepDx,
+                        BLOCK_Y + 10 * j,
+                        10 - 10 * j,
+                        12,
+                        RenderSupport.WIP_ENTITY(recipeHolder.id())
+                    );
+                }
                 RenderSupport.renderBlock(
                     guiGraphics,
                     renderedState,

--- a/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/ProceduralProcessCategory.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/jei/category/ProceduralProcessCategory.java
@@ -183,7 +183,7 @@ public class ProceduralProcessCategory implements IRecipeCategory<RecipeHolder<P
                         BLOCK_Y + 10 * j,
                         10 - 10 * j,
                         12,
-                        RenderSupport.WIP_ENTITY(recipeHolder.id())
+                        RenderSupport.wipEntity(recipeHolder.id())
                     );
                 }
                 RenderSupport.renderBlock(


### PR DESCRIPTION
- 现在方块序列处理的wip模型能在JEI中显示了。
<img width="747" height="791" alt="image" src="https://github.com/user-attachments/assets/a9a39612-248d-4d83-9102-9d3ec87d56e7" />