### PR TITLE
Update JEI dependency version and optimize registration config

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 minecraft = "1.21.1"
 neoForge = "21.1.219"
-jei = "19.21.0.247"
+jei = "19.32.0.358"
 jade = "15.3.4+neoforge"
 mekanism = "10.7.19.85"
 parchment = "2024.11.17"

--- a/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
+++ b/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
@@ -86,11 +86,10 @@ public class AnvilCraft {
     @Getter
     private static final IntegrationManager INTEGRATION_MANAGER = new IntegrationManager(AnvilCraft.MOD_ID);
 
-    public static final Registrum REGISTRUM = Registrum.create(MOD_ID);
+    public static final Registrum REGISTRUM = Registrum.create(MOD_ID).defaultCreativeTab((ResourceKey<CreativeModeTab>) null);
 
     public AnvilCraft(IEventBus modEventBus, ModContainer modContainer) {
         MOD_BUS = modEventBus;
-        REGISTRUM.defaultCreativeTab((ResourceKey<CreativeModeTab>) null);
         NeoForgeMod.enableMilkFluid();
         ModAttachments.register(modEventBus);
         ModItemGroups.register(modEventBus);


### PR DESCRIPTION
- 将JEI版本从19.21.0.247更新到19.32.0.358
- 在Registrum创建时直接设置默认创造模式标签页为null以防止意外的类加载问题
- fixed #4002