### PR TITLE
Pipe network support for cauldron, implement anvil‑hammer‑as‑anvil feature, add trading‑station villager‑trade particles and fix multiple bugs 管道网络适配炼药锅，实现铁砧锤充当铁砧功能，新增交易站村民交易粒子效果并修复多项漏洞

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/CauldronFluidHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/CauldronFluidHandler.java
@@ -1,0 +1,309 @@
+package dev.dubhe.anvilcraft.api.fluid;
+
+import dev.dubhe.anvilcraft.util.CauldronUtil;
+import dev.dubhe.anvilcraft.util.CompatUtil;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.fluids.CauldronFluidContent;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+public record CauldronFluidHandler(Level level, BlockPos pos) implements IFluidHandler {
+    private static final int DEFAULT_TOTAL_AMOUNT = 1000;
+
+    public CauldronFluidHandler(Level level, BlockPos pos) {
+        this.level = level;
+        this.pos = pos.immutable();
+    }
+
+    public static boolean isCauldron(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        return state.is(Blocks.CAULDRON) || fluidForContent(state.getBlock()) != null;
+    }
+
+    @Nullable
+    public static CauldronFluidHandler create(Level level, BlockPos pos) {
+        return isCauldron(level, pos) ? new CauldronFluidHandler(level, pos) : null;
+    }
+
+    public int layerAmount() {
+        Block content = contentBlock();
+        if (content == null) {
+            return 0;
+        }
+        return nextDrainAmount(content, currentLevel());
+    }
+
+    public int nextDrainAmount() {
+        Block content = contentBlock();
+        return content == null ? 0 : nextDrainAmount(content, currentLevel());
+    }
+
+    private static int nextDrainAmount(Block contentBlock, int currentLevel) {
+        if (currentLevel <= 0) {
+            return 0;
+        }
+        return amountBetweenLevels(contentBlock, currentLevel - 1, currentLevel);
+    }
+
+    public int layerAmountFor(FluidStack stack) {
+        Block content = contentForFluid(stack.getFluid());
+        return content == null ? 0 : nextFillAmount(content, currentLevel());
+    }
+
+    public int nextFillAmount(FluidStack stack) {
+        return layerAmountFor(stack);
+    }
+
+    private static int nextFillAmount(Block contentBlock, int currentLevel) {
+        int maxLevel = CauldronUtil.maxLevel(contentBlock);
+        if (currentLevel >= maxLevel) {
+            return 0;
+        }
+        return amountBetweenLevels(contentBlock, currentLevel, currentLevel + 1);
+    }
+
+    public int minLayerAmount() {
+        Block content = contentBlock();
+        if (content == null) {
+            return DEFAULT_TOTAL_AMOUNT;
+        }
+        int maxLevel = CauldronUtil.maxLevel(content);
+        if (maxLevel <= 0) {
+            return DEFAULT_TOTAL_AMOUNT;
+        }
+        return totalAmount(content) / maxLevel;
+    }
+
+    public int layerTransferAmountTo(CauldronFluidHandler target) {
+        FluidStack stored = getFluidInTank(0);
+        if (stored.isEmpty()) {
+            return 0;
+        }
+        int drainAmount = nextDrainAmount();
+        int fillAmount = target.nextFillAmount(stored);
+        if (drainAmount <= 0 || fillAmount <= 0) {
+            return 0;
+        }
+        return Math.max(drainAmount, fillAmount);
+    }
+
+    public boolean canTransferLayerTo(CauldronFluidHandler target) {
+        return transferLayerTo(target, FluidAction.SIMULATE) > 0;
+    }
+
+    public int fillLayer(FluidStack resource, FluidAction action) {
+        if (resource.isEmpty()) {
+            return 0;
+        }
+        Block content = contentForFluid(resource.getFluid());
+        if (content == null) {
+            return 0;
+        }
+        int filledAmount = nextFillAmount(content, currentLevel());
+        if (filledAmount <= 0 || CauldronUtil.fill(level, pos, content, 1, action.simulate()) != 1) {
+            return 0;
+        }
+        return filledAmount;
+    }
+
+    public int transferLayerTo(CauldronFluidHandler target, FluidAction action) {
+        Block content = contentBlock();
+        Fluid fluid = content == null ? null : fluidForContent(content);
+        if (fluid == null) {
+            return 0;
+        }
+        Block targetContent = contentForFluid(fluid);
+        if (targetContent == null) {
+            return 0;
+        }
+        int drainAmount = nextDrainAmount(content, currentLevel());
+        int fillAmount = target.nextFillAmount(new FluidStack(fluid, totalAmount(targetContent)));
+        if (drainAmount <= 0 || fillAmount <= 0) {
+            return 0;
+        }
+        if (CauldronUtil.drain(level, pos, content, 1, true) != 1
+            || CauldronUtil.fill(target.level, target.pos, targetContent, 1, true) != 1) {
+            return 0;
+        }
+        if (action.execute()) {
+            CauldronUtil.drain(level, pos, content, 1, false);
+            CauldronUtil.fill(target.level, target.pos, targetContent, 1, false);
+        }
+        return Math.max(drainAmount, fillAmount);
+    }
+
+    public int currentLevel() {
+        return CauldronUtil.currentLevel(level.getBlockState(pos));
+    }
+
+    @Override
+    public int getTanks() {
+        return 1;
+    }
+
+    @Override
+    public FluidStack getFluidInTank(int tank) {
+        if (tank != 0) {
+            return FluidStack.EMPTY;
+        }
+        Block content = contentBlock();
+        Fluid fluid = content == null ? null : fluidForContent(content);
+        int currentLevel = currentLevel();
+        if (fluid == null || currentLevel <= 0) {
+            return FluidStack.EMPTY;
+        }
+        return new FluidStack(fluid, amountAtLevel(content, currentLevel));
+    }
+
+    @Override
+    public int getTankCapacity(int tank) {
+        if (tank != 0) {
+            return 0;
+        }
+        Block content = contentBlock();
+        if (content == null) {
+            return DEFAULT_TOTAL_AMOUNT;
+        }
+        return totalAmount(content);
+    }
+
+    @Override
+    public boolean isFluidValid(int tank, FluidStack stack) {
+        return tank == 0 && !stack.isEmpty() && contentForFluid(stack.getFluid()) != null;
+    }
+
+    @Override
+    public int fill(FluidStack resource, FluidAction action) {
+        if (resource.isEmpty()) {
+            return 0;
+        }
+        Block content = contentForFluid(resource.getFluid());
+        if (content == null) {
+            return 0;
+        }
+        int startLevel = currentLevel();
+        int maxLevel = CauldronUtil.maxLevel(content);
+        int filledLevels = 0;
+        int filledAmount = 0;
+        while (startLevel + filledLevels < maxLevel) {
+            int nextAmount = nextFillAmount(content, startLevel + filledLevels);
+            if (resource.getAmount() - filledAmount < nextAmount) {
+                break;
+            }
+            filledLevels++;
+            filledAmount += nextAmount;
+        }
+        if (filledLevels <= 0) {
+            return 0;
+        }
+        int actuallyFilledLevels = CauldronUtil.fill(level, pos, content, filledLevels, action.simulate());
+        return amountBetweenLevels(content, startLevel, startLevel + actuallyFilledLevels);
+    }
+
+    @Override
+    public FluidStack drain(FluidStack resource, FluidAction action) {
+        if (resource.isEmpty()) {
+            return FluidStack.EMPTY;
+        }
+        FluidStack stored = getFluidInTank(0);
+        if (stored.isEmpty() || !FluidStack.isSameFluidSameComponents(stored, resource)) {
+            return FluidStack.EMPTY;
+        }
+        return drain(resource.getAmount(), action);
+    }
+
+    @Override
+    public FluidStack drain(int maxDrain, FluidAction action) {
+        Block content = contentBlock();
+        Fluid fluid = content == null ? null : fluidForContent(content);
+        if (fluid == null) {
+            return FluidStack.EMPTY;
+        }
+        int startLevel = currentLevel();
+        int drainedLevels = 0;
+        int drainedAmount = 0;
+        while (startLevel - drainedLevels > 0) {
+            int nextAmount = nextDrainAmount(content, startLevel - drainedLevels);
+            if (maxDrain - drainedAmount < nextAmount) {
+                break;
+            }
+            drainedLevels++;
+            drainedAmount += nextAmount;
+        }
+        if (drainedLevels <= 0) {
+            return FluidStack.EMPTY;
+        }
+        drainedLevels = CauldronUtil.drain(level, pos, content, drainedLevels, action.simulate());
+        if (drainedLevels <= 0) {
+            return FluidStack.EMPTY;
+        }
+        return new FluidStack(fluid, amountBetweenLevels(content, startLevel - drainedLevels, startLevel));
+    }
+
+    @Nullable
+    private Block contentBlock() {
+        BlockState state = level.getBlockState(pos);
+        if (state.is(Blocks.CAULDRON) || CauldronUtil.currentLevel(state) <= 0) {
+            return null;
+        }
+        return state.getBlock();
+    }
+
+    @Nullable
+    private static Block contentForFluid(Fluid fluid) {
+        ResourceLocation key = BuiltInRegistries.FLUID.getKey(fluid);
+        if (CompatUtil.F2C_TRANSFORM.containsKey(key)) {
+            return Objects.requireNonNull(CompatUtil.F2C_TRANSFORM.get(key)).get();
+        }
+        CauldronFluidContent content = CauldronFluidContent.getForFluid(fluid);
+        return content == null ? null : content.block;
+    }
+
+    @Nullable
+    private static Fluid fluidForContent(Block contentBlock) {
+        CauldronFluidContent content = CauldronFluidContent.getForBlock(contentBlock);
+        if (content != null) {
+            return content.fluid;
+        }
+        ResourceLocation fluidId = CompatUtil.getFluidFromCauldron(contentBlock);
+        return fluidId == null ? null : BuiltInRegistries.FLUID.get(fluidId);
+    }
+
+    private static int amountBetweenLevels(Block contentBlock, int fromLevel, int toLevel) {
+        return amountAtLevel(contentBlock, toLevel) - amountAtLevel(contentBlock, fromLevel);
+    }
+
+    private static int amountAtLevel(Block contentBlock, int level) {
+        int maxLevel = Math.max(1, CauldronUtil.maxLevel(contentBlock));
+        int clamped = Math.clamp(level, 0, maxLevel);
+        int totalAmount = totalAmount(contentBlock);
+        int base = totalAmount / maxLevel;
+        int remainder = totalAmount % maxLevel;
+        return base * clamped + Math.max(0, clamped - (maxLevel - remainder));
+    }
+
+    private static int totalAmount(Block contentBlock) {
+        CauldronFluidContent content = CauldronFluidContent.getForBlock(contentBlock);
+        return content == null ? DEFAULT_TOTAL_AMOUNT : content.totalAmount;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof CauldronFluidHandler(Level level1, BlockPos pos1) && level1 == this.level && pos1.equals(this.pos);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * System.identityHashCode(level) + pos.hashCode();
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidNetworkManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidNetworkManager.java
@@ -86,8 +86,21 @@ public final class FluidNetworkManager {
         if (level.isClientSide()) {
             return;
         }
-        LevelData d = byLevel.get(level);
-        if (d != null) {
+        data(level).dirty = true;
+    }
+
+    public void addAdjacentContainers(Level level, BlockPos pipePos) {
+        if (level.isClientSide()) {
+            return;
+        }
+        LevelData d = data(level);
+        boolean changed = false;
+        for (Direction dir : Direction.values()) {
+            BlockPos pos = pipePos.relative(dir);
+            if (!level.isLoaded(pos)) continue;
+            if (FluidNetworkScanner.isContainer(level, pos) && d.containers.add(pos.immutable())) changed = true;
+        }
+        if (changed) {
             d.dirty = true;
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidNetworkScanner.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidNetworkScanner.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.api.fluid.network;
 
+import dev.dubhe.anvilcraft.api.fluid.CauldronFluidHandler;
 import dev.dubhe.anvilcraft.block.entity.fluid.ControlValveBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.fluid.PipeCheckValveBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.fluid.PumpBlockEntity;
@@ -49,7 +50,8 @@ public final class FluidNetworkScanner {
 
     /** 判断某位置是否为流体容器（提供 IFluidHandler 且非管道部件）。供管理器剔除失效容器用。 */
     public static boolean isContainer(Level level, BlockPos pos) {
-        return level.getCapability(Capabilities.FluidHandler.BLOCK, pos, null) != null
+        return (level.getCapability(Capabilities.FluidHandler.BLOCK, pos, null) != null
+            || CauldronFluidHandler.isCauldron(level, pos))
             && !isPipePart(level.getBlockState(pos));
     }
 
@@ -85,6 +87,8 @@ public final class FluidNetworkScanner {
         if (isPipePart(level.getBlockState(pos))) {
             return null;
         }
+        IFluidHandler cauldron = CauldronFluidHandler.create(level, pos);
+        if (cauldron != null) return cauldron;
         return level.getCapability(Capabilities.FluidHandler.BLOCK, pos, sideToPipe);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidPipeNetwork.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidPipeNetwork.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.api.fluid.network;
 
+import dev.dubhe.anvilcraft.api.fluid.CauldronFluidHandler;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -152,15 +154,8 @@ public class FluidPipeNetwork {
     /** 从单个源端点向所有更低的端点分配其持有的流体。 */
     private void distributeFromSource(FluidEndpoint source) {
         // 源接管口朝本源容器那一面若装止逆阀，其允许方向必须朝网络（背离容器），否则本源无法向网络排液
-        if (source.sideToPipe() != null) {
-            Direction faceToContainer = source.sideToPipe().getOpposite();
-            Map<Direction, Direction> faces = faceFlow.get(source.fromPipePos());
-            if (faces != null) {
-                Direction allowed = faces.get(faceToContainer);
-                if (allowed != null && allowed == faceToContainer) {
-                    return; // 阀门只许流向容器 → 不能从此容器抽出
-                }
-            }
+        if (!canDrainFromEndpoint(source)) {
+            return;
         }
         IFluidHandler srcHandler = source.handler();
         // 逐个 tank 处理源中的流体（多数容器仅一个 tank）
@@ -169,34 +164,18 @@ public class FluidPipeNetwork {
             if (stored.isEmpty()) {
                 continue;
             }
-            // 从源出发做方向感知可达 BFS：二极管（泵）只能正向穿过、阀门按过滤放行、
-            // 面止逆阀只能沿允许方向穿过；得到 可达接管口 → 路径上的阀门列表。
-            boolean needReachability = !valves.isEmpty() || !diodes.isEmpty() || !faceFlow.isEmpty();
+            // 从源出发做方向感知可达 BFS：二极管（泵）只能正向穿过、阀门按过滤放行、面止逆阀只能沿允许方向穿过；得到 可达接管口 → 路径上的阀门列表。
+            boolean needReachability = hasDirectionalConstraints();
             Reachability reach = needReachability
                 ? computeReachable(source.fromPipePos(), stored)
                 : null;
             Map<BlockPos, List<ValveState>> pathValves = reach == null ? Map.of() : reach.pathValves();
             // 按等效高度升序分组，仅收集严格更低、接受该流体、且可达的目标
-            TreeMap<Integer, List<FluidEndpoint>> byHeight = new TreeMap<>();
-            for (FluidEndpoint target : endpoints) {
-                if (target == source) {
-                    continue;
-                }
-                if (target.effectiveHeight() >= source.effectiveHeight()) {
-                    continue;
-                }
-                if (target.handler().equals(srcHandler)) {
-                    continue; // 同一容器（如巨型储罐多 part）不自我搬运
-                }
-                if (target.handler().fill(stored.copyWithAmount(1), IFluidHandler.FluidAction.SIMULATE) <= 0) {
-                    continue; // 该目标无法接受此流体（类型不符或已满）
-                }
-                if (reach != null && !isEndpointReachable(reach, target)) {
-                    continue; // 不可达（逆二极管方向 或 被阀门过滤阻断）
-                }
-                byHeight.computeIfAbsent(target.effectiveHeight(), k -> new ArrayList<>()).add(target);
-            }
+            TreeMap<Integer, List<FluidEndpoint>> byHeight = collectTargetsByHeight(source, stored, reach);
             if (byHeight.isEmpty()) {
+                continue;
+            }
+            if (hasHigherPrioritySource(source, stored, byHeight)) {
                 continue;
             }
             // 从最低组开始填，本组填满才溢流到更高组
@@ -210,8 +189,7 @@ public class FluidPipeNetwork {
                 if (srcHandler.getFluidInTank(tankIdx).isEmpty()) {
                     break;
                 }
-                // 本组未被填满（受流速/预算限制，或本就有余量）→ 不向更高组溢流，
-                // 未流出的部分留在源中等待下 1 tick
+                // 本组未被填满（受流速/预算限制，或本就有余量）→ 不向更高组溢流，未流出的部分留在源中等待下 1 tick
                 if (!groupFull) {
                     break;
                 }
@@ -244,6 +222,9 @@ public class FluidPipeNetwork {
             .thenComparingInt(e -> Math.abs(e.containerPos().getZ() - src.getZ())));
 
         IFluidHandler srcHandler = source.handler();
+        if (usesLayerTransfer(source, group)) {
+            return fillGroupByLayers(source, tankIdx, group, groupSpeed, pathValves);
+        }
         int budget = groupSpeed;
 
         while (budget > 0) {
@@ -319,6 +300,289 @@ public class FluidPipeNetwork {
             }
         }
         return isGroupCapacityFull(group);
+    }
+
+    @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
+    private boolean fillGroupByLayers(
+        FluidEndpoint source, int tankIdx, List<FluidEndpoint> group, int groupSpeed,
+        Map<BlockPos, List<ValveState>> pathValves
+    ) {
+        IFluidHandler srcHandler = source.handler();
+        FluidStack initialStored = srcHandler.getFluidInTank(tankIdx);
+        int budgetLayers = Math.max(1, Math.ceilDiv(groupSpeed, minLayerAmount(source, group, initialStored)));
+
+        while (budgetLayers > 0) {
+            FluidStack stored = srcHandler.getFluidInTank(tankIdx);
+            if (stored.isEmpty()) {
+                break;
+            }
+            List<FluidEndpoint> active = new ArrayList<>();
+            for (FluidEndpoint target : group) {
+                int amount = transferAmount(source, target, stored);
+                if (amount <= 0 || minValveRemaining(pathValves.get(target.fromPipePos())) < amount) {
+                    continue;
+                }
+                if (canMoveLayer(source, tankIdx, target, amount, stored)) {
+                    active.add(target);
+                }
+            }
+            if (active.isEmpty()) {
+                break;
+            }
+            active.sort(layerTargetComparator(source));
+            FluidEndpoint target = active.getFirst();
+            List<ValveState> valvePath = pathValves.get(target.fromPipePos());
+            int amount = transferAmount(source, target, stored);
+            if (amount <= 0 || minValveRemaining(valvePath) < amount) {
+                break;
+            }
+            if (!canMoveLayer(source, tankIdx, target, amount, stored)) {
+                break;
+            }
+            int moved;
+            if (source.handler() instanceof CauldronFluidHandler sourceCauldron
+                && target.handler() instanceof CauldronFluidHandler targetCauldron) {
+                moved = sourceCauldron.transferLayerTo(targetCauldron, IFluidHandler.FluidAction.EXECUTE);
+            } else if (target.handler() instanceof CauldronFluidHandler targetCauldron) {
+                int drainAmount = Math.min(amount, stored.getAmount());
+                FluidStack drained = srcHandler.drain(stored.copyWithAmount(drainAmount), IFluidHandler.FluidAction.EXECUTE);
+                if (drained.isEmpty()) {
+                    break;
+                }
+                moved = targetCauldron.fillLayer(drained, IFluidHandler.FluidAction.EXECUTE);
+                if (moved <= 0) {
+                    srcHandler.fill(drained, IFluidHandler.FluidAction.EXECUTE);
+                    break;
+                }
+                discardOneMbRemainderAfterFillingCauldron(source, tankIdx, target);
+            } else {
+                FluidStack drained = srcHandler.drain(stored.copyWithAmount(amount), IFluidHandler.FluidAction.EXECUTE);
+                if (drained.isEmpty()) {
+                    break;
+                }
+                moved = target.handler().fill(drained, IFluidHandler.FluidAction.EXECUTE);
+                if (moved < drained.getAmount()) {
+                    srcHandler.fill(drained.copyWithAmount(drained.getAmount() - moved), IFluidHandler.FluidAction.EXECUTE);
+                }
+                discardOneMbRemainderAfterFillingCauldron(source, tankIdx, target);
+            }
+            if (moved <= 0) {
+                break;
+            }
+            budgetLayers--;
+            deductValves(valvePath, moved);
+            this.transferredThisTick = true;
+            if (!level.isClientSide()) {
+                TriggerUtil.pipeConnectContainers(level, source.containerPos());
+            }
+        }
+        return isGroupCapacityFull(group);
+    }
+
+    /**
+     * 低位流体源不得抢占高位源仍可供给的目标容器。
+     * 该逻辑保证整个管道网络遵循「高位容器优先输出」规则，即便单向阀会改变流体源的可达判定逻辑也不受影响。
+     */
+    private boolean hasHigherPrioritySource(
+        FluidEndpoint source, FluidStack stored, TreeMap<Integer, List<FluidEndpoint>> targetsByHeight
+    ) {
+        Set<FluidEndpoint> competingTargets = new HashSet<>();
+        for (List<FluidEndpoint> targets : targetsByHeight.values()) {
+            competingTargets.addAll(targets);
+        }
+        boolean needReachability = hasDirectionalConstraints();
+        for (FluidEndpoint higher : sourcesByHeightDesc) {
+            if (higher.effectiveHeight() <= source.effectiveHeight()) {
+                return false;
+            }
+            if (higher.handler().equals(source.handler()) || !canDrainFromEndpoint(higher)) {
+                continue;
+            }
+            IFluidHandler higherHandler = higher.handler();
+            for (int i = 0; i < higherHandler.getTanks(); i++) {
+                FluidStack higherStored = higherHandler.getFluidInTank(i);
+                if (higherStored.isEmpty() || !FluidStack.isSameFluidSameComponents(higherStored, stored)) {
+                    continue;
+                }
+                Reachability higherReach = needReachability
+                    ? computeReachable(higher.fromPipePos(), higherStored)
+                    : null;
+                TreeMap<Integer, List<FluidEndpoint>> higherTargets =
+                    collectTargetsByHeight(higher, higherStored, higherReach);
+                for (List<FluidEndpoint> group : higherTargets.values()) {
+                    if (group.contains(source)) {
+                        return true;
+                    }
+                    for (FluidEndpoint target : group) {
+                        if (competingTargets.contains(target)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private TreeMap<Integer, List<FluidEndpoint>> collectTargetsByHeight(
+        FluidEndpoint source, FluidStack stored, Reachability reach
+    ) {
+        TreeMap<Integer, List<FluidEndpoint>> byHeight = new TreeMap<>();
+        for (FluidEndpoint target : endpoints) {
+            if (target == source) {
+                continue;
+            }
+            if (target.effectiveHeight() >= source.effectiveHeight()) {
+                continue;
+            }
+            if (target.handler().equals(source.handler())) {
+                continue; // 同一容器（如巨型储罐多 part）不自我搬运
+            }
+            int amount = transferAmount(source, target, stored);
+            if (amount <= 0 || !canMoveLayer(source, 0, target, amount, stored)) {
+                continue; // Cannot accept one full transfer unit.
+            }
+            if (reach != null && !isEndpointReachable(reach, target)) {
+                continue; // 不可达（逆二极管方向 或 被阀门过滤阻断）
+            }
+            byHeight.computeIfAbsent(target.effectiveHeight(), k -> new ArrayList<>()).add(target);
+        }
+        return byHeight;
+    }
+
+    private boolean hasDirectionalConstraints() {
+        return !valves.isEmpty() || !diodes.isEmpty() || !faceFlow.isEmpty();
+    }
+
+    private boolean canDrainFromEndpoint(FluidEndpoint source) {
+        if (source.sideToPipe() == null) {
+            return true;
+        }
+        Direction faceToContainer = source.sideToPipe().getOpposite();
+        Map<Direction, Direction> faces = faceFlow.get(source.fromPipePos());
+        if (faces == null) {
+            return true;
+        }
+        Direction allowed = faces.get(faceToContainer);
+        return allowed == null || allowed != faceToContainer;
+    }
+
+    private static boolean usesLayerTransfer(FluidEndpoint source, List<FluidEndpoint> group) {
+        if (source.handler() instanceof CauldronFluidHandler) {
+            return true;
+        }
+        for (FluidEndpoint target : group) {
+            if (target.handler() instanceof CauldronFluidHandler) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int minLayerAmount(FluidEndpoint source, List<FluidEndpoint> group, FluidStack stored) {
+        int min = MAX_SPEED;
+        if (source.handler() instanceof CauldronFluidHandler cauldron) {
+            int amount = cauldron.nextDrainAmount();
+            if (amount > 0) {
+                min = Math.min(min, amount);
+            }
+        }
+        for (FluidEndpoint target : group) {
+            if (target.handler() instanceof CauldronFluidHandler cauldron) {
+                int amount = cauldron.nextFillAmount(stored);
+                if (amount > 0) {
+                    min = Math.min(min, amount);
+                }
+            }
+        }
+        return min == MAX_SPEED ? 1 : min;
+    }
+
+    private static int transferAmount(FluidEndpoint source, FluidEndpoint target, FluidStack stored) {
+        if (source.handler() instanceof CauldronFluidHandler sourceCauldron) {
+            if (target.handler() instanceof CauldronFluidHandler targetCauldron) {
+                return sourceCauldron.layerTransferAmountTo(targetCauldron);
+            }
+            return sourceCauldron.nextDrainAmount();
+        }
+        if (target.handler() instanceof CauldronFluidHandler cauldron) {
+            return cauldron.nextFillAmount(stored);
+        }
+        return 1;
+    }
+
+    private static Comparator<FluidEndpoint> layerTargetComparator(FluidEndpoint source) {
+        return Comparator.comparingInt(FluidPipeNetwork::currentAmount);
+    }
+
+    private static boolean canMoveLayer(
+        FluidEndpoint source, int tankIdx, FluidEndpoint target, int amount, FluidStack stored
+    ) {
+        if (source.handler() instanceof CauldronFluidHandler sourceCauldron
+            && target.handler() instanceof CauldronFluidHandler targetCauldron) {
+            return sourceCauldron.canTransferLayerTo(targetCauldron);
+        }
+        if (source.handler() instanceof CauldronFluidHandler sourceCauldron
+            && !canAcceptCauldronLayerWithoutRemainder(sourceCauldron, target, amount)) {
+            return false;
+        }
+        if (!(source.handler() instanceof CauldronFluidHandler)
+            && target.handler() instanceof CauldronFluidHandler cauldron) {
+            return canFillCauldronLayerFromContainer(cauldron, stored, amount);
+        }
+        if (amount <= 0 || stored.getAmount() < amount) {
+            return false;
+        }
+        FluidStack toMove = stored.copyWithAmount(amount);
+        if (source.handler().drain(toMove, IFluidHandler.FluidAction.SIMULATE).getAmount() < amount) {
+            return false;
+        }
+        return target.handler().fill(toMove, IFluidHandler.FluidAction.SIMULATE) >= amount;
+    }
+
+    private static boolean canFillCauldronLayerFromContainer(
+        CauldronFluidHandler cauldron, FluidStack stored, int amount
+    ) {
+        if (amount <= 0 || stored.isEmpty()) {
+            return false;
+        }
+        if (stored.getAmount() >= amount) {
+            return cauldron.fillLayer(stored.copyWithAmount(amount), IFluidHandler.FluidAction.SIMULATE) > 0;
+        }
+        int minLayerAmount = cauldron.minLayerAmount();
+        boolean roundingShortfall = cauldron.currentLevel() > 0
+            && amount > minLayerAmount
+            && stored.getAmount() >= minLayerAmount - 1;
+        return roundingShortfall
+            && cauldron.fillLayer(stored.copyWithAmount(stored.getAmount()), IFluidHandler.FluidAction.SIMULATE) > 0;
+    }
+
+    private static void discardOneMbRemainderAfterFillingCauldron(
+        FluidEndpoint source, int tankIdx, FluidEndpoint target
+    ) {
+        if (source.handler() instanceof CauldronFluidHandler
+            || !(target.handler() instanceof CauldronFluidHandler)) {
+            return;
+        }
+        FluidStack remaining = source.handler().getFluidInTank(tankIdx);
+        if (remaining.getAmount() == 1) {
+            source.handler().drain(remaining.copyWithAmount(1), IFluidHandler.FluidAction.EXECUTE);
+        }
+    }
+
+    private static boolean canAcceptCauldronLayerWithoutRemainder(
+        CauldronFluidHandler sourceCauldron, FluidEndpoint target, int amount
+    ) {
+        int remainingAfterFill = totalCapacity(target.handler()) - currentAmount(target) - amount;
+        return remainingAfterFill == 0 || remainingAfterFill >= sourceCauldron.minLayerAmount();
+    }
+
+    private static int totalCapacity(IFluidHandler handler) {
+        int total = 0;
+        for (int i = 0; i < handler.getTanks(); i++) {
+            total += handler.getTankCapacity(i);
+        }
+        return total;
     }
 
     /** 本组是否所有目标都按<b>容量</b>装满（与阀门限流无关，决定是否溢流到更高组）。 */

--- a/src/main/java/dev/dubhe/anvilcraft/api/heat/collector/HeatCollectorManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/heat/collector/HeatCollectorManager.java
@@ -145,7 +145,7 @@ public class HeatCollectorManager {
     private void collectSources(IHeatCollector collector, Map<Entry, Double2ObjectMap<IHeatCollector>> heatSources) {
         BlockPos collectorPos = collector.getCollectorPos();
         int collectorRange = collector.getCollectorRange();
-        int overlapRange = collectorRange + 1;
+        int overlapRange = collectorRange + InfiniteCollectorBlockEntity.RANGE;
         Map<Entry, Double2ObjectMap<IHeatCollector>> heatSourcesCache = new HashMap<>();
         for (BlockPos pos : BlockPos.betweenClosed(
             collectorPos.above(overlapRange).east(overlapRange).south(overlapRange),
@@ -153,11 +153,9 @@ public class HeatCollectorManager {
         )) {
             pos = pos.immutable();
             BlockState state = this.level.getBlockState(pos);
-            // Check for other collectors (both heat and infinite) in range
             if (!pos.equals(collectorPos)) {
-                boolean isNearHeatCollector = state.is(ModBlocks.HEAT_COLLECTOR.get());
-                boolean isNearInfiniteCollector = state.is(ModBlocks.INFINITE_COLLECTOR.get());
-                if (isNearHeatCollector || isNearInfiniteCollector) {
+                int otherCollectorRange = this.getCollectorRange(state);
+                if (otherCollectorRange > 0 && this.isRangeOverlapping(collectorPos, pos, collectorRange, otherCollectorRange)) {
                     collector.setCollectorWorking(false);
                     return;
                 }
@@ -187,6 +185,18 @@ public class HeatCollectorManager {
                 .computeIfAbsent(entry.getKey(), it -> new Double2ObjectAVLTreeMap<>())
                 .putAll(entry.getValue());
         }
+    }
+
+    private boolean isRangeOverlapping(BlockPos collectorPos, BlockPos otherPos, int collectorRange, int otherCollectorRange) {
+        return Math.abs(otherPos.getX() - collectorPos.getX()) <= collectorRange + otherCollectorRange
+            && Math.abs(otherPos.getY() - collectorPos.getY()) <= collectorRange + otherCollectorRange
+            && Math.abs(otherPos.getZ() - collectorPos.getZ()) <= collectorRange + otherCollectorRange;
+    }
+
+    private int getCollectorRange(BlockState state) {
+        if (state.is(ModBlocks.HEAT_COLLECTOR.get())) return 2;
+        if (state.is(ModBlocks.INFINITE_COLLECTOR.get())) return InfiniteCollectorBlockEntity.RANGE;
+        return 0;
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/block/PulseGeneratorBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/PulseGeneratorBlock.java
@@ -168,8 +168,13 @@ public class PulseGeneratorBlock extends HorizontalDirectionalBlock implements I
     protected void checkIsDeadlock(Level level, BlockPos pos, Supplier<BlockState> stateGetter, PulseGeneratorBlockEntity generator) {
         if (generator.getStartMode() == PulseGeneratorBlockEntity.Mode.LOOP) {
             if (generator.isDeadlock() && !generator.isInputtingSignal()) {
-                this.startWaiting(level, pos, stateGetter, generator);
                 generator.setDeadlock(false);
+                if (generator.getWaitingTime() == 0) {
+                    generator.setState(PulseGeneratorBlockEntity.State.WAITING);
+                    level.scheduleTick(pos, this, 1, TickPriority.LOW);
+                } else {
+                    this.startWaiting(level, pos, stateGetter, generator);
+                }
             } else {
                 generator.setDeadlock(generator.isInputtingSignal());
             }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
@@ -170,7 +170,8 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
                 this.getBlockPos().relative(direction)
             );
         }
-        if (!tempIrradiateBlockPos.equals(this.irradiateBlockPos)) {
+        boolean targetChanged = !tempIrradiateBlockPos.equals(this.irradiateBlockPos);
+        if (targetChanged) {
             if (this.irradiateBlockPos != null) {
                 BlockEntity oldBe = this.level.getBlockEntity(this.irradiateBlockPos);
                 if (oldBe instanceof BaseLaserBlockEntity lastIrradiatedLaserBlockEntity) {
@@ -178,11 +179,15 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
                 }
             }
         }
+        int newLaserLevel = this.calculateLaserLevel();
+        boolean laserLevelChanged = this.laserLevel != newLaserLevel;
+        this.updateLaserLevel(newLaserLevel);
         if (
             this.level.getBlockEntity(tempIrradiateBlockPos) instanceof BaseLaserBlockEntity irradiatedLaserBlockEntity
             && !this.isInIrradiateSelfLaserBlockSet(irradiatedLaserBlockEntity)
         ) {
-            if (!irradiatedLaserBlockEntity.getIgnoreFace().contains(direction)) {
+            boolean needsIrradiationUpdate = targetChanged || laserLevelChanged;
+            if (needsIrradiationUpdate && !irradiatedLaserBlockEntity.getIgnoreFace().contains(direction)) {
                 this.level.updateNeighborsAt(tempIrradiateBlockPos, getBlockState().getBlock());
                 irradiatedLaserBlockEntity.onIrradiated(this);
             }
@@ -190,7 +195,6 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
         this.updateIrradiateBlockPos(tempIrradiateBlockPos);
 
         if (!(this.level instanceof ServerLevel serverLevel)) return;
-        this.updateLaserLevel(this.calculateLaserLevel());
         int hurt = Math.min(16, this.laserLevel - 4);
         if (hurt > 0) {
             Vec3 startPos = this.getBlockPos()

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/HeatCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/HeatCollectorBlockEntity.java
@@ -62,8 +62,14 @@ public class HeatCollectorBlockEntity extends BlockEntity implements IPowerProdu
 
     @Override
     public void gridTick() {
-        if (!this.isWorking() || level == null || level.isClientSide()) return;
+        if (level == null || level.isClientSide()) return;
         int oldPower = this.outputPower;
+        if (!this.isWorking()) {
+            this.outputPower = 0;
+            this.inputtingPower = 0;
+            if (this.outputPower != oldPower && grid != null) grid.markChanged();
+            return;
+        }
         this.outputPower = this.inputtingPower;
         if (this.outputPower > 0 && this.getBlockState().getBlock() instanceof HeatCollectorBlock collector) {
             collector.activate(this.level, this.getBlockPos(), this.getBlockState());

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/InfiniteCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/InfiniteCollectorBlockEntity.java
@@ -7,21 +7,27 @@ import dev.dubhe.anvilcraft.api.power.IPowerProducer;
 import dev.dubhe.anvilcraft.api.power.PowerGrid;
 import dev.dubhe.anvilcraft.api.tooltip.providers.IHasAffectRange;
 import dev.dubhe.anvilcraft.block.InfiniteCollectorBlock;
+import dev.dubhe.anvilcraft.network.ChargeCollectorIncomingChargePacket;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
 
 public class InfiniteCollectorBlockEntity extends BlockEntity implements IPowerProducer, IHasAffectRange, IHeatCollector {
     public static final int BASE_OUTPUT_POWER = 256;
     public static final int RANGE = 3;
+    private static final int CHARGE_HISTORY_SIZE = 10;
 
     @Getter
     private int time = 0;
@@ -30,7 +36,11 @@ public class InfiniteCollectorBlockEntity extends BlockEntity implements IPowerP
     private PowerGrid grid = null;
     @Getter
     private int outputPower = 0;
-    private int inputtingPower = 0;
+    private int inputtingHeatPower = 0;
+    private int inputCooldownCount = ChargeCollectorBlockEntity.INPUT_COOLDOWN;
+    private double chargeCount = 0;
+    private int chargePower = 0;
+    private final LinkedList<Integer> charges = new LinkedList<>();
     @Getter
     private float rotation = 0;
     @Getter
@@ -39,6 +49,9 @@ public class InfiniteCollectorBlockEntity extends BlockEntity implements IPowerP
 
     public InfiniteCollectorBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         super(type, pos, blockState);
+        for (int i = 0; i < CHARGE_HISTORY_SIZE; i++) {
+            this.charges.add(0);
+        }
     }
 
     public static InfiniteCollectorBlockEntity createBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
@@ -54,27 +67,78 @@ public class InfiniteCollectorBlockEntity extends BlockEntity implements IPowerP
     protected void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.saveAdditional(tag, registries);
         tag.putInt("tickCache", this.time);
-        tag.putInt("inputtingPower", this.inputtingPower);
+        tag.putInt("inputtingHeatPower", this.inputtingHeatPower);
+        tag.putInt("InputCooldownCount", this.inputCooldownCount);
+        tag.putDouble("ChargeCount", this.chargeCount);
+        tag.putInt("ChargePower", this.chargePower);
+        tag.putIntArray("Charges", this.charges);
     }
 
     @Override
     protected void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
         super.loadAdditional(tag, registries);
         this.time = tag.getInt("tickCache");
-        this.inputtingPower = tag.getInt("inputtingPower");
+        this.inputtingHeatPower = tag.contains("inputtingHeatPower")
+            ? tag.getInt("inputtingHeatPower")
+            : tag.getInt("inputtingPower");
+        this.inputCooldownCount = tag.getInt("InputCooldownCount");
+        if (this.inputCooldownCount <= 0) {
+            this.inputCooldownCount = ChargeCollectorBlockEntity.INPUT_COOLDOWN;
+        }
+        this.chargeCount = tag.getDouble("ChargeCount");
+        this.chargePower = tag.getInt("ChargePower");
+        int[] savedCharges = tag.getIntArray("Charges");
+        this.charges.clear();
+        for (int charge : savedCharges) {
+            this.charges.add(charge);
+        }
+        while (this.charges.size() < CHARGE_HISTORY_SIZE) {
+            this.charges.add(0);
+        }
+        while (this.charges.size() > CHARGE_HISTORY_SIZE) {
+            this.charges.removeFirst();
+        }
     }
 
     @Override
     public void gridTick() {
-        if (!this.isWorking() || level == null || level.isClientSide()) return;
+        if (level == null || level.isClientSide()) return;
         int oldPower = this.outputPower;
-        this.outputPower = BASE_OUTPUT_POWER + this.inputtingPower;
+        if (!this.isWorking()) {
+            this.outputPower = 0;
+            this.inputtingHeatPower = 0;
+            this.chargeCount = 0;
+            if (this.outputPower != oldPower && grid != null) grid.markChanged();
+            return;
+        }
+        if (this.inputCooldownCount-- <= 1) {
+            this.inputCooldownCount = ChargeCollectorBlockEntity.INPUT_COOLDOWN;
+            this.addCharge((int) Math.floor(this.chargeCount));
+            this.chargeCount = 0;
+            this.refreshChargePower();
+        }
+        this.outputPower = BASE_OUTPUT_POWER + this.inputtingHeatPower + this.chargePower;
         if (this.outputPower > 0 && this.getBlockState().getBlock() instanceof InfiniteCollectorBlock collector) {
             collector.activate(this.level, this.getBlockPos(), this.getBlockState());
         }
         if (this.outputPower != oldPower && grid != null) grid.markChanged();
-        this.inputtingPower = 0;
+        this.inputtingHeatPower = 0;
         this.time++;
+    }
+
+    private void addCharge(int charge) {
+        this.charges.add(charge);
+        while (this.charges.size() > CHARGE_HISTORY_SIZE) {
+            this.charges.removeFirst();
+        }
+    }
+
+    private void refreshChargePower() {
+        int power = 0;
+        for (Integer charge : this.charges) {
+            power += charge;
+        }
+        this.chargePower = power / this.charges.size();
     }
 
     @Override
@@ -118,7 +182,7 @@ public class InfiniteCollectorBlockEntity extends BlockEntity implements IPowerP
      */
     public int inputtingHeat(int num) {
         if (!this.isWorking()) return num;
-        this.inputtingPower += num;
+        this.inputtingHeatPower += num;
         return 0;
     }
 
@@ -130,8 +194,15 @@ public class InfiniteCollectorBlockEntity extends BlockEntity implements IPowerP
      * @return 溢出的电荷数(即未被添加至收集器的电荷数)
      */
     public double incomingCharge(double num, BlockPos srcPos) {
-        if (!this.isWorking()) return num;
-        this.inputtingPower += (int) Math.floor(num);
+        if (!this.isWorking() || this.level == null) return num;
+        if (this.level instanceof ServerLevel serverLevel) {
+            PacketDistributor.sendToPlayersTrackingChunk(
+                serverLevel,
+                this.level.getChunkAt(worldPosition).getPos(),
+                new ChargeCollectorIncomingChargePacket(srcPos, this.worldPosition, num)
+            );
+        }
+        this.chargeCount += num;
         return 0;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/LensBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/LensBlockEntity.java
@@ -131,7 +131,8 @@ public class LensBlockEntity extends BaseLaserBlockEntity {
         BlockPos tempIrradiateBlockPos = this.scanIrradiateBlockPos(
             this.maxTransmissionDistance, direction, this.getBlockPos()
         );
-        if (!tempIrradiateBlockPos.equals(this.irradiateBlockPos)) {
+        boolean targetChanged = !tempIrradiateBlockPos.equals(this.irradiateBlockPos);
+        if (targetChanged) {
             if (this.irradiateBlockPos != null) {
                 BlockEntity oldBe = this.level.getBlockEntity(this.irradiateBlockPos);
                 if (oldBe instanceof BaseLaserBlockEntity lastIrradiatedLaserBlockEntity) {
@@ -139,11 +140,15 @@ public class LensBlockEntity extends BaseLaserBlockEntity {
                 }
             }
         }
+        int newLaserLevel = this.calculateLaserLevel();
+        boolean laserLevelChanged = this.laserLevel != newLaserLevel;
+        this.updateLaserLevel(newLaserLevel);
         if (
             this.level.getBlockEntity(tempIrradiateBlockPos) instanceof BaseLaserBlockEntity irradiatedLaserBlockEntity
             && !this.isInIrradiateSelfLaserBlockSet(irradiatedLaserBlockEntity)
         ) {
-            if (!irradiatedLaserBlockEntity.getIgnoreFace().contains(direction)) {
+            boolean needsIrradiationUpdate = targetChanged || laserLevelChanged;
+            if (needsIrradiationUpdate && !irradiatedLaserBlockEntity.getIgnoreFace().contains(direction)) {
                 this.level.updateNeighborsAt(tempIrradiateBlockPos, getBlockState().getBlock());
                 irradiatedLaserBlockEntity.onIrradiated(this);
             }
@@ -151,7 +156,6 @@ public class LensBlockEntity extends BaseLaserBlockEntity {
         this.updateIrradiateBlockPos(tempIrradiateBlockPos);
 
         if (!(this.level instanceof ServerLevel serverLevel)) return;
-        this.updateLaserLevel(this.calculateLaserLevel());
         int hurt = Math.min(16, this.laserLevel - 4);
         if (hurt > 0) {
             Vec3 startPos = this.getBlockPos()

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/TradingStationBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/TradingStationBlockEntity.java
@@ -16,12 +16,14 @@ import lombok.Getter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.MenuProvider;
@@ -385,8 +387,25 @@ public class TradingStationBlockEntity extends BlockEntity implements IItemHandl
             accessor.setUpdateMerchantTimer(40);
             accessor.setIncreaseProfessionLevelOnUpdate(true);
         }
+        this.spawnVillagerTradeParticles();
         TradingStationBlockEntity.updateAndSend(this);
         return true;
+    }
+
+    private void spawnVillagerTradeParticles() {
+        if (!(this.level instanceof ServerLevel serverLevel)) return;
+        BlockPos pos = this.getBlockPos();
+        serverLevel.sendParticles(
+            ParticleTypes.HAPPY_VILLAGER,
+            pos.getX() + 0.5,
+            pos.getY() + 1.0,
+            pos.getZ() + 0.5,
+            12,
+            0.35,
+            0.3,
+            0.35,
+            0.02
+        );
     }
 
     private Optional<MerchantOffer> findAcceptableOffer(Villager villager) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorOption.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorOption.java
@@ -1,6 +1,6 @@
 package dev.dubhe.anvilcraft.block.entity.celestial;
 
-import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 
@@ -9,14 +9,14 @@ import net.minecraft.world.level.ItemLike;
 ///
 /// ring - 要重构的环编号（R1-R6）
 /// megastructure - 巨构模型名称后缀（例如"eco_station"、"dyson_sphere"）
-/// modelLocation - 巨构模型的完整 {@link ModelResourceLocation}
+/// modelLocation - 巨构模型的位置。客户端渲染时转换为客户端模型标识。
 /// displayName - 巨构显示名称的翻译键
 /// material - 所需建筑材料的物品栈，若无则为 {@link ItemStack#EMPTY}
 /// materialCount - 所需材料的数量
 public record CelestialRefactorOption(
     int ring,
     String megastructure,
-    ModelResourceLocation modelLocation,
+    ResourceLocation modelLocation,
     String displayName,
     ItemStack material,
     int materialCount
@@ -24,7 +24,7 @@ public record CelestialRefactorOption(
 
     /// 创建一个不需要建筑材料的重构选项。
     public static CelestialRefactorOption noMaterial(
-        int ring, String megastructure, ModelResourceLocation modelLocation, String displayName
+        int ring, String megastructure, ResourceLocation modelLocation, String displayName
     ) {
         return new CelestialRefactorOption(
             ring, megastructure, modelLocation, displayName, ItemStack.EMPTY, 0
@@ -40,7 +40,7 @@ public record CelestialRefactorOption(
     /// material - 所需物品
     /// materialCount - 所需物品数量
     public static CelestialRefactorOption withMaterial(
-        int ring, String megastructure, ModelResourceLocation modelLocation, String displayName,
+        int ring, String megastructure, ResourceLocation modelLocation, String displayName,
         ItemLike material, int materialCount
     ) {
         return new CelestialRefactorOption(

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorRegistry.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorRegistry.java
@@ -3,7 +3,7 @@ package dev.dubhe.anvilcraft.block.entity.celestial;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModItems;
-import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -214,9 +214,7 @@ public final class CelestialRefactorRegistry {
         return options;
     }
 
-    private static ModelResourceLocation ringModel(int ring, String megastructure) {
-        return ModelResourceLocation.standalone(
-            AnvilCraft.of("block/celestial_forging_anvil_ring_" + ring + "_" + megastructure)
-        );
+    private static ResourceLocation ringModel(int ring, String megastructure) {
+        return AnvilCraft.of("block/celestial_forging_anvil_ring_" + ring + "_" + megastructure);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/SpecialCelestialBodyData.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/SpecialCelestialBodyData.java
@@ -1,8 +1,8 @@
 package dev.dubhe.anvilcraft.block.entity.celestial;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
-import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.Nullable;
 
@@ -85,8 +85,8 @@ public record SpecialCelestialBodyData(
     }
 
     /// 获取此特殊天体的独立模型/贴图资源路径
-    public ModelResourceLocation getModelLocation() {
-        return ModelResourceLocation.standalone(AnvilCraft.of("block/celestial_body/" + model));
+    public ResourceLocation getModelLocation() {
+        return AnvilCraft.of("block/celestial_body/" + model);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeBlock.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.block.fluid;
 
 import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
+import dev.dubhe.anvilcraft.api.fluid.CauldronFluidHandler;
 import dev.dubhe.anvilcraft.api.fluid.network.FluidNetworkManager;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
@@ -271,6 +272,7 @@ public abstract class PipeBlock extends Block
      */
     public static boolean isFluidHandler(Level level, BlockPos pos) {
         BlockState state = level.getBlockState(pos);
+        if (CauldronFluidHandler.isCauldron(level, pos)) return true;
         BlockEntity be = level.getBlockEntity(pos);
         return level.getCapability(Capabilities.FluidHandler.BLOCK, pos, state, be, null) != null;
     }
@@ -295,6 +297,7 @@ public abstract class PipeBlock extends Block
         if (state.getBlock() instanceof ControlValveBlock) {
             return ControlValveBlock.isConnectableFace(state, towardNeighbor);
         }
+        if (CauldronFluidHandler.isCauldron(level, pos)) return true;
         BlockEntity be = level.getBlockEntity(pos);
         return level.getCapability(Capabilities.FluidHandler.BLOCK, pos, state, be, null) != null;
     }
@@ -663,6 +666,7 @@ public abstract class PipeBlock extends Block
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
         super.onPlace(state, level, pos, oldState, movedByPiston);
         if (!level.isClientSide) {
+            FluidNetworkManager.INSTANCE.addAdjacentContainers(level, pos);
             FluidNetworkManager.INSTANCE.markDirty(level);
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeCornerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeCornerBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block.fluid;
 
+import dev.dubhe.anvilcraft.api.fluid.network.FluidNetworkManager;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -73,6 +74,7 @@ public class PipeCornerBlock extends PipeBlock {
         if (level.isClientSide) {
             return;
         }
+        FluidNetworkManager.INSTANCE.addAdjacentContainers(level, pos);
         // 红石信号变化 → 更新本管道止逆阀反向状态
         updateCheckValvePower(state, level, pos);
         CornerEnded corner = state.getValue(CORNER_ENDED);

--- a/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeNodeBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeNodeBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block.fluid;
 
+import dev.dubhe.anvilcraft.api.fluid.network.FluidNetworkManager;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -118,6 +119,7 @@ public class PipeNodeBlock extends PipeBlock {
         if (level.isClientSide()) {
             return;
         }
+        FluidNetworkManager.INSTANCE.addAdjacentContainers(level, pos);
 
         // 红石信号变化 → 更新本节点止逆阀反向状态
         updateCheckValvePower(state, level, pos);

--- a/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeStraightBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/fluid/PipeStraightBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block.fluid;
 
+import dev.dubhe.anvilcraft.api.fluid.network.FluidNetworkManager;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -94,6 +95,7 @@ public class PipeStraightBlock extends PipeBlock {
         if (level.isClientSide) {
             return;
         }
+        FluidNetworkManager.INSTANCE.addAdjacentContainers(level, pos);
         // 红石信号变化 → 更新本管道止逆阀反向状态
         updateCheckValvePower(state, level, pos);
         Direction.Axis axis = state.getValue(AXIS);

--- a/src/main/java/dev/dubhe/anvilcraft/block/item/HeatCollectorBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/item/HeatCollectorBlockItem.java
@@ -1,6 +1,10 @@
 package dev.dubhe.anvilcraft.block.item;
 
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.List;
 
 public class HeatCollectorBlockItem extends PlacementIntervalsBlockItem {
     public HeatCollectorBlockItem(Block block, Properties properties) {
@@ -15,5 +19,21 @@ public class HeatCollectorBlockItem extends PlacementIntervalsBlockItem {
     @Override
     public int getIntervalsRadius() {
         return 4;
+    }
+
+    @Override
+    protected int getIntervalsRadius(BlockState state) {
+        if (state.is(ModBlocks.INFINITE_COLLECTOR.get())) return 5;
+        return super.getIntervalsRadius(state);
+    }
+
+    @Override
+    protected List<Block> getIntervalBlocks() {
+        return List.of(ModBlocks.HEAT_COLLECTOR.get(), ModBlocks.INFINITE_COLLECTOR.get());
+    }
+
+    @Override
+    protected int getMaxIntervalsRadius() {
+        return 5;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/item/InfiniteCollectorBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/item/InfiniteCollectorBlockItem.java
@@ -1,6 +1,10 @@
 package dev.dubhe.anvilcraft.block.item;
 
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.List;
 
 public class InfiniteCollectorBlockItem extends PlacementIntervalsBlockItem {
     public InfiniteCollectorBlockItem(Block block, Properties properties) {
@@ -15,5 +19,16 @@ public class InfiniteCollectorBlockItem extends PlacementIntervalsBlockItem {
     @Override
     public int getIntervalsRadius() {
         return 6;
+    }
+
+    @Override
+    protected int getIntervalsRadius(BlockState state) {
+        if (state.is(ModBlocks.HEAT_COLLECTOR.get())) return 5;
+        return super.getIntervalsRadius(state);
+    }
+
+    @Override
+    protected List<Block> getIntervalBlocks() {
+        return List.of(ModBlocks.HEAT_COLLECTOR.get(), ModBlocks.INFINITE_COLLECTOR.get());
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/item/PlacementIntervalsBlockItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/item/PlacementIntervalsBlockItem.java
@@ -11,6 +11,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
+import java.util.List;
+
 /**
  * 限制方块放置间距的抽象 {@link BlockItem}。
  *
@@ -33,6 +35,10 @@ public abstract class PlacementIntervalsBlockItem extends BlockItem {
         return false;
     }
 
+    protected List<Block> getIntervalBlocks() {
+        return List.of(this.getBlock());
+    }
+
     /**
      * 获取放置间距半径。
      *
@@ -42,6 +48,21 @@ public abstract class PlacementIntervalsBlockItem extends BlockItem {
      * @return 放置间距半径（方块数）
      */
     public abstract int getIntervalsRadius();
+
+    protected int getIntervalsRadius(BlockState state) {
+        return this.getIntervalsRadius();
+    }
+
+    protected int getMaxIntervalsRadius() {
+        return this.getIntervalsRadius();
+    }
+
+    protected boolean isIntervalBlock(BlockState state) {
+        for (Block block : this.getIntervalBlocks()) {
+            if (state.is(block)) return true;
+        }
+        return false;
+    }
 
     /**
      * 判断是否可以在指定上下文中放置该方块。
@@ -60,12 +81,16 @@ public abstract class PlacementIntervalsBlockItem extends BlockItem {
         Player player = context.getPlayer();
         BlockPos clickedPos = context.getClickedPos();
         Iterable<BlockPos> blockPoss = BlockPos.betweenClosed(
-            clickedPos.offset(getIntervalsRadius(), getIntervalsRadius(), getIntervalsRadius()),
-            clickedPos.offset(-getIntervalsRadius(), -getIntervalsRadius(), -getIntervalsRadius())
+            clickedPos.offset(getMaxIntervalsRadius(), getMaxIntervalsRadius(), getMaxIntervalsRadius()),
+            clickedPos.offset(-getMaxIntervalsRadius(), -getMaxIntervalsRadius(), -getMaxIntervalsRadius())
         );
         for (BlockPos blockPos : blockPoss) {
             BlockState blockState = level.getBlockState(blockPos);
-            if (blockState.is(this.getBlock())) {
+            int distance = Math.max(
+                Math.max(Math.abs(blockPos.getX() - clickedPos.getX()), Math.abs(blockPos.getY() - clickedPos.getY())),
+                Math.abs(blockPos.getZ() - clickedPos.getZ())
+            );
+            if (this.isIntervalBlock(blockState) && distance <= this.getIntervalsRadius(blockState)) {
                 if (level.isClientSide() && player instanceof LocalPlayer localPlayer) {
                     if (this.doRangeNoOverlap()) {
                         localPlayer.displayClientMessage(

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/ClientEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/ClientEventListener.java
@@ -11,6 +11,7 @@ import dev.dubhe.anvilcraft.client.support.StructureDiskPreviewSupport;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import dev.dubhe.anvilcraft.network.DragonRodStopDevourPacket;
 import dev.dubhe.anvilcraft.network.UsePillBoxPacket;
 import dev.dubhe.anvilcraft.util.BlockHighlightUtil;
 import net.minecraft.client.Minecraft;
@@ -31,9 +32,12 @@ import net.neoforged.neoforge.client.event.RenderBlockScreenEffectEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.client.event.RenderTooltipEvent;
 import net.neoforged.neoforge.client.event.ScreenEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
 
 @EventBusSubscriber(modid = AnvilCraft.MOD_ID, value = Dist.CLIENT)
 public class ClientEventListener {
+    private static boolean wasAttackDown = false;
+
     @SubscribeEvent
     public static void blockHighlight(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_ENTITIES) return;
@@ -95,6 +99,8 @@ public class ClientEventListener {
 
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
+        handleAttackKeyRelease();
+
         long lastThoughtTime = ThoughtManager.getLastThoughtTime();
         if (lastThoughtTime < 0) {
             return;
@@ -104,6 +110,30 @@ public class ClientEventListener {
         long deltaTime = curTime - lastThoughtTime;
         if (deltaTime > ThoughtManager.getMAX_SECONDS() * 20) {
             ThoughtManager.onPostThought();
+        }
+    }
+
+    @SubscribeEvent
+    public static void onMouseButton(InputEvent.MouseButton.Post event) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (event.getAction() == InputConstants.RELEASE && minecraft.options.keyAttack.matchesMouse(event.getButton())) {
+            sendDragonRodStopDevourPacket(minecraft);
+            wasAttackDown = false;
+        }
+    }
+
+    private static void handleAttackKeyRelease() {
+        Minecraft minecraft = Minecraft.getInstance();
+        boolean attackDown = minecraft.options.keyAttack.isDown();
+        if (wasAttackDown && !attackDown) {
+            sendDragonRodStopDevourPacket(minecraft);
+        }
+        wasAttackDown = attackDown;
+    }
+
+    private static void sendDragonRodStopDevourPacket(Minecraft minecraft) {
+        if (minecraft.player != null && minecraft.getConnection() != null) {
+            PacketDistributor.sendToServer(new DragonRodStopDevourPacket());
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/ClientEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/ClientEventListener.java
@@ -10,8 +10,10 @@ import dev.dubhe.anvilcraft.client.support.AmuletSelectorSupport;
 import dev.dubhe.anvilcraft.client.support.StructureDiskPreviewSupport;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.inventory.HammerOpenedAnvilMenu;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
 import dev.dubhe.anvilcraft.network.DragonRodStopDevourPacket;
+import dev.dubhe.anvilcraft.network.OpenHammerAnvilPacket;
 import dev.dubhe.anvilcraft.network.UsePillBoxPacket;
 import dev.dubhe.anvilcraft.util.BlockHighlightUtil;
 import net.minecraft.client.Minecraft;
@@ -148,6 +150,28 @@ public class ClientEventListener {
             AnvilCraftClient.pillSelectorSupport.mouseScrolled(-amount);
             event.setCanceled(true);
         }
+    }
+
+    @SubscribeEvent
+    public static void onScreenMousePressed(ScreenEvent.MouseButtonPressed.Pre event) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (!minecraft.options.keyUse.matchesMouse(event.getButton())) return;
+        if (!(event.getScreen() instanceof AbstractContainerScreen<?> containerScreen)) return;
+        if (minecraft.player == null || minecraft.getConnection() == null) return;
+        if (!containerScreen.getMenu().getCarried().isEmpty()) return;
+        Slot slot = containerScreen.getSlotUnderMouse();
+        if (slot == null) return;
+        if (containerScreen.getMenu() instanceof HammerOpenedAnvilMenu menu
+            && slot.container == minecraft.player.getInventory()
+            && menu.anvilcraft$getOpenedHammerSlot() == slot.getContainerSlot()) {
+            return;
+        }
+        ItemStack stack = slot.getItem();
+        if (!(stack.getItem() instanceof AnvilHammerItem)) return;
+        int menuSlotId = containerScreen.getMenu().slots.indexOf(slot);
+        if (menuSlotId < 0) return;
+        PacketDistributor.sendToServer(new OpenHammerAnvilPacket(menuSlotId));
+        event.setCanceled(true);
     }
 
     @SubscribeEvent

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/GuiLayerRegistrationEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/GuiLayerRegistrationEventListener.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.platform.Window;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.tooltip.HudTooltipManager;
 import dev.dubhe.anvilcraft.block.multipart.AbstractMultiPartBlock;
+import dev.dubhe.anvilcraft.client.hud.AnvilHammerUseHUD;
 import dev.dubhe.anvilcraft.client.hud.IonoCraftBackpackHUD;
 import dev.dubhe.anvilcraft.client.hud.TradingStationHUD;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
@@ -71,6 +72,7 @@ public class GuiLayerRegistrationEventListener {
         });
 
         event.registerAboveAll(AnvilCraft.of("test"), GuiLayerRegistrationEventListener::render);
+        event.registerAboveAll(AnvilCraft.of("anvil_hammer_use"), AnvilHammerUseHUD::render);
         event.registerAboveAll(AnvilCraft.of("ionocraft_backpack"), IonoCraftBackpackHUD::render);
         event.registerAboveAll(AnvilCraft.of("trading_station"), TradingStationHUD::render);
         // 注意：结构磁盘预览不在这里注册，因为它需要在Screen的tooltip之后渲染

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
@@ -43,7 +43,11 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ButtonBlock;
+import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -653,6 +657,7 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 ));
             }
         } else {
+            this.runLocalDefaultInteraction();
             PacketDistributor.sendToServer(new HammerUsePacket(this.targetBlockPos, this.hand, this.hitVec));
             super.removed();
             return;
@@ -689,6 +694,20 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
     @Override
     public boolean shouldSkipRebuildBlock() {
         return !this.shouldRebuildChunk;
+    }
+
+    private void runLocalDefaultInteraction() {
+        Level level = this.minecraft.level;
+        if (level == null || this.minecraft.player == null) return;
+        BlockState state = level.getBlockState(this.targetBlockPos);
+        Block block = state.getBlock();
+        if (!(block instanceof DoorBlock
+              || block instanceof TrapDoorBlock
+              || block instanceof FenceGateBlock
+              || block instanceof ButtonBlock)) {
+            return;
+        }
+        state.useWithoutItem(level, this.minecraft.player, this.hitVec);
     }
 
     public static void renderRing(

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerSlotOverlay.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerSlotOverlay.java
@@ -1,0 +1,25 @@
+package dev.dubhe.anvilcraft.client.gui.screen;
+
+import dev.dubhe.anvilcraft.init.item.ModItemTags;
+import dev.dubhe.anvilcraft.inventory.HammerOpenedAnvilMenu;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.Slot;
+
+public final class AnvilHammerSlotOverlay {
+    private static final int COLOR = 0x66FFD800;
+
+    private AnvilHammerSlotOverlay() {
+    }
+
+    public static void render(GuiGraphics guiGraphics, HammerOpenedAnvilMenu menu, Slot slot) {
+        if (!menu.anvilcraft$isOpenedByHammer()) return;
+        if (Minecraft.getInstance().player == null) return;
+        Inventory inventory = Minecraft.getInstance().player.getInventory();
+        if (slot.container != inventory) return;
+        if (slot.getContainerSlot() != menu.anvilcraft$getOpenedHammerSlot()) return;
+        if (!slot.getItem().is(ModItemTags.ANVIL_HAMMER)) return;
+        guiGraphics.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, COLOR);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CelestialForgingAnvilScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CelestialForgingAnvilScreen.java
@@ -534,7 +534,7 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
     private void renderMegastructureModel(GuiGraphics guiGraphics, CelestialRefactorOption option, int x, int y, int w, int h) {
         BakedModel model = null;
         if (minecraft != null) {
-            model = minecraft.getModelManager().getModel(option.modelLocation());
+            model = minecraft.getModelManager().getModel(ModelResourceLocation.standalone(option.modelLocation()));
         }
 
         ModelBlockRenderer modelRenderer = minecraft.getBlockRenderer().getModelRenderer();
@@ -937,7 +937,7 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
     /// 通过方块模型渲染复杂模型天体（粉碎、空洞、错误天体等）。
     private void renderComplexModelPreview(GuiGraphics guiGraphics, SpecialCelestialBodyData special) {
         if (minecraft == null) return;
-        var modelLoc = special.getModelLocation();
+        var modelLoc = ModelResourceLocation.standalone(special.getModelLocation());
         BakedModel model = minecraft.getModelManager().getModel(modelLoc);
         if (model == minecraft.getModelManager().getMissingModel()) return;
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StructureScannerScreen.java
@@ -46,8 +46,8 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.network.PacketDistributor;
@@ -803,63 +803,13 @@ public class StructureScannerScreen extends AbstractContainerScreen<StructureSca
      * 根据 Scanner 朝向旋转方块状态
      */
     private BlockState rotateBlockStateForPreview(BlockState state, Direction scannerFacing) {
-        if (scannerFacing == Direction.NORTH) {
-            return state;
-        }
-
-        // 处理水平朝向属性（HORIZONTAL_FACING）
-        if (state.hasProperty(BlockStateProperties.HORIZONTAL_FACING)) {
-            Direction blockFacing = state.getValue(BlockStateProperties.HORIZONTAL_FACING);
-            Direction rotatedFacing = rotateDirection(blockFacing, scannerFacing);
-            return state.setValue(BlockStateProperties.HORIZONTAL_FACING, rotatedFacing);
-        }
-
-        // 处理水平朝向属性（HorizontalDirectionalBlock.FACING）
-        if (state.hasProperty(HorizontalDirectionalBlock.FACING)) {
-            Direction blockFacing = state.getValue(HorizontalDirectionalBlock.FACING);
-            Direction rotatedFacing = rotateDirection(blockFacing, scannerFacing);
-            return state.setValue(HorizontalDirectionalBlock.FACING, rotatedFacing);
-        }
-
-        // 处理六向朝向属性（FACING）- 用于活塞、发射器等
-        if (state.hasProperty(BlockStateProperties.FACING)) {
-            Direction blockFacing = state.getValue(BlockStateProperties.FACING);
-            Direction rotatedFacing = rotateDirection6Way(blockFacing, scannerFacing);
-            return state.setValue(BlockStateProperties.FACING, rotatedFacing);
-        }
-
-        return state;
-    }
-
-    /**
-     * 根据 Scanner 朝向旋转方向（水平4向）
-     */
-    private Direction rotateDirection(Direction blockFacing, Direction scannerFacing) {
-        return switch (scannerFacing) {
-            case SOUTH -> blockFacing.getOpposite();
-            case WEST -> blockFacing.getClockWise();
-            case EAST -> blockFacing.getCounterClockWise();
-            default -> blockFacing;
+        Rotation rotation = switch (scannerFacing) {
+            case SOUTH -> Rotation.CLOCKWISE_180;
+            case WEST -> Rotation.CLOCKWISE_90;
+            case EAST -> Rotation.COUNTERCLOCKWISE_90;
+            default -> Rotation.NONE;
         };
-    }
-
-    /**
-     * 根据 Scanner 朝向旋转方向（六向，包括UP和DOWN）
-     * 用于活塞、发射器等方块
-     */
-    private Direction rotateDirection6Way(Direction blockFacing, Direction scannerFacing) {
-        // UP和DOWN不受水平旋转影响
-        if (blockFacing == Direction.UP || blockFacing == Direction.DOWN) {
-            return blockFacing;
-        }
-
-        // 水平方向正常旋转
-        return switch (scannerFacing) {
-            case SOUTH -> blockFacing.getOpposite();
-            case WEST -> blockFacing.getClockWise();
-            case EAST -> blockFacing.getCounterClockWise();
-            default -> blockFacing;
-        };
+        return state.rotate(rotation);
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/dev/dubhe/anvilcraft/client/hud/AnvilHammerUseHUD.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/hud/AnvilHammerUseHUD.java
@@ -1,0 +1,56 @@
+package dev.dubhe.anvilcraft.client.hud;
+
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.util.Mth;
+
+public final class AnvilHammerUseHUD {
+    private static final int SEGMENTS = 48;
+    private static final int BACKGROUND_COLOR = 0x99D0D0D0;
+    private static final int PROGRESS_COLOR = 0xD8A9F59B;
+
+    private AnvilHammerUseHUD() {
+    }
+
+    public static void render(GuiGraphics graphics, DeltaTracker deltaTracker) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.options.hideGui || minecraft.screen != null) return;
+        LocalPlayer player = minecraft.player;
+        if (player == null || !player.isUsingItem()) return;
+        if (!(player.getUseItem().getItem() instanceof AnvilHammerItem)) return;
+
+        float partialTick = deltaTracker.getGameTimeDeltaPartialTick(minecraft.isPaused());
+        int remainingTicks = player.getUseItemRemainingTicks();
+        float progress = Mth.clamp(
+            (AnvilHammerItem.PORTABLE_ANVIL_USE_TICKS - remainingTicks + partialTick)
+            / AnvilHammerItem.PORTABLE_ANVIL_USE_TICKS,
+            0.0F,
+            1.0F
+        );
+        if (progress <= 0.0F) return;
+
+        renderRing(graphics, 24, minecraft.getWindow().getGuiScaledHeight() - 24, progress);
+    }
+
+    private static void renderRing(GuiGraphics graphics, int centerX, int centerY, float progress) {
+        drawRing(graphics, centerX, centerY, SEGMENTS, BACKGROUND_COLOR);
+        drawRing(graphics, centerX, centerY, Mth.ceil(SEGMENTS * progress), PROGRESS_COLOR);
+    }
+
+    private static void drawRing(GuiGraphics graphics, int centerX, int centerY, int segments, int color) {
+        for (int segment = 0; segment < segments; segment++) {
+            double angle = -Math.PI / 2.0D + Math.PI * 2.0D * segment / SEGMENTS;
+            drawPoint(graphics, centerX, centerY, angle, 10, color);
+            drawPoint(graphics, centerX, centerY, angle, 8, color);
+        }
+    }
+
+    private static void drawPoint(GuiGraphics graphics, int centerX, int centerY, double angle, int radius, int color) {
+        int x = centerX + Mth.floor(Math.cos(angle) * radius);
+        int y = centerY + Mth.floor(Math.sin(angle) * radius);
+        graphics.fill(x, y, x + 2, y + 2, color);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
@@ -969,7 +969,9 @@ public class CelestialForgingAnvilBlockEntityRenderer implements BlockEntityRend
         MultiBufferSource bufferSource,
         int packedOverlay
     ) {
-        BakedModel model = Minecraft.getInstance().getModelManager().getModel(special.getModelLocation());
+        BakedModel model = Minecraft.getInstance()
+            .getModelManager()
+            .getModel(ModelResourceLocation.standalone(special.getModelLocation()));
         if (model == Minecraft.getInstance().getModelManager().getMissingModel()) return;
 
         VertexConsumer consumer = bufferSource.getBuffer(RenderType.cutout());

--- a/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/PlayerEventListener.java
@@ -127,6 +127,11 @@ public class PlayerEventListener {
         final ItemStack stack = event.getItemStack();
         final Direction blockFace = event.getFace();
 
+        if (event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.STOP
+            || event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.ABORT) {
+            DragonRodItem.stopContinuousMode(player);
+            return;
+        }
         if (blockFace == null) return;
         if (state.getDestroySpeed(level, pos) < 0.0F) return;
         if (!stack.has(ModComponents.DEVOUR_RANGE)) return;
@@ -139,9 +144,6 @@ public class PlayerEventListener {
             DragonRodItem.devourBlock((ServerLevel) level, player, hand, pos, state, blockFace);
         } else if (event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.CLIENT_HOLD) {
             PacketDistributor.sendToServer(new DragonRodDevourPacket(hand, pos, blockFace));
-        } else if (event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.STOP
-            || event.getAction() == PlayerInteractEvent.LeftClickBlock.Action.ABORT) {
-            DragonRodItem.stopContinuousMode(player);
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModMenuTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModMenuTypes.java
@@ -52,6 +52,7 @@ import dev.dubhe.anvilcraft.inventory.ItemCollectorMenu;
 import dev.dubhe.anvilcraft.inventory.ItemDetectorMenu;
 import dev.dubhe.anvilcraft.inventory.JewelCraftingMenu;
 import dev.dubhe.anvilcraft.inventory.MagneticChuteMenu;
+import dev.dubhe.anvilcraft.inventory.PortableAnvilMenu;
 import dev.dubhe.anvilcraft.inventory.PulseGeneratorMenu;
 import dev.dubhe.anvilcraft.inventory.RoyalAnvilMenu;
 import dev.dubhe.anvilcraft.inventory.RoyalGrindstoneMenu;
@@ -63,13 +64,19 @@ import dev.dubhe.anvilcraft.inventory.StructureToolMenu;
 import dev.dubhe.anvilcraft.inventory.TeslaTowerMenu;
 import dev.dubhe.anvilcraft.inventory.TradingStationMenu;
 import dev.dubhe.anvilcraft.inventory.TranscendenceAnvilMenu;
+import net.minecraft.client.gui.screens.inventory.AnvilScreen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.inventory.AnvilMenu;
 
 import static dev.dubhe.anvilcraft.AnvilCraft.REGISTRUM;
 
 public class ModMenuTypes {
+    public static final MenuEntry<AnvilMenu> PORTABLE_ANVIL = REGISTRUM
+        .menu("portable_anvil", (type, id, inv) -> new PortableAnvilMenu(id, inv), () -> AnvilScreen::new)
+        .register();
+
     public static final MenuEntry<CelestialForgingAnvilMenu> CFA = REGISTRUM
         .menu("celestial_forging_anvil", CelestialForgingAnvilMenu::new, () -> CelestialForgingAnvilScreen::new)
         .register();

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/EmberAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/EmberAnvilMenu.java
@@ -6,23 +6,44 @@ import dev.dubhe.anvilcraft.util.anvil.AnvilMenuResult;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.DataSlot;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.CommonHooks;
+import org.jetbrains.annotations.Nullable;
 
-public class EmberAnvilMenu extends AnvilMenu {
+import java.util.Objects;
+
+public class EmberAnvilMenu extends AnvilMenu implements HammerOpenedAnvilMenu {
     public final AnvilMenuResult result = AnvilMenuResult.builder()
         .allowBeyondMaxLevel(AnvilCraft.CONFIG.emberAnvilBeyondMaxLevel)
         .ignoreEnchantmentCompatible()
         .create();
+    private final Inventory playerInventory;
+    private final DataSlot openedHammerSlot = DataSlot.standalone();
+    private final @Nullable OpenedHammerSource openedHammerSource;
+    private boolean closingForHammerMove;
 
     public EmberAnvilMenu(int containerId, Inventory playerInventory) {
-        super(containerId, playerInventory);
+        this(containerId, playerInventory, ContainerLevelAccess.NULL);
     }
 
     public EmberAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access) {
+        this(containerId, playerInventory, access, HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT);
+    }
+
+    public EmberAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, int openedHammerSlot) {
+        this(containerId, playerInventory, access, OpenedHammerSource.fromInventory(playerInventory, openedHammerSlot));
+    }
+
+    public EmberAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, @Nullable OpenedHammerSource source) {
         super(containerId, playerInventory, access);
+        this.playerInventory = playerInventory;
+        this.openedHammerSource = source;
+        this.openedHammerSlot.set(source == null ? HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT : source.clientInventorySlot());
+        this.addDataSlot(this.openedHammerSlot);
     }
 
     @Override
@@ -44,10 +65,65 @@ public class EmberAnvilMenu extends AnvilMenu {
             inputLeft,
             inputRight,
             this.itemName,
-            tax -> CommonHooks.onAnvilChange(this, inputLeft, inputRight, this.resultSlots, this.itemName, tax, this.player)
+            tax -> CommonHooks.onAnvilChange(
+                this,
+                inputLeft,
+                inputRight,
+                this.resultSlots,
+                Objects.requireNonNull(this.itemName),
+                tax,
+                this.player
+            )
         );
         this.resultSlots.setItem(0, this.result.result);
         this.cost.set(this.result.xpCost);
         this.repairItemCountCost = this.result.repairItemCountCost;
+    }
+
+    @Override
+    public int anvilcraft$getOpenedHammerSlot() {
+        return this.openedHammerSlot.get();
+    }
+
+    @Override
+    public void clicked(int slotId, int button, ClickType clickType, Player player) {
+        boolean touchedHammer = HammerOpenedAnvilMenuHelper.touchesOpenedHammerSlot(
+            this,
+            this.playerInventory,
+            slotId,
+            button,
+            clickType,
+            this.openedHammerSlot.get()
+        );
+        if (touchedHammer) {
+            HammerOpenedAnvilMenuHelper.closeOnServer(player);
+            return;
+        }
+        super.clicked(slotId, button, clickType, player);
+        this.closeIfOpenedHammerMoved();
+    }
+
+    @Override
+    public void broadcastChanges() {
+        super.broadcastChanges();
+        this.closeIfOpenedHammerMoved();
+    }
+
+    @Override
+    protected void onTake(Player player, ItemStack stack) {
+        super.onTake(player, stack);
+        if (this.openedHammerSource != null) {
+            HammerOpenedAnvilMenuHelper.playUseSound(player);
+        }
+        this.closeIfOpenedHammerMoved();
+    }
+
+    private void closeIfOpenedHammerMoved() {
+        if (this.openedHammerSource == null || this.closingForHammerMove) return;
+        if (this.openedHammerSource.stillInPlace()) {
+            return;
+        }
+        this.closingForHammerMove = true;
+        HammerOpenedAnvilMenuHelper.closeOnServer(this.player);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/HammerOpenedAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/HammerOpenedAnvilMenu.java
@@ -1,0 +1,9 @@
+package dev.dubhe.anvilcraft.inventory;
+
+public interface HammerOpenedAnvilMenu {
+    int anvilcraft$getOpenedHammerSlot();
+
+    default boolean anvilcraft$isOpenedByHammer() {
+        return this.anvilcraft$getOpenedHammerSlot() != HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/HammerOpenedAnvilMenuHelper.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/HammerOpenedAnvilMenuHelper.java
@@ -1,0 +1,52 @@
+package dev.dubhe.anvilcraft.inventory;
+
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.Slot;
+
+public final class HammerOpenedAnvilMenuHelper {
+    public static final int NO_HAMMER_SLOT = -1;
+    public static final int REMOTE_HAMMER_SLOT = -2;
+
+    private HammerOpenedAnvilMenuHelper() {
+    }
+
+    public static boolean isValidInventorySlot(Inventory inventory, int slot) {
+        return slot < 0 || slot >= inventory.getContainerSize();
+    }
+
+    public static boolean touchesOpenedHammerSlot(
+        AbstractContainerMenu menu,
+        Inventory inventory,
+        int slotId,
+        int button,
+        ClickType clickType,
+        int openedHammerSlot
+    ) {
+        if (isValidInventorySlot(inventory, openedHammerSlot)) return false;
+        if (slotId >= 0 && slotId < menu.slots.size()) {
+            Slot slot = menu.getSlot(slotId);
+            if (slot.container == inventory && slot.getContainerSlot() == openedHammerSlot) {
+                return true;
+            }
+        }
+        return clickType == ClickType.SWAP
+               && (button == openedHammerSlot && openedHammerSlot < 9
+                   || button == Inventory.SLOT_OFFHAND && openedHammerSlot == Inventory.SLOT_OFFHAND);
+    }
+
+    public static void closeOnServer(Player player) {
+        if (!player.level().isClientSide) {
+            player.closeContainer();
+        }
+    }
+
+    public static void playUseSound(Player player) {
+        if (player.level().isClientSide) return;
+        player.level().playSound(null, player.blockPosition(), SoundEvents.ANVIL_USE, SoundSource.BLOCKS, 1.0F, 1.0F);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/OpenedHammerSource.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/OpenedHammerSource.java
@@ -1,0 +1,106 @@
+package dev.dubhe.anvilcraft.inventory;
+
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public final class OpenedHammerSource {
+    private final @Nullable Inventory inventory;
+    private final int inventorySlot;
+    private final @Nullable Slot menuSlot;
+    private final int clientInventorySlot;
+    private final Item openedHammerItem;
+
+    private OpenedHammerSource(
+        @Nullable Inventory inventory,
+        int inventorySlot,
+        @Nullable Slot menuSlot,
+        int clientInventorySlot,
+        Item openedHammerItem
+    ) {
+        this.inventory = inventory;
+        this.inventorySlot = inventorySlot;
+        this.menuSlot = menuSlot;
+        this.clientInventorySlot = clientInventorySlot;
+        this.openedHammerItem = openedHammerItem;
+    }
+
+    public static @Nullable OpenedHammerSource fromInventory(Inventory inventory, int inventorySlot) {
+        if (HammerOpenedAnvilMenuHelper.isValidInventorySlot(inventory, inventorySlot)) return null;
+        ItemStack stack = inventory.getItem(inventorySlot);
+        if (!(stack.getItem() instanceof AnvilHammerItem)) return null;
+        return new OpenedHammerSource(inventory, inventorySlot, null, inventorySlot, stack.getItem());
+    }
+
+    public static @Nullable OpenedHammerSource fromMenuSlot(Slot slot, Inventory playerInventory) {
+        ItemStack stack = slot.getItem();
+        if (!(stack.getItem() instanceof AnvilHammerItem)) return null;
+        int clientSlot = slot.container == playerInventory
+                         ? slot.getContainerSlot()
+                         : HammerOpenedAnvilMenuHelper.REMOTE_HAMMER_SLOT;
+        return new OpenedHammerSource(null, HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT, slot, clientSlot, stack.getItem());
+    }
+
+    public int clientInventorySlot() {
+        return this.clientInventorySlot;
+    }
+
+    public Item openedHammerItem() {
+        return this.openedHammerItem;
+    }
+
+    public boolean stillInPlace() {
+        return this.getStack().is(this.openedHammerItem);
+    }
+
+    public void damage() {
+        ItemStack hammer = this.getStack();
+        if (!hammer.is(this.openedHammerItem) || !hammer.isDamageableItem()) return;
+        int nextDamage = hammer.getDamageValue() + 1;
+        if (nextDamage >= hammer.getMaxDamage()) {
+            this.setStack(ItemStack.EMPTY);
+        } else {
+            hammer.setDamageValue(nextDamage);
+            this.setChanged();
+        }
+    }
+
+    private ItemStack getStack() {
+        if (this.inventory != null) {
+            return this.inventory.getItem(this.inventorySlot);
+        }
+        if (this.menuSlot != null) {
+            return this.menuSlot.getItem();
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private void setStack(ItemStack stack) {
+        if (this.inventory != null) {
+            this.inventory.setItem(this.inventorySlot, stack);
+            this.inventory.setChanged();
+            return;
+        }
+        if (this.menuSlot != null) {
+            this.menuSlot.set(stack);
+            this.menuSlot.setChanged();
+            Container container = this.menuSlot.container;
+            container.setChanged();
+        }
+    }
+
+    private void setChanged() {
+        if (this.inventory != null) {
+            this.inventory.setChanged();
+            return;
+        }
+        if (this.menuSlot != null) {
+            this.menuSlot.setChanged();
+            this.menuSlot.container.setChanged();
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/PortableAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/PortableAnvilMenu.java
@@ -1,0 +1,88 @@
+package dev.dubhe.anvilcraft.inventory;
+
+import dev.dubhe.anvilcraft.init.ModMenuTypes;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.DataSlot;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+public class PortableAnvilMenu extends AnvilMenu implements HammerOpenedAnvilMenu {
+    private final Inventory playerInventory;
+    private final DataSlot openedHammerSlot = DataSlot.standalone();
+    private final @Nullable OpenedHammerSource openedHammerSource;
+    private boolean closingForHammerMove;
+
+    public PortableAnvilMenu(int containerId, Inventory playerInventory) {
+        this(containerId, playerInventory, ContainerLevelAccess.NULL, HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT);
+    }
+
+    public PortableAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, int openedHammerSlot) {
+        this(containerId, playerInventory, access, OpenedHammerSource.fromInventory(playerInventory, openedHammerSlot));
+    }
+
+    public PortableAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, @Nullable OpenedHammerSource source) {
+        super(containerId, playerInventory, access);
+        this.playerInventory = playerInventory;
+        this.openedHammerSource = source;
+        this.openedHammerSlot.set(source == null ? HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT : source.clientInventorySlot());
+        this.addDataSlot(this.openedHammerSlot);
+    }
+
+    @Override
+    public MenuType<?> getType() {
+        return ModMenuTypes.PORTABLE_ANVIL.get();
+    }
+
+    @Override
+    public int anvilcraft$getOpenedHammerSlot() {
+        return this.openedHammerSlot.get();
+    }
+
+    @Override
+    protected void onTake(Player player, ItemStack stack) {
+        super.onTake(player, stack);
+        if (this.openedHammerSource != null) {
+            this.openedHammerSource.damage();
+            HammerOpenedAnvilMenuHelper.playUseSound(player);
+        }
+        this.closeIfOpenedHammerMoved();
+    }
+
+    @Override
+    public void clicked(int slotId, int button, ClickType clickType, Player player) {
+        boolean touchedHammer = HammerOpenedAnvilMenuHelper.touchesOpenedHammerSlot(
+            this,
+            this.playerInventory,
+            slotId,
+            button,
+            clickType,
+            this.openedHammerSlot.get()
+        );
+        if (touchedHammer) {
+            HammerOpenedAnvilMenuHelper.closeOnServer(player);
+            return;
+        }
+        super.clicked(slotId, button, clickType, player);
+        this.closeIfOpenedHammerMoved();
+    }
+
+    @Override
+    public void broadcastChanges() {
+        super.broadcastChanges();
+        this.closeIfOpenedHammerMoved();
+    }
+
+    private void closeIfOpenedHammerMoved() {
+        if (this.openedHammerSource == null || this.closingForHammerMove) return;
+        if (this.openedHammerSource.stillInPlace()) {
+            return;
+        }
+        this.closingForHammerMove = true;
+        HammerOpenedAnvilMenuHelper.closeOnServer(this.player);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalAnvilMenu.java
@@ -10,23 +10,44 @@ import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.DataSlot;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.CommonHooks;
+import org.jetbrains.annotations.Nullable;
 
-public class RoyalAnvilMenu extends AnvilMenu {
+import java.util.Objects;
+
+public class RoyalAnvilMenu extends AnvilMenu implements HammerOpenedAnvilMenu {
     public final AnvilMenuResult result = AnvilMenuResult.builder()
         .allowBeyondMaxLevel(AnvilCraft.CONFIG.royalAnvilBeyondMaxLevel)
         .create();
+    private final Inventory playerInventory;
+    private final DataSlot openedHammerSlot = DataSlot.standalone();
+    private final @Nullable OpenedHammerSource openedHammerSource;
+    private boolean closingForHammerMove;
 
     public RoyalAnvilMenu(int containerId, Inventory playerInventory) {
-        super(containerId, playerInventory);
+        this(containerId, playerInventory, ContainerLevelAccess.NULL);
     }
 
     public RoyalAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access) {
+        this(containerId, playerInventory, access, HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT);
+    }
+
+    public RoyalAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, int openedHammerSlot) {
+        this(containerId, playerInventory, access, OpenedHammerSource.fromInventory(playerInventory, openedHammerSlot));
+    }
+
+    public RoyalAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, @Nullable OpenedHammerSource source) {
         super(containerId, playerInventory, access);
+        this.playerInventory = playerInventory;
+        this.openedHammerSource = source;
+        this.openedHammerSlot.set(source == null ? HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT : source.clientInventorySlot());
+        this.addDataSlot(this.openedHammerSlot);
     }
 
     @Override
@@ -48,7 +69,15 @@ public class RoyalAnvilMenu extends AnvilMenu {
             inputLeft,
             inputRight,
             this.itemName,
-            tax -> CommonHooks.onAnvilChange(this, inputLeft, inputRight, this.resultSlots, this.itemName, tax, this.player)
+            tax -> CommonHooks.onAnvilChange(
+                this,
+                inputLeft,
+                inputRight,
+                this.resultSlots,
+                Objects.requireNonNull(this.itemName),
+                tax,
+                this.player
+            )
         );
         this.resultSlots.setItem(0, this.result.result);
         this.cost.set(this.result.xpCost);
@@ -56,8 +85,50 @@ public class RoyalAnvilMenu extends AnvilMenu {
     }
 
     @Override
+    public int anvilcraft$getOpenedHammerSlot() {
+        return this.openedHammerSlot.get();
+    }
+
+    @Override
+    public void clicked(int slotId, int button, ClickType clickType, Player player) {
+        boolean touchedHammer = HammerOpenedAnvilMenuHelper.touchesOpenedHammerSlot(
+            this,
+            this.playerInventory,
+            slotId,
+            button,
+            clickType,
+            this.openedHammerSlot.get()
+        );
+        if (touchedHammer) {
+            HammerOpenedAnvilMenuHelper.closeOnServer(player);
+            return;
+        }
+        super.clicked(slotId, button, clickType, player);
+        this.closeIfOpenedHammerMoved();
+    }
+
+    @Override
+    public void broadcastChanges() {
+        super.broadcastChanges();
+        this.closeIfOpenedHammerMoved();
+    }
+
+    private void closeIfOpenedHammerMoved() {
+        if (this.openedHammerSource == null || this.closingForHammerMove) return;
+        if (this.openedHammerSource.stillInPlace()) {
+            return;
+        }
+        this.closingForHammerMove = true;
+        HammerOpenedAnvilMenuHelper.closeOnServer(this.player);
+    }
+
+    @Override
     protected void onTake(Player player, ItemStack stack) {
         super.onTake(player, stack);
+        if (this.openedHammerSource != null) {
+            HammerOpenedAnvilMenuHelper.playUseSound(player);
+        }
+        this.closeIfOpenedHammerMoved();
         Level level = player.level();
         if (level.isClientSide()) return;
         int curedNumber = IAbnormal.getAbnormalCount(player, ICursed.class);

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/TranscendenceAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/TranscendenceAnvilMenu.java
@@ -8,12 +8,17 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AnvilMenu;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.DataSlot;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.CommonHooks;
+import org.jetbrains.annotations.Nullable;
 
-public class TranscendenceAnvilMenu extends AnvilMenu {
+import java.util.Objects;
+
+public class TranscendenceAnvilMenu extends AnvilMenu implements HammerOpenedAnvilMenu {
     public final AnvilMenuResult result = AnvilMenuResult.builder()
         .allowBeyondMaxLevel(AnvilCraft.CONFIG.transcendenceAnvilBeyondMaxLevel)
         .allowEnchantingMultipleItems()
@@ -22,13 +27,34 @@ public class TranscendenceAnvilMenu extends AnvilMenu {
         .noTaxInRepairUsingItem()
         .useNewRepairCostAlgorithm()
         .create();
+    private final Inventory playerInventory;
+    private final DataSlot openedHammerSlot = DataSlot.standalone();
+    private final @Nullable OpenedHammerSource openedHammerSource;
+    private boolean closingForHammerMove;
 
     public TranscendenceAnvilMenu(int containerId, Inventory playerInventory) {
-        super(containerId, playerInventory);
+        this(containerId, playerInventory, ContainerLevelAccess.NULL);
     }
 
     public TranscendenceAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access) {
+        this(containerId, playerInventory, access, HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT);
+    }
+
+    public TranscendenceAnvilMenu(int containerId, Inventory playerInventory, ContainerLevelAccess access, int openedHammerSlot) {
+        this(containerId, playerInventory, access, OpenedHammerSource.fromInventory(playerInventory, openedHammerSlot));
+    }
+
+    public TranscendenceAnvilMenu(
+        int containerId,
+        Inventory playerInventory,
+        ContainerLevelAccess access,
+        @Nullable OpenedHammerSource source
+    ) {
         super(containerId, playerInventory, access);
+        this.playerInventory = playerInventory;
+        this.openedHammerSource = source;
+        this.openedHammerSlot.set(source == null ? HammerOpenedAnvilMenuHelper.NO_HAMMER_SLOT : source.clientInventorySlot());
+        this.addDataSlot(this.openedHammerSlot);
     }
 
     @Override
@@ -50,7 +76,15 @@ public class TranscendenceAnvilMenu extends AnvilMenu {
             inputLeft,
             inputRight,
             this.itemName,
-            tax -> CommonHooks.onAnvilChange(this, inputLeft, inputRight, this.resultSlots, this.itemName, tax, this.player)
+            tax -> CommonHooks.onAnvilChange(
+                this,
+                inputLeft,
+                inputRight,
+                this.resultSlots,
+                Objects.requireNonNull(this.itemName),
+                tax,
+                this.player
+            )
         );
         this.resultSlots.setItem(0, this.result.result);
         this.cost.set(this.result.xpCost);
@@ -58,13 +92,54 @@ public class TranscendenceAnvilMenu extends AnvilMenu {
     }
 
     @Override
+    public int anvilcraft$getOpenedHammerSlot() {
+        return this.openedHammerSlot.get();
+    }
+
+    @Override
+    public void clicked(int slotId, int button, ClickType clickType, Player player) {
+        boolean touchedHammer = HammerOpenedAnvilMenuHelper.touchesOpenedHammerSlot(
+            this,
+            this.playerInventory,
+            slotId,
+            button,
+            clickType,
+            this.openedHammerSlot.get()
+        );
+        if (touchedHammer) {
+            HammerOpenedAnvilMenuHelper.closeOnServer(player);
+            return;
+        }
+        super.clicked(slotId, button, clickType, player);
+        this.closeIfOpenedHammerMoved();
+    }
+
+    @Override
+    public void broadcastChanges() {
+        super.broadcastChanges();
+        this.closeIfOpenedHammerMoved();
+    }
+
+    private void closeIfOpenedHammerMoved() {
+        if (this.openedHammerSource == null || this.closingForHammerMove) return;
+        if (this.openedHammerSource.stillInPlace()) {
+            return;
+        }
+        this.closingForHammerMove = true;
+        HammerOpenedAnvilMenuHelper.closeOnServer(this.player);
+    }
+
+    @Override
     protected void onTake(Player player, ItemStack stack) {
-        int costCache = this.cost.get();
         super.onTake(player, stack);
-        if (costCache >= 5 && costCache < 15) {
+        if (this.openedHammerSource != null) {
+            HammerOpenedAnvilMenuHelper.playUseSound(player);
+        }
+        this.closeIfOpenedHammerMoved();
+        if (this.cost.get() >= 5 && this.cost.get() < 15) {
             player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 6000, 1));
             player.addEffect(new MobEffectInstance(MobEffects.ABSORPTION, 6000, 1));
-        } else if (costCache >= 15) {
+        } else if (this.cost.get() >= 15) {
             player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 12000, 2));
             player.addEffect(new MobEffectInstance(MobEffects.ABSORPTION, 12000, 2));
         }

--- a/src/main/java/dev/dubhe/anvilcraft/item/AnvilHammerItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/AnvilHammerItem.java
@@ -7,6 +7,12 @@ import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.client.AnvilCraftClient;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
+import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.inventory.EmberAnvilMenu;
+import dev.dubhe.anvilcraft.inventory.OpenedHammerSource;
+import dev.dubhe.anvilcraft.inventory.PortableAnvilMenu;
+import dev.dubhe.anvilcraft.inventory.RoyalAnvilMenu;
+import dev.dubhe.anvilcraft.inventory.TranscendenceAnvilMenu;
 import dev.dubhe.anvilcraft.mixin.invoker.BlockBehaviourInvoker;
 import dev.dubhe.anvilcraft.network.RocketJumpPacket;
 import dev.dubhe.anvilcraft.util.BreakBlockUtil;
@@ -14,13 +20,16 @@ import dev.dubhe.anvilcraft.util.TriggerUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.EquipmentSlotGroup;
@@ -28,11 +37,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.item.FallingBlockEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Equipable;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.component.Fireworks;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -58,6 +70,7 @@ import java.util.function.Predicate;
 import static dev.dubhe.anvilcraft.util.MultiPartBlockUtil.getChainableMainPartPos;
 
 public class AnvilHammerItem extends Item implements Equipable {
+    public static final int PORTABLE_ANVIL_USE_TICKS = 40;
     public static final Property<?>[] SUPPORTED_PROPERTIES = {
         BlockStateProperties.FACING,
         BlockStateProperties.FACING_HOPPER,
@@ -165,6 +178,52 @@ public class AnvilHammerItem extends Item implements Equipable {
         return true;
     }
 
+    public static void openPortableAnvil(Player player, int inventorySlot) {
+        if (!(player instanceof ServerPlayer serverPlayer)) return;
+        OpenedHammerSource source = OpenedHammerSource.fromInventory(serverPlayer.getInventory(), inventorySlot);
+        openPortableAnvil(serverPlayer, source);
+    }
+
+    private static void openPortableAnvil(ServerPlayer serverPlayer, @Nullable OpenedHammerSource source) {
+        if (source == null) return;
+        if (!serverPlayer.containerMenu.getCarried().isEmpty()) return;
+        if (serverPlayer.containerMenu != serverPlayer.inventoryMenu) {
+            serverPlayer.closeContainer();
+        }
+        MenuProvider provider = new SimpleMenuProvider(
+            (id, playerInventory, menuPlayer) -> createPortableAnvilMenu(id, playerInventory, source),
+            Component.translatable("container.repair")
+        );
+        ModMenuTypes.open(serverPlayer, provider);
+    }
+
+    public static void openPortableAnvilFromMenuSlot(Player player, int menuSlotId) {
+        if (!(player instanceof ServerPlayer serverPlayer)) return;
+        if (!serverPlayer.containerMenu.getCarried().isEmpty()) return;
+        if (menuSlotId < 0 || menuSlotId >= serverPlayer.containerMenu.slots.size()) return;
+        Slot slot = serverPlayer.containerMenu.getSlot(menuSlotId);
+        OpenedHammerSource source = OpenedHammerSource.fromMenuSlot(slot, serverPlayer.getInventory());
+        openPortableAnvil(serverPlayer, source);
+    }
+
+    private static net.minecraft.world.inventory.AbstractContainerMenu createPortableAnvilMenu(
+        int id,
+        Inventory playerInventory,
+        OpenedHammerSource source
+    ) {
+        Item hammerItem = source.openedHammerItem();
+        if (hammerItem == ModItems.ROYAL_ANVIL_HAMMER.get()) {
+            return new RoyalAnvilMenu(id, playerInventory, net.minecraft.world.inventory.ContainerLevelAccess.NULL, source);
+        }
+        if (hammerItem == ModItems.EMBER_ANVIL_HAMMER.get()) {
+            return new EmberAnvilMenu(id, playerInventory, net.minecraft.world.inventory.ContainerLevelAccess.NULL, source);
+        }
+        if (hammerItem == ModItems.TRANSCENDENCE_ANVIL_HAMMER.get()) {
+            return new TranscendenceAnvilMenu(id, playerInventory, net.minecraft.world.inventory.ContainerLevelAccess.NULL, source);
+        }
+        return new PortableAnvilMenu(id, playerInventory, net.minecraft.world.inventory.ContainerLevelAccess.NULL, source);
+    }
+
     /**
      * 右键方块
      */
@@ -195,6 +254,34 @@ public class AnvilHammerItem extends Item implements Equipable {
             return;
         }
         HammerManager.getChange(block).change(player, blockPos, level, anvilHammer);
+    }
+
+    @Override
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
+        ItemStack stack = player.getItemInHand(usedHand);
+        player.startUsingItem(usedHand);
+        return InteractionResultHolder.consume(stack);
+    }
+
+    @Override
+    public ItemStack finishUsingItem(ItemStack stack, Level level, LivingEntity livingEntity) {
+        if (!level.isClientSide && livingEntity instanceof ServerPlayer player) {
+            int slot = player.getUsedItemHand() == InteractionHand.MAIN_HAND
+                       ? player.getInventory().selected
+                       : Inventory.SLOT_OFFHAND;
+            openPortableAnvil(player, slot);
+        }
+        return stack;
+    }
+
+    @Override
+    public int getUseDuration(ItemStack stack, LivingEntity entity) {
+        return PORTABLE_ANVIL_USE_TICKS;
+    }
+
+    @Override
+    public UseAnim getUseAnimation(ItemStack stack) {
+        return UseAnim.NONE;
     }
 
     private static boolean rocketJump(@Nullable ServerPlayer serverPlayer, ServerLevel level, BlockPos blockPos) {

--- a/src/main/java/dev/dubhe/anvilcraft/item/DragonRodItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/DragonRodItem.java
@@ -189,7 +189,7 @@ public class DragonRodItem extends Item {
         if (dragonRod.is(ModItems.TRANSCENDENCE_DRAGON_ROD)) {
             long currentTick = level.getGameTime();
             long lastTick = LAST_TRANSCENDENCE_DEVOUR_TICK.getOrDefault(player.getUUID(), 0L);
-            boolean isWarmedUp = (currentTick - lastTick) < 15; // 0.75s内再次使用=已预热
+            boolean isWarmedUp = (currentTick - lastTick) < 10; // 0.5s内再次使用=已预热
             player.getCooldowns().addCooldown(ModItems.TRANSCENDENCE_DRAGON_ROD.asItem(), isWarmedUp ? 0 : 10);
             LAST_TRANSCENDENCE_DEVOUR_TICK.put(player.getUUID(), currentTick);
             if (isWarmedUp) {

--- a/src/main/java/dev/dubhe/anvilcraft/item/SpectralSlingshotItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/SpectralSlingshotItem.java
@@ -159,9 +159,11 @@ public class SpectralSlingshotItem extends ProjectileWeaponItem {
                 if (SpectralSlingshotItem.canTakeOutAmmo(itemstack)) player.addItem(stack); // 如果能拿出来，那么拿出来
                 itemstack.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.EMPTY);
                 // 装载走正常的使用流程
-                this.startSoundPlayed = false;
-                this.midLoadSoundPlayed = false;
-                player.startUsingItem(hand);
+                if (!SpectralSlingshotItem.getSlingShotAmmo(player).isEmpty()) {
+                    this.startSoundPlayed = false;
+                    this.midLoadSoundPlayed = false;
+                    player.startUsingItem(hand);
+                }
             }
             return InteractionResultHolder.consume(itemstack);
         } else if (!SpectralSlingshotItem.getSlingShotAmmo(player).isEmpty()) {

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/AbstractContainerScreenMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/AbstractContainerScreenMixin.java
@@ -1,0 +1,28 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import dev.dubhe.anvilcraft.client.gui.screen.AnvilHammerSlotOverlay;
+import dev.dubhe.anvilcraft.inventory.HammerOpenedAnvilMenu;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.Slot;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AbstractContainerScreen.class)
+abstract class AbstractContainerScreenMixin<T extends AbstractContainerMenu> {
+    @Shadow
+    @Final
+    protected T menu;
+
+    @Inject(method = "renderSlot", at = @At("TAIL"))
+    private void anvilcraft$renderHammerOpenedAnvilSlot(GuiGraphics guiGraphics, Slot slot, CallbackInfo ci) {
+        if (this.menu instanceof HammerOpenedAnvilMenu hammerOpenedAnvilMenu) {
+            AnvilHammerSlotOverlay.render(guiGraphics, hammerOpenedAnvilMenu, slot);
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/network/DragonRodStopDevourPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/DragonRodStopDevourPacket.java
@@ -1,0 +1,26 @@
+package dev.dubhe.anvilcraft.network;
+
+import dev.anvilcraft.lib.v2.network.packet.IPacket;
+import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.item.DragonRodItem;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.player.Player;
+
+public record DragonRodStopDevourPacket() implements IServerboundPacket {
+    public static final Type<DragonRodStopDevourPacket> TYPE = IPacket.type(AnvilCraft.of("dragon_rod_stop_devour"));
+    public static final StreamCodec<ByteBuf, DragonRodStopDevourPacket> STREAM_CODEC = StreamCodec.unit(
+        new DragonRodStopDevourPacket()
+    );
+
+    @Override
+    public Type<DragonRodStopDevourPacket> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void handleOnServer(Player player) {
+        DragonRodItem.stopContinuousMode(player);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/network/OpenHammerAnvilPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/OpenHammerAnvilPacket.java
@@ -1,0 +1,29 @@
+package dev.dubhe.anvilcraft.network;
+
+import dev.anvilcraft.lib.v2.network.packet.IPacket;
+import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.player.Player;
+
+public record OpenHammerAnvilPacket(int menuSlotId) implements IServerboundPacket {
+    public static final Type<OpenHammerAnvilPacket> TYPE = IPacket.type(AnvilCraft.of("open_hammer_anvil"));
+    public static final StreamCodec<ByteBuf, OpenHammerAnvilPacket> STREAM_CODEC = StreamCodec.composite(
+        ByteBufCodecs.VAR_INT,
+        OpenHammerAnvilPacket::menuSlotId,
+        OpenHammerAnvilPacket::new
+    );
+
+    @Override
+    public Type<OpenHammerAnvilPacket> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void handleOnServer(Player player) {
+        AnvilHammerItem.openPortableAnvilFromMenuSlot(player, this.menuSlotId);
+    }
+}

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -84,6 +84,7 @@
     "tsmm.SetBlockCommandMixin"
   ],
   "client": [
+    "AbstractContainerScreenMixin",
     "ClientLevelMixin",
     "ClientPacketListenerMixin",
     "GameRendererMixin",


### PR DESCRIPTION
- **管道网络适配炼药锅**
- **当铁砧锤成为铁砧——** resolved #1950 
- 让交易站村民交易成功时发出粒子效果
- 修复止逆阀是使得高处优先输出不生效的问题 fixed #_群里说的_
- 修复超限龙杖松开左键不会取消挖掘的问题 fixed #4057 
- 修复了锻星砧服务端的客户端类导致各种服务器问题 fixed #4054 
- 修复了大激光器紧贴接收导致严重卡顿的问题 fixed #4060 
- 修复了无限收集器收集电荷的两个问题 fixed #4058 
- 修复了无限收集器和集热器能放一起的问题 fixed #3986 
- 修复了幻灵弹弓卸下弹药时播放上弦动画的问题 fixed #2971 
- 修复了铁砧锤右键部分可交互方块没有声音的问题 fixed #3321 
- 修复了脉冲发生器特殊情况下会产生超限更新的问题 fixed #2533 
- 修复了非北结构扫描仪中增幅器位置错误的问题 fixed #3518 