### PR TITLE
fix beacon renderer

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderPipelines.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderPipelines.java
@@ -29,7 +29,6 @@ public class ModRenderPipelines {
         DestFactor.ONE
     );
 
-    /// 加法混合（发光叠加），用于超新星爆发光束/闪光。
     public static final BlendFunction ADDITIVE_BLEND = new BlendFunction(
         SourceFactor.SRC_ALPHA,
         DestFactor.ONE,
@@ -37,7 +36,6 @@ public class ModRenderPipelines {
         DestFactor.ONE
     );
 
-    /// 乘法混合（DST_COLOR × SRC_COLOR），用于恒星颜色叠加，精确调色板着色。
     public static final BlendFunction MULTIPLY_BLEND = new BlendFunction(
         SourceFactor.DST_COLOR,
         DestFactor.ZERO,
@@ -76,28 +74,22 @@ public class ModRenderPipelines {
         .withLocation(AnvilCraft.of("pipeline/lightning"))
         .build();
 
-    /// 超新星爆发光束/闪光：加法混合发光，双面可见，不写深度。复用 lightning 着色器（顶点色）。
-    public static final RenderPipeline SUPERNOVA_BEAM = RenderPipeline.builder(RenderPipelines.BLOCK_SNIPPET)
+    public static final RenderPipeline SUPERNOVA_BEAM = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
         .withColorTargetState(new ColorTargetState(ADDITIVE_BLEND))
         .withShaderDefine("ALPHA_CUTOUT", 0.01F)
-        .withFragmentShader(AnvilCraft.of("core/rendertype_lightning"))
         .withDepthStencilState(new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, false))
         .withCull(false)
         .withLocation(AnvilCraft.of("pipeline/supernova_beam"))
         .build();
-
-    /// 腐化信标暗色光束：普通半透明混合（非加法），双面可见，写深度以呈现"暗色遮挡"感。
-    /// 复用 lightning 片段着色器（顶点色），与超新星光束区别在于用 TRANSLUCENT 而非 ADDITIVE 混合。
-    public static final RenderPipeline CORRUPTED_BEACON_BEAM = RenderPipeline.builder(RenderPipelines.BLOCK_SNIPPET)
-        .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
+    
+    public static final RenderPipeline CORRUPTED_BEACON_BEAM = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
         .withShaderDefine("ALPHA_CUTOUT", 0.01F)
-        .withFragmentShader(AnvilCraft.of("core/rendertype_lightning"))
-        .withDepthStencilState(new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, true))
+        .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
+        .withDepthStencilState(new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, false))
         .withCull(false)
         .withLocation(AnvilCraft.of("pipeline/corrupted_beacon_beam"))
         .build();
 
-    /// 恒星颜色叠加：乘法混合（DST_COLOR × SRC_COLOR），使灰度恒星贴图精确按恒星 RGB 着色。
     public static final RenderPipeline STAR_COLOR_OVERLAY = RenderPipeline.builder(RenderPipelines.BLOCK_SNIPPET)
         .withColorTargetState(new ColorTargetState(MULTIPLY_BLEND))
         .withShaderDefine("ALPHA_CUTOUT", 0.01F)
@@ -105,7 +97,6 @@ public class ModRenderPipelines {
         .withLocation(AnvilCraft.of("pipeline/star_color_overlay"))
         .build();
 
-    /// 天体大气层/光晕立方体：普通半透明混合，双面可见（NO_CULL）。
     public static final RenderPipeline CELESTIAL_ATMOSPHERE = RenderPipeline.builder(RenderPipelines.BLOCK_SNIPPET)
         .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
         .withShaderDefine("ALPHA_CUTOUT", 0.01F)
@@ -114,7 +105,6 @@ public class ModRenderPipelines {
         .withLocation(AnvilCraft.of("pipeline/celestial_atmosphere"))
         .build();
 
-    /// 超新星闪光 billboard：加法混合发光贴图，双面可见，不写深度。
     public static final RenderPipeline SUPERNOVA_FLASH = RenderPipeline.builder(RenderPipelines.BLOCK_SNIPPET)
         .withColorTargetState(new ColorTargetState(ADDITIVE_BLEND))
         .withShaderDefine("ALPHA_CUTOUT", 0.01F)

--- a/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderTypes.java
@@ -55,7 +55,6 @@ public class ModRenderTypes {
             .createRenderSetup()
     );
 
-    /// 超新星爆发光束/闪光——加法混合发光。
     public static final RenderType SUPERNOVA_BEAM = RenderType.create(
         "anvilcraft:supernova_beam",
         RenderSetup.builder(ModRenderPipelines.SUPERNOVA_BEAM)
@@ -64,10 +63,8 @@ public class ModRenderTypes {
             .createRenderSetup()
     );
 
-    /// 托举光束 + 超新星放射光束共用（加法混合，顶点色）。
     public static final RenderType STELLAR_BEAM = SUPERNOVA_BEAM;
 
-    /// 腐化信标暗色光束（普通半透明混合，顶点色，高不透明度呈"暗色遮挡"感）。
     public static final RenderType CORRUPTED_BEACON_BEAM = RenderType.create(
         "anvilcraft:corrupted_beacon_beam",
         RenderSetup.builder(ModRenderPipelines.CORRUPTED_BEACON_BEAM)
@@ -76,12 +73,8 @@ public class ModRenderTypes {
             .createRenderSetup()
     );
 
-    /// 纯白贴图，供颜色叠加/大气立方体按顶点色着色使用。
-    /// 26.1 移除了原版 `minecraft:textures/misc/white.png`（1.21 有），故改用模组自带的白贴图，
-    /// 否则恒星光晕/颜色叠加/大气立方体会因缺失贴图渲染成紫黑方块。
     private static final Identifier WHITE_TEXTURE = AnvilCraft.of("textures/misc/white.png");
 
-    /// 恒星颜色叠加——乘法混合（DST_COLOR × SRC_COLOR），精确调色板着色。
     public static final RenderType STAR_COLOR_OVERLAY = RenderType.create(
         "anvilcraft:star_color_overlay",
         RenderSetup.builder(ModRenderPipelines.STAR_COLOR_OVERLAY)
@@ -91,7 +84,6 @@ public class ModRenderTypes {
             .createRenderSetup()
     );
 
-    /// 天体大气层/光晕立方体——半透明混合，双面可见。
     public static final RenderType CELESTIAL_ATMOSPHERE = RenderType.create(
         "anvilcraft:celestial_atmosphere",
         RenderSetup.builder(ModRenderPipelines.CELESTIAL_ATMOSPHERE)
@@ -102,15 +94,12 @@ public class ModRenderTypes {
             .createRenderSetup()
     );
 
-    /// 天体贴图（cutout，按动态烘焙贴图）——行星本体。
     public static final Function<Identifier, RenderType> STAR_CUTOUT =
         Util.memoize((Identifier tex) -> RenderTypes.entityCutout(tex));
 
-    /// 行星环（半透明，按动态烘焙贴图）。
     public static final Function<Identifier, RenderType> CELESTIAL_RING =
         Util.memoize((Identifier tex) -> RenderTypes.entityTranslucent(tex));
 
-    /// 超新星闪光 billboard（加法混合，按逐帧贴图）。
     public static final Function<Identifier, RenderType> SUPERNOVA_FLASH = Util.memoize(
         tex -> RenderType.create(
             "anvilcraft:supernova_flash",

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CorruptedBeaconRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CorruptedBeaconRenderer.java
@@ -4,13 +4,18 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import dev.dubhe.anvilcraft.block.entity.CorruptedBeaconBlockEntity;
 import dev.dubhe.anvilcraft.block.workstation.CorruptedBeaconBlock;
+import dev.dubhe.anvilcraft.client.init.ModAtlasIds;
 import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.state.CorruptedBeaconRenderState;
+import dev.dubhe.anvilcraft.client.renderer.blockentity.state.LaserRenderState;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
@@ -18,24 +23,16 @@ import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 import org.jspecify.annotations.Nullable;
 
-/// 腐化信标渲染器：绘制锻星砧风格的四棱锥暗色光束（深紫黑，普通半透明混合以呈"暗色遮挡"感）。
-/// 玻璃外壳已由方块模型自身渲染，故此处只画光束。
-/// 采用 26.1 extract/submit 架构 + collector.submitCustomGeometry（与超新星光束同一条可靠路径，无闪烁）。
-public class CorruptedBeaconRenderer
-    implements BlockEntityRenderer<CorruptedBeaconBlockEntity, CorruptedBeaconRenderState> {
+public class CorruptedBeaconRenderer implements BlockEntityRenderer<CorruptedBeaconBlockEntity, CorruptedBeaconRenderState> {
 
-    /// 四棱锥光束参数
     private static final float BEAM_BASE_Y = 0.5f;
     private static final float BEAM_INNER_HALF = 0.08f;
     private static final int BEAM_GLOW_LAYERS = 4;
     private static final float BEAM_GLOW_HALF_STEP = 0.06f;
-
-    /// 暗色光束颜色（深紫黑）
     private static final float BEAM_R = 0.02f;
     private static final float BEAM_G = 0.0f;
     private static final float BEAM_B = 0.05f;
 
-    @SuppressWarnings("unused")
     public CorruptedBeaconRenderer(BlockEntityRendererProvider.Context ignored) {
     }
 
@@ -63,29 +60,40 @@ public class CorruptedBeaconRenderer
     }
 
     @Override
-    public void submit(CorruptedBeaconRenderState state, PoseStack pose, SubmitNodeCollector collector,
-                       CameraRenderState camera) {
+    public void submit(
+        CorruptedBeaconRenderState state,
+        PoseStack pose,
+        SubmitNodeCollector collector,
+        CameraRenderState camera
+    ) {
         if (!state.isLit()) return;
         float beamHeight = state.getBeamHeight();
         if (beamHeight <= 0.01f) return;
         float apexY = BEAM_BASE_Y + beamHeight;
-        collector.submitCustomGeometry(pose, ModRenderTypes.CORRUPTED_BEACON_BEAM, (last, consumer) -> {
-            Matrix4f matrix = last.pose();
-            for (int layer = BEAM_GLOW_LAYERS; layer >= 1; layer--) {
-                float half = BEAM_INNER_HALF + BEAM_GLOW_HALF_STEP * layer;
-                float falloff = 1.0f / (layer + 1);
-                falloff *= falloff;
-                float alpha = 0.45f * falloff;
-                float tipFade = 0.3f * falloff;
-                emitBeamPyramid(consumer, matrix, half, apexY, alpha, tipFade);
+        collector.submitCustomGeometry(
+            pose, ModRenderTypes.CORRUPTED_BEACON_BEAM, (last, consumer) -> {
+                Matrix4f matrix = last.pose();
+                for (int layer = BEAM_GLOW_LAYERS; layer >= 1; layer--) {
+                    float half = BEAM_INNER_HALF + BEAM_GLOW_HALF_STEP * layer;
+                    float falloff = 1.0f / (layer + 1);
+                    falloff *= falloff;
+                    float alpha = 0.45f * falloff;
+                    float tipFade = 0.3f * falloff;
+                    emitBeamPyramid(consumer, matrix, half, apexY, alpha, tipFade);
+                }
+                emitBeamPyramid(consumer, matrix, BEAM_INNER_HALF, apexY, 0.82f, 0.25f);
             }
-            emitBeamPyramid(consumer, matrix, BEAM_INNER_HALF, apexY, 0.82f, 0.25f);
-        });
+        );
     }
 
-    /// 发射一个以 (0.5,0.5) 为水平中心的四棱锥：方形底面在 BEAM_BASE_Y、半宽 halfWidth，锥尖在 (0.5, apexY, 0.5)。
-    private static void emitBeamPyramid(VertexConsumer vc, Matrix4f matrix, float halfWidth,
-                                        float apexY, float alpha, float tipFade) {
+    private static void emitBeamPyramid(
+        VertexConsumer vc,
+        Matrix4f matrix,
+        float halfWidth,
+        float apexY,
+        float alpha,
+        float tipFade
+    ) {
         float cx = 0.5f;
         float cz = 0.5f;
         float x0 = cx - halfWidth;
@@ -94,20 +102,35 @@ public class CorruptedBeaconRenderer
         float z1 = cz + halfWidth;
         float[][] corners = {{x0, z0}, {x1, z0}, {x1, z1}, {x0, z1}};
         float tipAlpha = alpha * tipFade;
+
+        final TextureAtlas atlas = Minecraft.getInstance().getAtlasManager().getAtlasOrThrow(ModAtlasIds.LASER);
+        TextureAtlasSprite sprite = atlas.getSprite(LaserRenderState.LASER_TEXTURE);
+
         for (int i = 0; i < 4; i++) {
             float[] c0 = corners[i];
             float[] c1 = corners[(i + 1) % 4];
-            beamVertex(vc, matrix, c0[0], BEAM_BASE_Y, c0[1], alpha);
-            beamVertex(vc, matrix, c1[0], BEAM_BASE_Y, c1[1], alpha);
-            beamVertex(vc, matrix, cx, apexY, cz, tipAlpha);
-            beamVertex(vc, matrix, cx, apexY, cz, tipAlpha);
+
+            beamVertex(vc, matrix, c0[0], BEAM_BASE_Y, c0[1], alpha, sprite.getU0(), sprite.getV0());
+            beamVertex(vc, matrix, c1[0], BEAM_BASE_Y, c1[1], alpha, sprite.getU0(), sprite.getV1());
+            beamVertex(vc, matrix, cx, apexY, cz, tipAlpha, sprite.getU1(), sprite.getV1());
+            beamVertex(vc, matrix, cx, apexY, cz, tipAlpha, sprite.getU0(), sprite.getV1());
         }
     }
 
-    private static void beamVertex(VertexConsumer vc, Matrix4f matrix,
-                                   float x, float y, float z, float alpha) {
-        vc.addVertex(matrix, x, y, z).setColor(BEAM_R, BEAM_G, BEAM_B, alpha)
-            .setUv(0.5f, 0.5f).setUv1(0, 0).setUv2(240, 240).setNormal(0, 1, 0);
+    private static void beamVertex(
+        VertexConsumer vc,
+        Matrix4f matrix,
+        float x,
+        float y,
+        float z,
+        float alpha,
+        float u,
+        float v
+    ) {
+        vc.addVertex(matrix, x, y, z)
+            .setColor(BEAM_R, BEAM_G, BEAM_B, alpha)
+            .setUv(u, v)
+            .setUv2(240, 240);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Fix corrupted beacon renderer submission for the 26.1 render pipeline path.
- Use the beacon beam pipeline snippet for supernova and corrupted beacon beam render pipelines.
- Keep the branch's prior CFA celestial rendering fixes in the same head branch.

## Test Plan
- git diff --check
- .\\gradlew.bat compileJava --console=plain