### PR TITLE
Add sliding_rail_stop_like tag, modify some behaviors and fix bugs. 添加了类滑轨站方块标签，修改了滑轨站和动力滑轨的部分行为，修复了bug。

### DIFF
--- a/src/generated/resources/data/anvilcraft/tags/block/sliding_rail_stop_like.json
+++ b/src/generated/resources/data/anvilcraft/tags/block/sliding_rail_stop_like.json
@@ -1,0 +1,11 @@
+{
+  "values": [
+    "#anvilcraft:heatable_blocks",
+    "minecraft:campfire",
+    "anvilcraft:sliding_rail_stop",
+    "anvilcraft:heater",
+    "anvilcraft:burning_heater",
+    "anvilcraft:corrupted_beacon",
+    "anvilcraft:neutron_irradiator"
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingBlockStructureResolver.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingBlockStructureResolver.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,6 +22,7 @@ public class SlidingBlockStructureResolver {
     private final BlockPos startPos;
     @Getter
     private final Direction pushDirection;
+    private final List<BlockPos> ignorePositions = new ArrayList<>();
     /**
      * All block positions to be moved by the piston
      */
@@ -43,6 +45,10 @@ public class SlidingBlockStructureResolver {
         } else {
             this.pushDirection = pistonDirection.getOpposite();
         }
+    }
+
+    public void addIgnorePosition(BlockPos pos) {
+        this.ignorePositions.add(pos.immutable());
     }
 
     public boolean resolve() {
@@ -68,6 +74,7 @@ public class SlidingBlockStructureResolver {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean addBlockLine(BlockPos originPos, Direction direction) {
+        if (ignorePositions.contains(originPos)) return true;
         BlockState nowState = this.level.getBlockState(originPos);
         if (
             nowState.isAir()
@@ -165,6 +172,7 @@ public class SlidingBlockStructureResolver {
         for (Direction dir : Direction.values()) {
             if (dir.getAxis() != this.pushDirection.getAxis()) {
                 BlockPos branchPos = fromPos.relative(dir);
+                if (ignorePositions.contains(branchPos)) continue;
                 BlockState branchState = this.level.getBlockState(branchPos);
                 if (
                     branchState.anvilcraft$canStickTo(branchPos, fromPos, fromState)

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/PoweredSlidingRailBlock.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.block.sliding;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.entity.MagnetizedNodeEntity;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
@@ -18,6 +19,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -176,7 +178,24 @@ public class PoweredSlidingRailBlock extends BaseSlidingRailBlock implements IHa
 
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos fromPos, boolean isMoving) {
+        boolean wasPowered = state.getValue(POWERED);
         boolean powered = this.updatePower(level, pos, state, fromPos);
+
+        if (!wasPowered && powered) {
+            Direction facing = state.getValue(FACING);
+            BlockPos behindPos = pos.relative(facing.getOpposite());
+            BlockState behindState = level.getBlockState(behindPos);
+            if (behindState.is(ModBlockTags.SLIDING_RAIL_STOP_LIKE)) {
+                BlockPos aboveStopPos = behindPos.above();
+                if (!level.isEmptyBlock(aboveStopPos)) {
+                    BlockState aboveStopState = level.getBlockState(aboveStopPos);
+                    if (PistonBaseBlock.isPushable(aboveStopState, level, aboveStopPos, null, true, null)) {
+                        SlidingRailStopBlock.moveBlocksAbove(level, behindPos, facing);
+                    }
+                }
+            }
+        }
+
         pushAbove:
         if (powered) {
             fromPos = pos.above();

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailStopBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/SlidingRailStopBlock.java
@@ -1,9 +1,10 @@
 package dev.dubhe.anvilcraft.block.sliding;
 
+import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.anvilcraft.lib.v2.util.MathUtil;
-import dev.anvilcraft.lib.v2.util.Util;
 import dev.dubhe.anvilcraft.api.sliding.SlidingBlockStructureResolver;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -14,7 +15,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.shapes.BooleanOp;
@@ -26,7 +26,6 @@ import org.apache.commons.lang3.tuple.Triple;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -89,59 +88,20 @@ public class SlidingRailStopBlock extends BaseSlidingRailBlock {
 
     @Override
     public void onSlidingAbove(Level level, BlockPos pos, BlockState state, SlidingBlockEntity entity) {
-        Direction moveTo = entity.getMoveDirection();
-        if (this.canMoveSlidingTo(level, pos, Objects.requireNonNull(moveTo))) {
-            return;
-        } else if (this.canMoveSlidingTo(level, pos, moveTo.getCounterClockWise())) {
-            entity.setMoveDirection(moveTo.getCounterClockWise());
-            return;
-        } else if (this.canMoveSlidingTo(level, pos, moveTo.getClockWise())) {
-            entity.setMoveDirection(moveTo.getClockWise());
-            return;
-        } else if (this.canMoveSlidingTo(level, pos, moveTo.getOpposite())) {
-            entity.setMoveDirection(moveTo.getOpposite());
-            return;
-        }
+        if (entity.tickCount <= 2) return;
         ISlidingRail.stopSlidingBlock(entity);
     }
 
     @Override
     protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos fromPos, boolean isMoving) {
         super.neighborChanged(state, level, pos, neighborBlock, fromPos, isMoving);
-        if (level.isEmptyBlock(pos.above())) return;
-        BlockState topBlock = level.getBlockState(pos.above());
-        if (!PistonBaseBlock.isPushable(topBlock, level, pos, null, true, null)) return;
-        Direction moveTo = MathUtil.getDirection(fromPos, pos);
-        if (Objects.requireNonNull(moveTo).getAxis() == Direction.Axis.Y) return;
-        if (this.canMoveBlockTo(level, pos, topBlock, moveTo)) {
-            SlidingRailStopBlock.moveBlocksAbove(level, pos, moveTo);
-        } else if (this.canMoveBlockTo(level, pos, topBlock, moveTo.getCounterClockWise())) {
-            SlidingRailStopBlock.moveBlocksAbove(level, pos, moveTo.getCounterClockWise());
-        } else if (this.canMoveBlockTo(level, pos, topBlock, moveTo.getClockWise())) {
-            SlidingRailStopBlock.moveBlocksAbove(level, pos, moveTo.getClockWise());
-        }
     }
 
-    private boolean canMoveBlockTo(Level level, BlockPos pos, BlockState topBlock, Direction moveTo) {
-        if (moveTo.getAxis() == Direction.Axis.Y) return false;
-        BlockPos railPos = pos.relative(moveTo);
-        BlockState railState = level.getBlockState(railPos);
-        return Util.castSafely(railState.getBlock(), ISlidingRail.class)
-            .map(rail -> rail.canMoveBlockToTop(level, railPos, railState, topBlock, moveTo.getOpposite()))
-            .orElse(false);
-    }
-
-    private boolean canMoveSlidingTo(Level level, BlockPos pos, Direction moveTo) {
-        if (moveTo.getAxis() == Direction.Axis.Y) return false;
-        BlockPos railPos = pos.relative(moveTo);
-        BlockState railState = level.getBlockState(railPos);
-        return Util.castSafely(railState.getBlock(), ISlidingRail.class)
-            .map(rail -> rail.canMoveSlidingToTop(level, railPos, railState, moveTo.getOpposite()))
-            .orElse(false);
-    }
-
-    private static void moveBlocksAbove(Level level, BlockPos pos, Direction moveToSide) {
+    public static void moveBlocksAbove(Level level, BlockPos pos, Direction moveToSide) {
         SlidingBlockStructureResolver resolver = new SlidingBlockStructureResolver(level, pos.above(), moveToSide, true);
+        if (level.getBlockState(pos).is(ModBlockTags.SLIDING_RAIL_STOP_LIKE)) {
+            resolver.addIgnorePosition(pos);
+        }
         if (!resolver.resolve()) return;
         List<Triple<BlockPos, BlockState, Optional<BlockEntity>>> toPushes = new ArrayList<>();
         List<BlockPos> toPushPoses = new ArrayList<>(resolver.getToPush());
@@ -156,7 +116,13 @@ public class SlidingRailStopBlock extends BaseSlidingRailBlock {
             if (toPushState.hasProperty(BlockStateProperties.WATERLOGGED)) {
                 toPushState = toPushState.setValue(BlockStateProperties.WATERLOGGED, false);
             }
-            toPushes.add(Triple.of(toPushPos, toPushState, Optional.empty()));
+            BlockEntity be = (toPushState.getBlock() instanceof IMoveableEntityBlock)
+                             ? level.getBlockEntity(toPushPos)
+                             : null;
+            Optional<BlockEntity> blockEntity = Optional.ofNullable(be);
+            if (be != null) level.removeBlockEntity(toPushPos);
+
+            toPushes.add(Triple.of(toPushPos, toPushState, blockEntity));
         }
 
         List<BlockPos> toDestroys = resolver.getToDestroy();

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -145,6 +145,15 @@ public class BlockTagLoader {
             .addTag(Tags.Blocks.GLASS_PANES)
             .addTag(BlockTags.REPLACEABLE);
 
+        provider.addTag(ModBlockTags.SLIDING_RAIL_STOP_LIKE)
+            .addTag(ModBlockTags.HEATABLE_BLOCKS)
+            .add(findResourceKey(Blocks.CAMPFIRE))
+            .add(ModBlocks.SLIDING_RAIL_STOP.getKey())
+            .add(ModBlocks.HEATER.getKey())
+            .add(ModBlocks.BURNING_HEATER.getKey())
+            .add(ModBlocks.CORRUPTED_BEACON.getKey())
+            .add(ModBlocks.NEUTRON_IRRADIATOR.getKey());
+
         provider.addTag(ModBlockTags.END_PORTAL_UNABLE_CHANGE).add(findResourceKey(Blocks.DRAGON_EGG));
 
         provider.addTag(ModBlockTags.NEUTRONIUM_CANNOT_PASS_THROUGH)

--- a/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.entity;
 import dev.anvilcraft.lib.v2.util.Util;
 import dev.dubhe.anvilcraft.api.sliding.SlidingBlockSection;
 import dev.dubhe.anvilcraft.block.sliding.ISlidingRail;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import dev.dubhe.anvilcraft.network.SlidingEntitySyncPacket;
 import lombok.Getter;
@@ -102,6 +103,9 @@ public class SlidingBlockEntity extends Entity {
         BlockState belowState = this.level().getBlockState(belowPos);
         if (belowState.getBlock() instanceof ISlidingRail slidingRail && !this.level().isClientSide) {
             slidingRail.onSlidingAbove(this.level(), belowPos, belowState, this);
+        } else if (belowState.is(ModBlockTags.SLIDING_RAIL_STOP_LIKE) && !this.level().isClientSide && this.time > 2) {
+            ISlidingRail.stopSlidingBlock(this);
+            return;
         }
         Direction.Axis horizontalAnother = Objects.requireNonNull(this.moveDirection).getClockWise().getAxis();
         this.setPos(this.position().with(horizontalAnother, Math.ceil(this.position().get(horizontalAnother)) - 0.5));
@@ -123,7 +127,11 @@ public class SlidingBlockEntity extends Entity {
     }
 
     protected boolean checkCanMove() {
-        if (!(this.level().getBlockState(this.blockPosition().below()).getBlock() instanceof ISlidingRail)) return false;
+        BlockPos belowPos = this.blockPosition().below();
+        BlockState belowState = this.level().getBlockState(belowPos);
+        boolean isSlidingRail = belowState.getBlock() instanceof ISlidingRail;
+        boolean isStopLike = belowState.is(ModBlockTags.SLIDING_RAIL_STOP_LIKE);
+        if (!isSlidingRail && !isStopLike) return false;
         if (this.time > 1 && this.getDeltaMovement().equals(Vec3.ZERO)) return false;
         for (Vec3i pos : this.section.getWallsOnSide(Objects.requireNonNull(this.moveDirection))) {
             BlockPos checking = this.blockPosition().offset(pos);

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
@@ -44,6 +44,7 @@ public class ModBlockTags {
     public static final TagKey<Block> ANVIL_TIER_2 = bind("anvil_tier_2");
     public static final TagKey<Block> ANVIL_TIER_3 = bind("anvil_tier_3");
     public static final TagKey<Block> POWER_CONVERTER = bind("power_converter");
+    public static final TagKey<Block> SLIDING_RAIL_STOP_LIKE = bind("sliding_rail_stop_like");
 
     // common tags
     public static final TagKey<Block> ORES_TUNGSTEN = bindC("ores/tungsten");


### PR DESCRIPTION
- 为各种热金属块、两种加热器、腐化信标、营火和中子辐照器添加了类滑轨站方块标签（sliding_rail_stop_like）
- 修改了滑轨站和动力滑轨的部分行为
- 现在滑动方块实体经过类滑轨站会停下，只有在动力滑轨激活的同时才会进行拉取，常亮的动力滑轨不会有动作
- fixed #3971 
- fixed #3324 
- resolved #3346 