### PR TITLE
fix(power-grid): defer outline generation and limit render worker threads

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/power/SimplePowerGrid.java
@@ -7,7 +7,6 @@ import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.renderer.Line;
 import dev.dubhe.anvilcraft.client.support.PowerGridSupport;
 import dev.dubhe.anvilcraft.util.ColorUtil;
-import dev.dubhe.anvilcraft.util.VirtualThreadFactoryImpl;
 import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
@@ -53,7 +52,7 @@ public class SimplePowerGrid {
     );
 
     static {
-        recreateExecutor();
+        recreateExecutorLimitedParallelism();
     }
 
     private final Random random = new Random();
@@ -70,7 +69,14 @@ public class SimplePowerGrid {
     private @Nullable Future<?> shapeFuture;
 
     /// 简单电网
-    public SimplePowerGrid(int id, String level, BlockPos pos, List<PowerComponentInfo> powerComponentInfoList, int generate, int consume) {
+    public SimplePowerGrid(
+        int id,
+        String level,
+        BlockPos pos,
+        List<PowerComponentInfo> powerComponentInfoList,
+        int generate,
+        int consume
+    ) {
         this.pos = pos;
         this.level = level;
         this.id = id;
@@ -81,7 +87,6 @@ public class SimplePowerGrid {
         this.consume = consume;
         this.blocks.addAll(powerComponentInfoList.stream().map(PowerComponentInfo::pos).toList());
         this.powerComponentInfoList.addAll(powerComponentInfoList);
-        this.createMergedOutlineShape();
         this.createTransmitterVisualLines();
     }
 
@@ -114,11 +119,16 @@ public class SimplePowerGrid {
         return Optional.empty();
     }
 
-    public static void recreateExecutor() {
+    public static void recreateExecutorLimitedParallelism() {
         if (EXECUTOR != null) {
             EXECUTOR.shutdownNow();
         }
-        EXECUTOR = Executors.newThreadPerTaskExecutor(new VirtualThreadFactoryImpl());
+        EXECUTOR = Executors.newFixedThreadPool(
+            Math.max(
+                Runtime.getRuntime().availableProcessors() / 4,
+                4
+            )
+        );
     }
 
     public static SimplePowerGrid decode(FriendlyByteBuf buf) {
@@ -176,7 +186,9 @@ public class SimplePowerGrid {
     }
 
     private void createMergedOutlineShape() {
-        if (SimplePowerGrid.EXECUTOR.isShutdown()) SimplePowerGrid.recreateExecutor();
+        if (SimplePowerGrid.EXECUTOR == null || SimplePowerGrid.EXECUTOR.isShutdown()) {
+            SimplePowerGrid.recreateExecutorLimitedParallelism();
+        }
         this.shapeFuture = SimplePowerGrid.EXECUTOR.submit(() -> {
             List<VoxelShape> input = new ArrayList<>();
             for (PowerComponentInfo it : this.powerComponentInfoList) {
@@ -206,8 +218,15 @@ public class SimplePowerGrid {
     }
 
     public void destroy() {
-        if (!this.shapeFuture.isDone()) {
+        if (this.shapeFuture != null && !this.shapeFuture.isDone()) {
             this.shapeFuture.cancel(true);
+        }
+    }
+
+    /// 显式请求电网边框
+    public void requestGridOutline() {
+        if (this.shapeFuture == null) {
+            this.createMergedOutlineShape();
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/PowerGridSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/PowerGridSupport.java
@@ -30,11 +30,18 @@ public class PowerGridSupport {
     public static void submitPowerGridBounds(PoseStack poseStack, SubmitNodeCollector nodeCollector, Vec3 camera) {
         if (Minecraft.getInstance().level == null) return;
         String level = Minecraft.getInstance().level.dimension().identifier().toString();
+        List<SimplePowerGrid> gridsToRender = new ArrayList<>();
+        for (SimplePowerGrid grid : PowerGridSupport.GRID_MAP.values()) {
+            if (!grid.shouldRender(camera)) continue;
+            if (!grid.getLevel().equals(level)) continue;
+            grid.requestGridOutline();
+            if (grid.getPowerGridBoundLines().isEmpty()) continue;
+            gridsToRender.add(grid);
+        }
+        if (gridsToRender.isEmpty()) return;
         nodeCollector.submitCustomGeometry(
             poseStack, RenderTypes.lines(), (pose, buffer) -> {
-                for (SimplePowerGrid grid : PowerGridSupport.GRID_MAP.values()) {
-                    if (!grid.shouldRender(camera)) continue;
-                    if (!grid.getLevel().equals(level)) continue;
+                for (SimplePowerGrid grid : gridsToRender) {
                     for (Line line : grid.getPowerGridBoundLines()) {
                         line.render(pose, buffer, camera, grid.getColor());
                     }
@@ -94,7 +101,7 @@ public class PowerGridSupport {
     }
 
     public static void clearAllGrid() {
-        SimplePowerGrid.recreateExecutor();
+        SimplePowerGrid.recreateExecutorLimitedParallelism();
         for (SimplePowerGrid value : GRID_MAP.values()) {
             value.destroy();
         }

--- a/src/main/java/dev/dubhe/anvilcraft/network/PowerGridSyncPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/PowerGridSyncPacket.java
@@ -32,7 +32,9 @@ public record PowerGridSyncPacket(SimplePowerGrid grid) implements IClientboundP
         PowerGridSupport.getGridMap().compute(
             this.grid.getId(),
             (_, grid) -> {
-                if (grid != null) grid.destroy();
+                if (grid != null) {
+                    grid.destroy();
+                }
                 return this.grid;
             }
         );


### PR DESCRIPTION
Generate power grid outlines only when bounds are requested for visible grids.
Replace per-task virtual threads with a bounded fixed thread pool and guard outline task cancellation when no task has been started.