### PR TITLE
More recipes for producing dye items and fix tint color of cements 更多产出染料的配方，以及修复水泥流体的着色

### DIFF
--- a/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/black_dye_from_ink_sac.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/black_dye_from_ink_sac.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:item_crush/flower/black_dye_from_ink_sac"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:item_crush/flower/black_dye_from_ink_sac"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/blue_dye_from_lapis_lazuli.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/blue_dye_from_lapis_lazuli.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:item_crush/flower/blue_dye_from_lapis_lazuli"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:item_crush/flower/blue_dye_from_lapis_lazuli"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/brown_dye_from_cocoa_beans.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/brown_dye_from_cocoa_beans.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:item_crush/flower/brown_dye_from_cocoa_beans"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:item_crush/flower/brown_dye_from_cocoa_beans"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/white_dye_from_bone_meal.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/item_crush/flower/white_dye_from_bone_meal.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:item_crush/flower/white_dye_from_bone_meal"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:item_crush/flower/white_dye_from_bone_meal"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/black_dye_from_ink_sac.json
+++ b/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/black_dye_from_ink_sac.json
@@ -1,0 +1,14 @@
+{
+  "type": "anvilcraft:item_crush",
+  "ingredients": [
+    {
+      "items": "minecraft:ink_sac"
+    }
+  ],
+  "results": [
+    {
+      "count": 2,
+      "id": "minecraft:black_dye"
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/blue_dye_from_lapis_lazuli.json
+++ b/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/blue_dye_from_lapis_lazuli.json
@@ -1,0 +1,14 @@
+{
+  "type": "anvilcraft:item_crush",
+  "ingredients": [
+    {
+      "items": "minecraft:lapis_lazuli"
+    }
+  ],
+  "results": [
+    {
+      "count": 2,
+      "id": "minecraft:blue_dye"
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/brown_dye_from_cocoa_beans.json
+++ b/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/brown_dye_from_cocoa_beans.json
@@ -1,0 +1,14 @@
+{
+  "type": "anvilcraft:item_crush",
+  "ingredients": [
+    {
+      "items": "minecraft:cocoa_beans"
+    }
+  ],
+  "results": [
+    {
+      "count": 2,
+      "id": "minecraft:brown_dye"
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/white_dye_from_bone_meal.json
+++ b/src/generated/resources/data/anvilcraft/recipe/item_crush/flower/white_dye_from_bone_meal.json
@@ -1,0 +1,14 @@
+{
+  "type": "anvilcraft:item_crush",
+  "ingredients": [
+    {
+      "items": "minecraft:bone_meal"
+    }
+  ],
+  "results": [
+    {
+      "count": 2,
+      "id": "minecraft:white_dye"
+    }
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/tags/item/super_heating_boost_production.json
+++ b/src/generated/resources/data/anvilcraft/tags/item/super_heating_boost_production.json
@@ -1,6 +1,8 @@
 {
   "values": [
     "#c:raw_materials",
-    "#c:ores"
+    "#c:ores",
+    "minecraft:sea_pickle",
+    "minecraft:cactus"
   ]
 }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/ItemCrushRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/ItemCrushRecipeLoader.java
@@ -192,6 +192,10 @@ public class ItemCrushRecipeLoader {
         flower(provider, Items.PEONY, Items.PINK_DYE, 4);
         flower(provider, Items.PINK_PETALS, Items.PINK_DYE);
         flower(provider, Items.PINK_TULIP, Items.PINK_DYE);
+        flower(provider, Items.BONE_MEAL, Items.WHITE_DYE);
+        flower(provider, Items.INK_SAC, Items.BLACK_DYE);
+        flower(provider, Items.COCOA_BEANS, Items.BROWN_DYE);
+        flower(provider, Items.LAPIS_LAZULI, Items.BLUE_DYE);
     }
 
     private static void tool(RegistrumRecipeProvider provider, ItemLike tool, ItemLike result) {

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/ItemTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/ItemTagLoader.java
@@ -216,7 +216,9 @@ public class ItemTagLoader {
 
         provider.addTag(ModItemTags.SUPER_HEATING_BOOST_PRODUCTION)
             .addTag(Tags.Items.RAW_MATERIALS)
-            .addTag(Tags.Items.ORES);
+            .addTag(Tags.Items.ORES)
+            .add(findResourceKey(Items.SEA_PICKLE))
+            .add(findResourceKey(Items.CACTUS));
 
         provider.addTag(ModItemTags.RAW_MUTTON)
             .add(findResourceKey(Items.MUTTON));

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/VanillaRecipesWrap.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/VanillaRecipesWrap.java
@@ -294,16 +294,26 @@ public class VanillaRecipesWrap {
         Ingredient first = ingredients.getFirst();
         ItemIngredientPredicate.Builder predicateBuilder = ItemIngredientPredicate.Builder.item();
         String ingredient = "empty";
+        boolean boost = true;
         for (Ingredient.Value value : first.getValues()) {
             if (value instanceof Ingredient.ItemValue(ItemStack item)) {
+                if (!item.is(ModItemTags.SUPER_HEATING_BOOST_PRODUCTION)) boost = false;
                 ingredient = BuiltInRegistries.ITEM.getKey(item.getItem()).getPath();
                 predicateBuilder.of(item);
             }
             if (value instanceof Ingredient.TagValue(TagKey<Item> tag)) {
+                HolderSet.Named<Item> named = BuiltInRegistries.ITEM.getOrCreateTag(tag);
+                for (Holder<Item> holder : named) {
+                    if (!holder.is(ModItemTags.SUPER_HEATING_BOOST_PRODUCTION)) {
+                        boost = false;
+                        break;
+                    }
+                }
                 ingredient = tag.location().getPath().replace("/", "_");
                 predicateBuilder.of(tag);
             }
         }
+        result.setCount(result.getCount() * (boost ? 2 : 1));
         String res = BuiltInRegistries.ITEM.getKey(result.getItem()).getPath();
         ResourceLocation location = AnvilCraft.of("heating_warp_%s_2_%s".formatted(ingredient, res));
         VanillaRecipesWrap.recipes.add(


### PR DESCRIPTION
- 实现了 #4014。
- resolved #4014
- 修复了水泥流体在鱼缸、流体储罐与jade信息栏中颜色显示异常的问题。