### PR TITLE
Added Block Comparator achievement 新增方块比较器成就

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -85,6 +85,8 @@
   "advancements.anvilcraft.root.title": "ʇɟɐɹƆꞁᴉʌuⱯ oʇ ǝɯoɔꞁǝM",
   "advancements.anvilcraft.royal_blacksmith.description": "ǝuoʇspuᴉɹᵷ ꞁɐʎoɹ puɐ 'ǝꞁqɐʇ ᵷuᴉɥʇᴉɯs ꞁɐʎoɹ 'ꞁᴉʌuɐ ꞁɐʎoɹ ǝɥʇ uᴉɐʇqO",
   "advancements.anvilcraft.royal_blacksmith.title": "ɥʇᴉɯsʞɔɐꞁq ꞁɐʎoᴚ",
+  "advancements.anvilcraft.salted_fish_turns_over.description": "ǝʇɐʇs ꞁɐʇuozᴉɹoɥ ɐ oʇ ǝʇɐʇs ꞁɐɔᴉʇɹǝʌ ɐ ɯoɹɟ ɹoʇɐɹɐdɯoƆ ʞɔoꞁᗺ ɐ uɹnʇ oʇ ɹǝɯɯɐɥ ꞁᴉʌuɐ uɐ ǝs∩",
+  "advancements.anvilcraft.salted_fish_turns_over.title": "ɹǝʌo suɹnʇ ɥsᴉɟ pǝʇꞁɐs ǝɥ⟘",
   "advancements.anvilcraft.self_in_flaming.description": "suodɐǝʍ ɹo sꞁooʇ ꞁɐʇǝɯ ɹǝqɯǝ ʎuɐ ɹᴉɐdǝɹ oʇ ǝᵷɹoɟǝɹ ǝɹᴉɟ ᵷuᴉs∩",
   "advancements.anvilcraft.self_in_flaming.title": "ᵷuᴉɯɐꞁɟ uᴉ ɟꞁǝS",
   "advancements.anvilcraft.smithing_table.description": "uo ʍou ɯoɹɟ sǝʇɐꞁdɯǝʇ ᵷuᴉɥʇᴉɯs ǝɯnsuoɔ ɹǝᵷuoꞁ ou puɐ ꞁǝǝʇs ꞁɐʎoᴚ ɥʇᴉʍ ǝꞁqɐʇ ᵷuᴉɥʇᴉɯs ɹnoʎ ǝpɐɹᵷd∩",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -85,6 +85,8 @@
   "advancements.anvilcraft.root.title": "Welcome to AnvilCraft",
   "advancements.anvilcraft.royal_blacksmith.description": "Obtain the royal anvil, royal smithing table, and royal grindstone",
   "advancements.anvilcraft.royal_blacksmith.title": "Royal blacksmith",
+  "advancements.anvilcraft.salted_fish_turns_over.description": "Use an anvil hammer to turn a Block Comparator from a vertical state to a horizontal state",
+  "advancements.anvilcraft.salted_fish_turns_over.title": "The salted fish turns over",
   "advancements.anvilcraft.self_in_flaming.description": "Using fire reforge to repair any ember metal tools or weapons",
   "advancements.anvilcraft.self_in_flaming.title": "Self in flaming",
   "advancements.anvilcraft.smithing_table.description": "Upgrade your smithing table with Royal steel and no longer consume smithing templates from now on",

--- a/src/generated/resources/data/anvilcraft/advancement/anvilcraft/placer_shuttle.json
+++ b/src/generated/resources/data/anvilcraft/advancement/anvilcraft/placer_shuttle.json
@@ -10,6 +10,7 @@
       "translate": "advancements.anvilcraft.placer_shuttle.description"
     },
     "frame": "goal",
+    "hidden": true,
     "icon": {
       "count": 1,
       "id": "anvilcraft:smart_block_placer"

--- a/src/generated/resources/data/anvilcraft/advancement/anvilcraft/salted_fish_turns_over.json
+++ b/src/generated/resources/data/anvilcraft/advancement/anvilcraft/salted_fish_turns_over.json
@@ -1,0 +1,28 @@
+{
+  "parent": "anvilcraft:anvilcraft/all_in_one",
+  "criteria": {
+    "block_comparator_turn_over": {
+      "trigger": "anvilcraft:block_comparator_turn_over"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "advancements.anvilcraft.salted_fish_turns_over.description"
+    },
+    "frame": "goal",
+    "hidden": true,
+    "icon": {
+      "count": 1,
+      "id": "anvilcraft:block_comparator"
+    },
+    "title": {
+      "translate": "advancements.anvilcraft.salted_fish_turns_over.title"
+    }
+  },
+  "requirements": [
+    [
+      "block_comparator_turn_over"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/src/main/java/dev/dubhe/anvilcraft/advancements/criterion/BlockComparatorTurnOverTrigger.java
+++ b/src/main/java/dev/dubhe/anvilcraft/advancements/criterion/BlockComparatorTurnOverTrigger.java
@@ -1,0 +1,39 @@
+package dev.dubhe.anvilcraft.advancements.criterion;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.dubhe.anvilcraft.init.ModCriterionTriggers;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.critereon.ContextAwarePredicate;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Optional;
+
+public class BlockComparatorTurnOverTrigger extends SimpleCriterionTrigger<BlockComparatorTurnOverTrigger.TriggerInstance> {
+    @Override
+    public Codec<TriggerInstance> codec() {
+        return TriggerInstance.CODEC;
+    }
+
+    public void trigger(ServerPlayer player) {
+        this.trigger(player, TriggerInstance::matches);
+    }
+
+    public record TriggerInstance(Optional<ContextAwarePredicate> player) implements SimpleInstance {
+        public static final Codec<TriggerInstance> CODEC = RecordCodecBuilder.create((instance) -> instance.group(
+            EntityPredicate.ADVANCEMENT_CODEC.optionalFieldOf("player").forGetter(TriggerInstance::player)
+        ).apply(instance, TriggerInstance::new));
+
+        public static Criterion<TriggerInstance> turnOver() {
+            return ModCriterionTriggers.BLOCK_COMPARATOR_TURN_OVER.get().createCriterion(
+                new TriggerInstance(Optional.empty())
+            );
+        }
+
+        public boolean matches() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/advancement/AdvancementLineHelper.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/advancement/AdvancementLineHelper.java
@@ -7,6 +7,7 @@ import dev.dubhe.anvilcraft.advancements.criterion.AnvilHammerHurtEntityTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.AnvilHitPiezoelectricCrystalTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.AnvilLootingTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.AnvilOnGroundTrigger;
+import dev.dubhe.anvilcraft.advancements.criterion.BlockComparatorTurnOverTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.ConvertBeaconTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.DevourerDevourTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.DispenserRepairIronGolem;
@@ -363,6 +364,10 @@ public class AdvancementLineHelper {
 
         public AdvancementHelper placerShuttle(String key) {
             return this.addCriterion(key, PlacerShuttleTrigger.TriggerInstance.shuttle());
+        }
+
+        public AdvancementHelper blockComparatorTurnOver(String key) {
+            return this.addCriterion(key, BlockComparatorTurnOverTrigger.TriggerInstance.turnOver());
         }
 
         public AdvancementHolder build(String id) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/BlockComparatorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BlockComparatorBlock.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.MapCodec;
 import dev.anvilcraft.lib.v2.util.ShapeUtil;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
+import dev.dubhe.anvilcraft.util.TriggerUtil;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -127,7 +128,7 @@ public class BlockComparatorBlock extends Block implements IHammerRemovable, IHa
         }
         Direction.Axis axis;
         if (facing.getAxis() == Direction.Axis.Y) {
-            axis = context.getHorizontalDirection().getAxis();
+            axis = context.getHorizontalDirection().getClockWise().getAxis();
         } else {
             axis = facing.getClockWise().getAxis();
         }
@@ -279,7 +280,11 @@ public class BlockComparatorBlock extends Block implements IHammerRemovable, IHa
     public boolean change(Player player, BlockPos blockPos, Level level, ItemStack anvilHammer) {
         BlockState state = level.getBlockState(blockPos);
         FacingWithAxis fwa = state.getValue(FACING_WITH_AXIS);
-        level.setBlockAndUpdate(blockPos, state.setValue(FACING_WITH_AXIS, fwa.toggleAxis()));
+        FacingWithAxis newFwa = fwa.toggleAxis();
+        level.setBlockAndUpdate(blockPos, state.setValue(FACING_WITH_AXIS, newFwa));
+        if (fwa.getAxis() == Direction.Axis.Y && newFwa.getAxis() != Direction.Axis.Y) {
+            TriggerUtil.blockComparatorTurnOver(level, blockPos);
+        }
         return true;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/AdvancementLang.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/AdvancementLang.java
@@ -163,6 +163,11 @@ public class AdvancementLang {
         provider.add("advancements.anvilcraft.super_heat.description", "Making a heat collector reach the max efficiency");
         // endregion
 
+        // region block comparator line
+        provider.add("advancements.anvilcraft.salted_fish_turns_over.title", "The salted fish turns over");
+        provider.add("advancements.anvilcraft.salted_fish_turns_over.description", "Use an anvil hammer to turn a Block Comparator from a vertical state to a horizontal state");
+        // endregion
+
         // region automation line
         provider.add("advancements.anvilcraft.redstone_milker.title", "Redstone milker");
         provider.add("advancements.anvilcraft.redstone_milker.description", "Using a dispenser to milk cows");

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModAdvancements.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModAdvancements.java
@@ -81,6 +81,8 @@ public class ModAdvancements {
     public static final AdvancementHolder NUCLEAR_POWER_10A;
     public static final AdvancementHolder TRANSCENDENCE;
 
+    public static final AdvancementHolder SALTED_FISH_TURNS_OVER;
+
     static {
         AdvancementLineHelper mainLine = new AdvancementLineHelper();
         ROOT = mainLine.next()
@@ -147,7 +149,7 @@ public class ModAdvancements {
                 AdvancementType.GOAL,
                 true,
                 true,
-                false
+                true
             )
             .placerShuttle("placer_shuttle")
             .build("placer_shuttle");
@@ -386,6 +388,20 @@ public class ModAdvancements {
                 List.of("hurt_entity")
             )
             .build("all_in_one");
+
+        SALTED_FISH_TURNS_OVER = mainLine.createBranch().next()
+            .display(
+                ModBlocks.BLOCK_COMPARATOR,
+                Component.translatable("advancements.anvilcraft.salted_fish_turns_over.title"),
+                Component.translatable("advancements.anvilcraft.salted_fish_turns_over.description"),
+                null,
+                AdvancementType.GOAL,
+                true,
+                true,
+                true
+            )
+            .blockComparatorTurnOver("block_comparator_turn_over")
+            .build("salted_fish_turns_over");
 
         AdvancementLineHelper killingLine = mainLine.createBranch();
         HAMMER_AND_NAIL = killingLine.next()

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModCriterionTriggers.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModCriterionTriggers.java
@@ -6,6 +6,7 @@ import dev.dubhe.anvilcraft.advancements.criterion.AnvilHammerHurtEntityTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.AnvilHitPiezoelectricCrystalTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.AnvilLootingTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.AnvilOnGroundTrigger;
+import dev.dubhe.anvilcraft.advancements.criterion.BlockComparatorTurnOverTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.ConvertBeaconTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.DevourerDevourTrigger;
 import dev.dubhe.anvilcraft.advancements.criterion.DispenserRepairIronGolem;
@@ -114,6 +115,9 @@ public class ModCriterionTriggers {
         "mineral_fountain_crate",
         MineralFountainCreateTrigger::new
     );
+
+    public static final DeferredHolder<CriterionTrigger<?>, BlockComparatorTurnOverTrigger> BLOCK_COMPARATOR_TURN_OVER =
+        REGISTER.register("block_comparator_turn_over", BlockComparatorTurnOverTrigger::new);
 
     public static void register(IEventBus eventBus) {
         REGISTER.register(eventBus);

--- a/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/HammerChangeBlockPacket.java
@@ -5,9 +5,11 @@ import dev.anvilcraft.lib.v2.network.packet.IPacket;
 import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.event.HammerChangeBlockEvent;
+import dev.dubhe.anvilcraft.block.BlockComparatorBlock;
 import dev.dubhe.anvilcraft.block.ChuteBlock;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
 import dev.dubhe.anvilcraft.util.StateUtil;
+import dev.dubhe.anvilcraft.util.TriggerUtil;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -82,5 +84,14 @@ public record HammerChangeBlockPacket(BlockPos pos, BlockState state) implements
             }
         }
         level.setBlock(this.pos, this.state, Block.UPDATE_ALL_IMMEDIATE);
+        // 咸鱼翻身：将方块比较器从任意方向的 Y 状态翻转到 X 或 Z 状态时触发
+        if (blockState.getBlock() instanceof BlockComparatorBlock
+            && this.state.getBlock() instanceof BlockComparatorBlock) {
+            Direction.Axis oldAxis = blockState.getValue(BlockComparatorBlock.FACING_WITH_AXIS).getAxis();
+            Direction.Axis newAxis = this.state.getValue(BlockComparatorBlock.FACING_WITH_AXIS).getAxis();
+            if (oldAxis == Direction.Axis.Y && newAxis != Direction.Axis.Y) {
+                TriggerUtil.blockComparatorTurnOver(level, this.pos);
+            }
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/TriggerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/TriggerUtil.java
@@ -160,4 +160,12 @@ public class TriggerUtil {
             }
         }
     }
+
+    public static void blockComparatorTurnOver(Level level, BlockPos pos) {
+        if (!level.isClientSide) {
+            for (ServerPlayer player : PlayerUtil.searchPlayerByPos(level, pos, 5)) {
+                ModCriterionTriggers.BLOCK_COMPARATOR_TURN_OVER.get().trigger(player);
+            }
+        }
+    }
 }


### PR DESCRIPTION
- 添加 BlockComparatorTurnOverTrigger 自定义触发器，用于监听方块比较器翻转事件
- 实现咸鱼翻身成就，触发条件为用铁砧锤将方块比较器从垂直状态翻转至水平状态
- 在方块比较器和网络数据包中增加触发器调用逻辑，确保成就正确触发
- 修改方块比较器方向切换逻辑，增加触发器触发判断
- 在成就注册模块中添加咸鱼翻身成就及相关显示文字
- 更新语言文件，添加咸鱼翻身成就名称及描述文本
- 在代码工具类中新增触发成就的辅助方法，方便复用调用