### PR TITLE
Clarify connectivity checker tri-state semantics

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/power/ConnectivityChecker.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/ConnectivityChecker.java
@@ -28,8 +28,10 @@ public abstract class ConnectivityChecker {
     }
 
     /**
+     * Checks whether a component should be connected to the power grid.
+     *
      * @return FALSE = 拒绝加入电网，且优先级最高；DEFAULT = 弃权；TRUE = 允许加入电网，
-     *     仅在没有 checker 返回 FALSE 时生效
+     * 仅在没有 checker 返回 FALSE 时生效
      */
     public abstract TriState checkInRange(PowerGrid powerGrid, IPowerComponent component);
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/power/ConnectivityChecker.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/ConnectivityChecker.java
@@ -31,7 +31,7 @@ public abstract class ConnectivityChecker {
      * Checks whether a component should be connected to the power grid.
      *
      * @return FALSE = 拒绝加入电网，且优先级最高；DEFAULT = 弃权；TRUE = 允许加入电网，
-     * 仅在没有 checker 返回 FALSE 时生效
+     *     仅在没有 checker 返回 FALSE 时生效
      */
     public abstract TriState checkInRange(PowerGrid powerGrid, IPowerComponent component);
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/power/ConnectivityChecker.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/ConnectivityChecker.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.api.power;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLists;
+import net.neoforged.neoforge.common.util.TriState;
 
 import java.util.List;
 
@@ -13,13 +14,22 @@ public abstract class ConnectivityChecker {
     }
 
     public static boolean check(PowerGrid powerGrid, IPowerComponent component) {
+        boolean allDefault = true;
         for (ConnectivityChecker it : instances) {
-            if (it.checkInRange(powerGrid, component)) {
-                return true;
+            TriState triState = it.checkInRange(powerGrid, component);
+            if (triState == TriState.FALSE) {
+                return false;
+            }
+            if (triState != TriState.DEFAULT) {
+                allDefault = false;
             }
         }
-        return false;
+        return !allDefault;
     }
 
-    abstract boolean checkInRange(PowerGrid powerGrid, IPowerComponent component);
+    /**
+     * @return FALSE = 拒绝加入电网，且优先级最高；DEFAULT = 弃权；TRUE = 允许加入电网，
+     *     仅在没有 checker 返回 FALSE 时生效
+     */
+    public abstract TriState checkInRange(PowerGrid powerGrid, IPowerComponent component);
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/power/FastCollisionConnectivityChecker.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/FastCollisionConnectivityChecker.java
@@ -1,9 +1,11 @@
 package dev.dubhe.anvilcraft.api.power;
 
+import net.neoforged.neoforge.common.util.TriState;
+
 public class FastCollisionConnectivityChecker extends ConnectivityChecker {
 
     @Override
-    boolean checkInRange(PowerGrid powerGrid, IPowerComponent component) {
-        return powerGrid.collideFast(component.getShape());
+    public TriState checkInRange(PowerGrid powerGrid, IPowerComponent component) {
+        return powerGrid.collideFast(component.getShape()) ? TriState.TRUE : TriState.DEFAULT;
     }
 }


### PR DESCRIPTION
Document that FALSE has veto priority, DEFAULT abstains, and TRUE only allows joining when no checker returns FALSE. Update the fast collision checker to return TriState values accordingly.
