### PR TITLE
Optimize the interaction logic between fluid containers and emitters. 优化流体容器与发射器交互逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/FluidHandlerWrapper.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/FluidHandlerWrapper.java
@@ -1,0 +1,300 @@
+package dev.dubhe.anvilcraft.api.fluid;
+
+import dev.dubhe.anvilcraft.fluid.HoneyFluid;
+import dev.dubhe.anvilcraft.init.block.ModFluids;
+import lombok.Getter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.Potion;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.alchemy.Potions;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidType;
+import net.neoforged.neoforge.fluids.FluidUtil;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * 流体处理器封装器。
+ *
+ * <p>
+ * 统一处理发射器与流体容器（鱼缸、储罐等 {@link IFluidHandler} 实现）之间的流体交互，
+ * 简化填充/抽取时物品转换逻辑，避免重复代码。
+ * </p>
+ */
+@Getter
+public class FluidHandlerWrapper {
+    /**
+     * -- GETTER --
+     *  获取被包装的原始流体处理器。
+     */
+    private final IFluidHandler handler;
+
+    public FluidHandlerWrapper(IFluidHandler handler) {
+        this.handler = handler;
+    }
+
+    /**
+     * 从世界中获取指定位置的流体处理器封装。
+     *
+     * @param level 世界
+     * @param pos   目标位置
+     * @param side  访问面，可为 null
+     * @return 封装实例，若目标无流体处理器则返回 null
+     */
+    @Nullable
+    public static FluidHandlerWrapper of(Level level, BlockPos pos, @Nullable Direction side) {
+        IFluidHandler handler = level.getCapability(Capabilities.FluidHandler.BLOCK, pos, side);
+        return handler != null ? new FluidHandlerWrapper(handler) : null;
+    }
+
+    /**
+     * 判断包装器是否持有有效的流体处理器。
+     */
+    public boolean isValid() {
+        return true;
+    }
+
+    // region 填充：从物品向处理器注入流体
+
+    /**
+     * 将流体容器物品中的流体填充到此处理器。
+     *
+     *  <p>
+     * 模拟并执行：从物品流体处理器中抽取 → 向此处理器填充 → 返回空容器。
+     *
+     * @param filledContainer 装有流体的容器物品栈
+     * @return 填充成功返回空容器物品，失败返回 null
+     */
+    @Nullable
+    public ItemStack fillFromItem(ItemStack filledContainer) {
+        return fillFromItem(filledContainer, false, null);
+    }
+
+    /**
+     * 将流体容器物品中的流体填充到此处理器（可选择是否模拟）。
+     *
+     * @param filledContainer 装有流体的容器物品栈
+     * @param simulateOnly    仅模拟（true）或执行实际转移（false）
+     * @return 填充成功返回空容器物品，失败返回 null
+     */
+    @Nullable
+    public ItemStack fillFromItem(ItemStack filledContainer, boolean simulateOnly) {
+        return fillFromItem(filledContainer, simulateOnly, null);
+    }
+
+    /**
+     * 将流体容器物品中的流体填充到此处理器（可选择是否模拟和随机概率）。
+     *
+     * @param filledContainer 装有流体的容器物品栈
+     * @param simulateOnly    仅模拟（true）或执行实际转移（false）
+     * @param random          随机源，用于附魔之瓶的概率判定；null 则视为 100% 成功
+     * @return 填充成功返回空容器物品，失败返回 null
+     */
+    @Nullable
+    public ItemStack fillFromItem(ItemStack filledContainer, boolean simulateOnly, @Nullable RandomSource random) {
+        // 尝试通过标准 IFluidHandlerItem 处理（桶、蜂蜜瓶等）
+        IFluidHandlerItem itemHandler = FluidUtil.getFluidHandler(filledContainer).orElse(null);
+        if (itemHandler != null) {
+            // 模拟：从物品中抽取
+            FluidStack drained = itemHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
+            if (drained.isEmpty()) return null;
+
+            // 模拟：向目标处理器中填充
+            int filled = handler.fill(drained, IFluidHandler.FluidAction.SIMULATE);
+            if (filled < drained.getAmount()) return null;
+
+            // 模拟模式下到此为止
+            if (simulateOnly) {
+                return itemHandler.getContainer();
+            }
+
+            // 执行：从物品中抽取并填充到目标
+            itemHandler.drain(drained, IFluidHandler.FluidAction.EXECUTE);
+            handler.fill(drained, IFluidHandler.FluidAction.EXECUTE);
+
+            return itemHandler.getContainer();
+        }
+
+        // 处理水瓶（PotionContents，不含有 IFluidHandlerItem）
+        ItemStack result = tryFillFromPotion(filledContainer, simulateOnly);
+        if (result != null) return result;
+
+        // 处理附魔之瓶（50% 概率填充经验液体）
+        return tryFillFromExpBottle(filledContainer, simulateOnly, random);
+    }
+
+    // region 特殊物品处理
+
+    /**
+     * 尝试从水瓶中填充水到处理器。
+     */
+    @Nullable
+    private ItemStack tryFillFromPotion(ItemStack stack, boolean simulateOnly) {
+        PotionContents contents = stack.get(DataComponents.POTION_CONTENTS);
+        if (contents == null) return null;
+        if (contents.potion().isEmpty()) return null;
+        Holder<Potion> potion = contents.potion().get();
+        if (potion != Potions.WATER) return null;
+
+        FluidStack water = new FluidStack(Fluids.WATER, FluidType.BUCKET_VOLUME / 4);
+        int filled = handler.fill(water, IFluidHandler.FluidAction.SIMULATE);
+        if (filled < water.getAmount()) return null;
+
+        if (!simulateOnly) {
+            handler.fill(water, IFluidHandler.FluidAction.EXECUTE);
+        }
+        return new ItemStack(Items.GLASS_BOTTLE);
+    }
+
+    /**
+     * 尝试从附魔之瓶中填充经验液体到处理器。
+     *
+     *  <p>始终消耗附魔之瓶并返回玻璃瓶，但仅 50% 概率实际填充经验液体。</p>
+     */
+    @Nullable
+    private ItemStack tryFillFromExpBottle(ItemStack stack, boolean simulateOnly, @Nullable RandomSource random) {
+        if (!stack.is(Items.EXPERIENCE_BOTTLE)) return null;
+
+        FluidStack expFluid = new FluidStack(ModFluids.EXP_FLUID, FluidType.BUCKET_VOLUME / 4);
+
+        // 模拟：检查是否有足够空间
+        int filled = handler.fill(expFluid, IFluidHandler.FluidAction.SIMULATE);
+        if (filled < expFluid.getAmount()) return null;
+
+        // 执行：50% 概率实际填充
+        if (!simulateOnly && (random == null || random.nextBoolean())) {
+            handler.fill(expFluid, IFluidHandler.FluidAction.EXECUTE);
+        }
+
+        // 始终返回玻璃瓶（即使概率失败）
+        return new ItemStack(Items.GLASS_BOTTLE);
+    }
+
+    // endregion
+
+    // region 抽取：从处理器向空容器抽取流体
+
+    /**
+     * 从此处理器抽取流体到空容器物品。
+     *
+     *  <p>
+     * 根据空容器类型自动决定抽取量（桶 1000mB，瓶 250mB）。
+     *
+     * @param emptyContainer 空容器物品（桶、玻璃瓶等）
+     * @return 装满流体的容器物品，失败返回 null
+     */
+    @Nullable
+    public ItemStack drainToItem(ItemStack emptyContainer) {
+        return drainToItem(emptyContainer, false);
+    }
+
+    @Nullable
+    public ItemStack drainToItem(ItemStack emptyContainer, boolean simulateOnly) {
+        int amount = emptyContainer.is(Items.GLASS_BOTTLE)
+            ? FluidType.BUCKET_VOLUME / 4
+            : FluidType.BUCKET_VOLUME;
+        return drainToItem(emptyContainer, amount, simulateOnly);
+    }
+
+    /**
+     * 从此处理器抽取指定量流体到空容器物品。
+     *
+     * @param emptyContainer 空容器物品
+     * @param amount         要抽取的流体量（mB）
+     * @param simulateOnly   仅模拟
+     * @return 装满流体的容器物品，失败返回 null
+     */
+    @Nullable
+    public ItemStack drainToItem(ItemStack emptyContainer, int amount, boolean simulateOnly) {
+        // 模拟：从目标处理器抽取
+        FluidStack drained = handler.drain(amount, IFluidHandler.FluidAction.SIMULATE);
+        if (drained.getAmount() < amount) return null;
+
+        // 确定结果物品
+        ItemStack result = determineFilledContainer(drained, emptyContainer);
+        if (result.isEmpty()) return null;
+
+        // 模拟模式下到此为止
+        if (simulateOnly) return result;
+
+        // 执行抽取
+        handler.drain(amount, IFluidHandler.FluidAction.EXECUTE);
+        return result;
+    }
+
+    /**
+     * 根据抽取到的流体和空容器类型确定装满后的容器物品。
+     */
+    private static ItemStack determineFilledContainer(FluidStack drained, ItemStack emptyContainer) {
+        boolean isBottle = emptyContainer.is(Items.GLASS_BOTTLE);
+
+        if (isBottle) {
+            // 蜂蜜瓶
+            if (drained.getFluid() instanceof HoneyFluid) {
+                return new ItemStack(Items.HONEY_BOTTLE);
+            }
+            // 水瓶（需要 PotionContents）
+            if (drained.getFluid() == Fluids.WATER) {
+                return PotionContents.createItemStack(Items.POTION, Potions.WATER);
+            }
+            // 经验流体 → 附魔之瓶
+            if (drained.getFluid() == ModFluids.EXP_FLUID.get()) {
+                return new ItemStack(Items.EXPERIENCE_BOTTLE);
+            }
+        }
+
+        // 通用：检查流体是否有对应的桶装形式
+        Item bucketItem = drained.getFluid().getBucket();
+        if (bucketItem != Items.AIR) {
+            return new ItemStack(bucketItem);
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    // endregion
+
+    // region 便捷查询
+
+    /**
+     * 获取处理器中的当前流体。
+     */
+    public FluidStack getFluid() {
+        return handler.getFluidInTank(0);
+    }
+
+    /**
+     * 获取处理器容量。
+     */
+    public int getCapacity() {
+        return handler.getTankCapacity(0);
+    }
+
+    /**
+     * 处理器是否为空。
+     */
+    public boolean isEmpty() {
+        return handler.getFluidInTank(0).isEmpty();
+    }
+
+    /**
+     * 处理器是否已满。
+     */
+    public boolean isFull() {
+        FluidStack fluid = handler.getFluidInTank(0);
+        return fluid.getAmount() >= handler.getTankCapacity(0);
+    }
+
+    // endregion
+}

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.block.entity;
 import com.google.common.collect.ImmutableList;
 import dev.anvilcraft.lib.v2.recipe.cache.IItemHandlerCache;
 import dev.anvilcraft.lib.v2.util.MathUtil;
+import dev.dubhe.anvilcraft.api.fluid.FluidHandlerWrapper;
 import dev.dubhe.anvilcraft.api.fluid.IFluidHandlerHolder;
 import dev.dubhe.anvilcraft.api.fluid.network.FluidNetworkManager;
 import dev.dubhe.anvilcraft.api.itemhandler.IItemHandlerHolder;
@@ -18,7 +19,6 @@ import dev.dubhe.anvilcraft.util.AnvilUtil;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -27,6 +27,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
@@ -39,9 +40,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemUtils;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.MobBucketItem;
-import net.minecraft.world.item.alchemy.Potion;
-import net.minecraft.world.item.alchemy.PotionContents;
-import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -66,7 +64,6 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
 @Getter
@@ -764,85 +761,50 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
 
     // region 流体交互
     private boolean interactWithFluid(Level level, Player player, InteractionHand hand, ItemStack inHand) {
-        if (FluidUtil.interactWithFluidHandler(player, hand, this.fluidHandler)) return true;
-        if (inHand.is(Items.GLASS_BOTTLE)) {
-            return this.tryFillEmptyBottle(level, player, hand, inHand);
+        FluidHandlerWrapper wrapper = new FluidHandlerWrapper(this.fluidHandler);
+
+        // 客户端：仅模拟检查是否能交互，不修改状态
+        if (level.isClientSide()) {
+            return wrapper.fillFromItem(inHand, true, null) != null
+                || wrapper.drainToItem(inHand, true) != null;
         }
-        return this.tryDrainFilledBottle(level, player, hand, inHand);
-    }
 
-    private boolean tryFillEmptyBottle(Level level, Player player, InteractionHand hand, ItemStack inHand) {
-        FluidStack stack = this.fluidHandler.getFluid();
-        BlockPos pos = this.getBlockPos();
-        if (stack.is(Fluids.WATER)) {
-            FluidStack drained = this.fluidHandler.drain(250, IFluidHandler.FluidAction.SIMULATE);
-            if (drained.getAmount() != 250) return false;
-            if (level.isClientSide()) return true;
-            this.fluidHandler.drain(250, IFluidHandler.FluidAction.EXECUTE);
-
-            ItemStack result = Items.POTION.getDefaultInstance();
+        // 服务端：先试填充（物品→鱼缸）
+        ItemStack result = wrapper.fillFromItem(inHand, false, level.getRandom());
+        if (result != null) {
             player.setItemInHand(hand, ItemUtils.createFilledResult(inHand, player, result));
-            player.awardStat(Stats.USE_CAULDRON);
-            player.awardStat(Stats.ITEM_USED.get(inHand.getItem()));
-            level.playSound(null, pos, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS);
-            level.gameEvent(null, GameEvent.FLUID_PICKUP, pos);
-            return true;
-        } else if (stack.is(ModFluids.EXP_FLUID)) {
-            FluidStack drained = this.fluidHandler.drain(250, IFluidHandler.FluidAction.SIMULATE);
-            if (drained.getAmount() != 250) return false;
-            if (level.isClientSide()) return true;
-            this.fluidHandler.drain(250, IFluidHandler.FluidAction.EXECUTE);
-
-            ItemStack result = Items.EXPERIENCE_BOTTLE.getDefaultInstance();
-            player.setItemInHand(hand, ItemUtils.createFilledResult(inHand, player, result));
-            player.awardStat(Stats.USE_CAULDRON);
-            player.awardStat(Stats.ITEM_USED.get(inHand.getItem()));
-            level.playSound(null, pos, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS);
-            level.gameEvent(null, GameEvent.FLUID_PICKUP, pos);
-            return true;
-        }
-        return false;
-    }
-
-    private boolean tryDrainFilledBottle(Level level, Player player, InteractionHand hand, ItemStack inHand) {
-        if (inHand.has(DataComponents.POTION_CONTENTS)) {
-            PotionContents contents = inHand.get(DataComponents.POTION_CONTENTS);
-            if (Objects.requireNonNull(contents).potion().isEmpty()) return false;
-            Holder<Potion> potion = contents.potion().get();
-            if (potion == Potions.WATER) {
-                FluidStack stack = new FluidStack(Fluids.WATER, 250);
-                int filled = this.fluidHandler.fill(stack, IFluidHandler.FluidAction.SIMULATE);
-                if (filled != 250) return false;
-                if (level.isClientSide()) return true;
-                this.fluidHandler.fill(stack, IFluidHandler.FluidAction.EXECUTE);
-
-                player.setItemInHand(hand, ItemUtils.createFilledResult(inHand, player, Items.GLASS_BOTTLE.getDefaultInstance()));
-                player.awardStat(Stats.FILL_CAULDRON);
-                player.awardStat(Stats.ITEM_USED.get(inHand.getItem()));
-                BlockPos pos = this.getBlockPos();
-                level.playSound(null, pos, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS);
-                level.gameEvent(null, GameEvent.FLUID_PLACE, pos);
-                return true;
-            }
-        } else if (inHand.is(Items.EXPERIENCE_BOTTLE)) {
-            FluidStack stack = new FluidStack(ModFluids.EXP_FLUID, 250);
-            int filled = this.fluidHandler.fill(stack, IFluidHandler.FluidAction.SIMULATE);
-            if (filled != 250) return false;
-            if (level.isClientSide()) return true;
-            // 50%概率
-            if (level.getRandom().nextBoolean()) {
-                this.fluidHandler.fill(stack, IFluidHandler.FluidAction.EXECUTE);
-            }
-
-            player.setItemInHand(hand, ItemUtils.createFilledResult(inHand, player, Items.GLASS_BOTTLE.getDefaultInstance()));
             player.awardStat(Stats.FILL_CAULDRON);
             player.awardStat(Stats.ITEM_USED.get(inHand.getItem()));
-            BlockPos pos = this.getBlockPos();
-            level.playSound(null, pos, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS);
-            level.gameEvent(null, GameEvent.FLUID_PLACE, pos);
+            SoundEvent sound = isBottleType(inHand)
+                ? SoundEvents.BOTTLE_EMPTY
+                : SoundEvents.BUCKET_EMPTY;
+            level.playSound(null, this.getBlockPos(), sound, SoundSource.BLOCKS);
+            level.gameEvent(null, GameEvent.FLUID_PLACE, this.getBlockPos());
             return true;
         }
+
+        // 服务端：再试抽取（鱼缸→容器）
+        result = wrapper.drainToItem(inHand);
+        if (result != null) {
+            player.setItemInHand(hand, ItemUtils.createFilledResult(inHand, player, result));
+            player.awardStat(Stats.USE_CAULDRON);
+            player.awardStat(Stats.ITEM_USED.get(inHand.getItem()));
+            SoundEvent sound = inHand.is(Items.GLASS_BOTTLE)
+                ? SoundEvents.BOTTLE_FILL
+                : SoundEvents.BUCKET_FILL;
+            level.playSound(null, this.getBlockPos(), sound, SoundSource.BLOCKS);
+            level.gameEvent(null, GameEvent.FLUID_PICKUP, this.getBlockPos());
+            return true;
+        }
+
         return false;
+    }
+
+    private static boolean isBottleType(ItemStack stack) {
+        return stack.is(Items.GLASS_BOTTLE)
+            || stack.is(Items.HONEY_BOTTLE)
+            || stack.is(Items.POTION)
+            || stack.is(Items.EXPERIENCE_BOTTLE);
     }
 
     public void entityInsideFluidContent(Level level, BlockPos pos, Entity entity) {

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModDispenserBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModDispenserBehavior.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.init;
 
 import dev.anvilcraft.lib.v2.registrum.util.entry.ItemEntry;
+import dev.dubhe.anvilcraft.api.fluid.FluidHandlerWrapper;
 import dev.dubhe.anvilcraft.block.item.HasMobBlockItem;
 import dev.dubhe.anvilcraft.block.item.ResinBlockItem;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
@@ -16,6 +17,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
@@ -35,11 +37,6 @@ import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.phys.AABB;
-import net.neoforged.neoforge.capabilities.Capabilities;
-import net.neoforged.neoforge.fluids.FluidStack;
-import net.neoforged.neoforge.fluids.FluidType;
-import net.neoforged.neoforge.fluids.FluidUtil;
-import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 
 import java.util.List;
 import java.util.UUID;
@@ -55,62 +52,11 @@ public class ModDispenserBehavior {
      */
     public static final UUID ANVILCRAFT_DISPENSER = new UUID(0x976850D40E652AB5L, 0x83D24BBA75A6B114L);
     private static final DefaultDispenseItemBehavior DEFAULT_BEHAVIOUR = new DefaultDispenseItemBehavior();
-    private static final DefaultDispenseItemBehavior FLUID_BUCKET = new DefaultDispenseItemBehavior() {
-        @Override
-        public ItemStack execute(BlockSource source, ItemStack stack) {
-            BlockPos blockpos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
-            Level level = source.level();
-            IFluidHandler target = level.getCapability(Capabilities.FluidHandler.BLOCK, blockpos, null);
-            if (target != null) {
-                var fluidHandler = FluidUtil.getFluidHandler(stack).orElse(null);
-                if (fluidHandler != null) {
-                    FluidStack drained = fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
-                    if (!drained.isEmpty()) {
-                        int filled = target.fill(drained, IFluidHandler.FluidAction.SIMULATE);
-                        if (filled >= drained.getAmount()) {
-                            fluidHandler.drain(drained, IFluidHandler.FluidAction.EXECUTE);
-                            target.fill(drained, IFluidHandler.FluidAction.EXECUTE);
-                            return this.consumeWithRemainder(source, stack, fluidHandler.getContainer());
-                        }
-                    }
-                }
-            }
-            return ModDispenserBehavior.DEFAULT_BEHAVIOUR.dispense(source, stack);
-        }
-    };
 
-    private static final DefaultDispenseItemBehavior EMPTY_FLUID_CONTAINER = new DefaultDispenseItemBehavior() {
-        @Override
-        public ItemStack execute(BlockSource source, ItemStack stack) {
-            BlockPos blockpos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
-            Level level = source.level();
-            IFluidHandler target = level.getCapability(Capabilities.FluidHandler.BLOCK, blockpos, null);
-            if (target != null) {
-                boolean isBottle = stack.is(Items.GLASS_BOTTLE);
-                int amount = isBottle ? FluidType.BUCKET_VOLUME / 4 : FluidType.BUCKET_VOLUME;
-
-                FluidStack drained = target.drain(amount, IFluidHandler.FluidAction.SIMULATE);
-                if (drained.getAmount() >= amount) {
-                    if (isBottle && drained.getFluid() instanceof dev.dubhe.anvilcraft.fluid.HoneyFluid) {
-                        if (!level.isClientSide()) {
-                            target.drain(amount, IFluidHandler.FluidAction.EXECUTE);
-                        }
-                        return this.consumeWithRemainder(source, stack, new ItemStack(Items.HONEY_BOTTLE));
-                    }
-                    Item bucketItem = drained.getFluid().getBucket();
-                    if (bucketItem != Items.AIR) {
-                        if (!level.isClientSide()) {
-                            target.drain(amount, IFluidHandler.FluidAction.EXECUTE);
-                        }
-                        return this.consumeWithRemainder(source, stack, new ItemStack(bucketItem));
-                    }
-                }
-            }
-            return ModDispenserBehavior.DEFAULT_BEHAVIOUR.dispense(source, stack);
-        }
-    };
-
-    private static final DefaultDispenseItemBehavior BUCKET = new DefaultDispenseItemBehavior() {
+    /**
+     * 特殊桶类（油桶、水泥桶等）使用原版 {@link DispensibleContainerItem#emptyContents} 逻辑。
+     */
+    private static final DefaultDispenseItemBehavior DISPENSIBLE_BUCKET = new DefaultDispenseItemBehavior() {
         @Override
         public ItemStack execute(BlockSource source, ItemStack stack) {
             DispensibleContainerItem item = (DispensibleContainerItem) stack.getItem();
@@ -125,43 +71,86 @@ public class ModDispenserBehavior {
         }
     };
 
+    /**
+     * 对物品包装一个 FluidHandlerWrapper 优先的发射行为。
+     *
+     * <p>先尝试 {@link FluidHandlerWrapper#fillFromItem}（物品→处理器），
+     * 再尝试 {@link FluidHandlerWrapper#drainToItem}（处理器→物品），
+     * 两者都失败时回退到原版行为。
+     */
+    private static DefaultDispenseItemBehavior wrapFluidInteraction(DispenseItemBehavior original) {
+        return new DefaultDispenseItemBehavior() {
+            @Override
+            public ItemStack execute(BlockSource source, ItemStack stack) {
+                BlockPos pos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
+                Level level = source.level();
+                FluidHandlerWrapper wrapper = FluidHandlerWrapper.of(level, pos, null);
+                if (wrapper != null) {
+                    // 先试填充（物品→处理器）
+                    ItemStack result = wrapper.fillFromItem(stack, false, level.getRandom());
+                    if (result != null) {
+                        playEmptySound(level, pos, stack);
+                        return this.consumeWithRemainder(source, stack, result);
+                    }
+                    // 再试抽取（处理器→物品）
+                    result = wrapper.drainToItem(stack);
+                    if (result != null) {
+                        playFillSound(level, pos, stack);
+                        return this.consumeWithRemainder(source, stack, result);
+                    }
+                }
+                return original.dispense(source, stack);
+            }
+        };
+    }
+
     public static void register() {
         DispenserBlock.registerBehavior(Items.IRON_INGOT, ModDispenserBehavior::ironIngot);
         DispenserBlock.registerBehavior(Items.BOWL, ModDispenserBehavior::bowl);
         DispenserBlock.registerBehavior(Items.GOLDEN_APPLE, ModDispenserBehavior::goldenApple);
         DispenserBlock.registerBehavior(ModBlocks.RESIN_BLOCK, ModDispenserBehavior::resinBlock);
-        DispenserBlock.registerBehavior(Items.MILK_BUCKET, FLUID_BUCKET);
-        DispenserBlock.registerBehavior(ModItems.OIL_BUCKET, BUCKET);
-        DispenserBlock.registerBehavior(ModItems.MELT_GEM_BUCKET, BUCKET);
         DispenserBlock.registerBehavior(ModBlocks.MENGER_SPONGE, ModDispenserBehavior::mengerSponge);
+
+        // 特殊桶：油桶、水泥桶等（走原版空容器排放逻辑）
+        DispenserBlock.registerBehavior(ModItems.OIL_BUCKET, DISPENSIBLE_BUCKET);
+        DispenserBlock.registerBehavior(ModItems.MELT_GEM_BUCKET, DISPENSIBLE_BUCKET);
         for (ItemEntry<BucketItem> cementBucket : ModItems.CEMENT_BUCKETS.values()) {
-            DispenserBlock.registerBehavior(cementBucket, BUCKET);
+            DispenserBlock.registerBehavior(cementBucket, DISPENSIBLE_BUCKET);
         }
 
-        DispenseItemBehavior originalBucket = DispenserBlock.DISPENSER_REGISTRY.get(Items.BUCKET);
-        DispenserBlock.registerBehavior(Items.BUCKET, new DefaultDispenseItemBehavior() {
-            @Override
-            public ItemStack execute(BlockSource source, ItemStack stack) {
-                BlockPos blockpos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
-                Level level = source.level();
-                IFluidHandler target = level.getCapability(Capabilities.FluidHandler.BLOCK, blockpos, null);
-                if (target != null) {
-                    int amount = FluidType.BUCKET_VOLUME;
-                    FluidStack drained = target.drain(amount, IFluidHandler.FluidAction.SIMULATE);
-                    if (drained.getAmount() >= amount) {
-                        Item bucketItem = drained.getFluid().getBucket();
-                        if (bucketItem != Items.AIR) {
-                            if (!level.isClientSide()) {
-                                target.drain(amount, IFluidHandler.FluidAction.EXECUTE);
-                            }
-                            return this.consumeWithRemainder(source, stack, new ItemStack(bucketItem));
-                        }
-                    }
-                }
-                return originalBucket.dispense(source, stack);
-            }
-        });
-        DispenserBlock.registerBehavior(Items.GLASS_BOTTLE, EMPTY_FLUID_CONTAINER);
+        // 通用流体物品：FluidHandlerWrapper 优先，失败回退原版
+        wrapAndRegister(Items.MILK_BUCKET);
+        wrapAndRegister(Items.WATER_BUCKET);
+        wrapAndRegister(Items.LAVA_BUCKET);
+        wrapAndRegister(Items.POWDER_SNOW_BUCKET);
+        wrapAndRegister(Items.BUCKET);
+        wrapAndRegister(Items.GLASS_BOTTLE);
+        wrapAndRegister(Items.HONEY_BOTTLE);
+        wrapAndRegister(Items.POTION);
+        wrapAndRegister(Items.EXPERIENCE_BOTTLE);
+    }
+
+    private static void wrapAndRegister(Item item) {
+        DispenseItemBehavior original = DispenserBlock.DISPENSER_REGISTRY.get(item);
+        if (original == null) return;
+        DispenserBlock.registerBehavior(item, wrapFluidInteraction(original));
+    }
+
+    private static void playEmptySound(Level level, BlockPos pos, ItemStack container) {
+        SoundEvent sound = container.is(Items.GLASS_BOTTLE)
+            || container.is(Items.HONEY_BOTTLE)
+            || container.is(Items.POTION)
+            || container.is(Items.EXPERIENCE_BOTTLE)
+            ? SoundEvents.BOTTLE_EMPTY
+            : SoundEvents.BUCKET_EMPTY;
+        level.playSound(null, pos, sound, SoundSource.BLOCKS, 1.0F, 1.0F);
+    }
+
+    private static void playFillSound(Level level, BlockPos pos, ItemStack container) {
+        SoundEvent sound = container.is(Items.GLASS_BOTTLE)
+            ? SoundEvents.BOTTLE_FILL
+            : SoundEvents.BUCKET_FILL;
+        level.playSound(null, pos, sound, SoundSource.BLOCKS, 1.0F, 1.0F);
     }
 
     private static ItemStack mengerSponge(BlockSource source, ItemStack stack) {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/DefaultDispenseItemBehaviorMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/DefaultDispenseItemBehaviorMixin.java
@@ -27,13 +27,13 @@ public abstract class DefaultDispenseItemBehaviorMixin {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;split(I)Lnet/minecraft/world/item/ItemStack;"),
         cancellable = true
     )
-    @SuppressWarnings("resource")
     public void betterDispense(BlockSource blockSource, ItemStack item, CallbackInfoReturnable<ItemStack> cir) {
         if (!(item.getItem() instanceof BucketItem)
             && !item.is(Items.POWDER_SNOW_BUCKET)
             && !item.is(Items.GLASS_BOTTLE)
             && !item.is(Items.HONEY_BOTTLE)
-            && !item.is(Items.POTION)) {
+            && !item.is(Items.POTION)
+            && !item.is(Items.EXPERIENCE_BOTTLE)) {
             return;
         }
         Direction direction = blockSource.state().getValue(DispenserBlock.FACING);


### PR DESCRIPTION
- 新增 FluidHandlerWrapper 类，统一管理流体容器与流体处理器之间的填充和抽取逻辑
- 在 FishTankBlockEntity 中整合 FluidHandlerWrapper，重构流体交互方法，简化物品转换处理
- 修改 ModDispenserBehavior，新增包装流体物品的发射行为， 实现优先使用 FluidHandlerWrapper 处理，失败回退原版行为
- 统一桶类物品（如油桶、水泥桶）使用原版 DispensibleContainerItem 逻辑
- DefaultDispenseItemBehaviorMixin 里扩展物品白名单，支持经验瓶的分发行为
- 更新声音及游戏事件触发，区分瓶类和桶类容器的填充与排放音效