### PR TITLE
Add config for scale of gui of anvil hammer screen 增加铁砧锤界面GUI大小的配置选项

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -131,6 +131,8 @@
   "anvilcraft.configuration.amulet_box_take_out_all_totem.tooltip": "xoq ʇǝꞁnɯɐ ᵷuᴉpꞁoɥ ǝɥʇ uᴉ pǝɹoʇs ɯǝʇoʇ ꞁꞁɐ ʇno ǝʞɐʇ oʇ ʞɔᴉꞁɔ ʇɥᵷᴉɹ puɐ ʇɟᴉɥs ssǝɹԀ",
   "anvilcraft.configuration.anvil_collision_craft_speed": "pǝǝdS ʇɟɐɹƆ uoᴉsᴉꞁꞁoƆ ꞁᴉʌuⱯ",
   "anvilcraft.configuration.anvil_collision_craft_speed.tooltip": "(ʞɔᴉʇ/ɯ) pǝǝds ʇɟɐɹɔ uoᴉsᴉꞁꞁoɔ ꞁᴉʌuⱯ",
+  "anvilcraft.configuration.anvil_hammer_screen_scale": "ǝꞁɐɔS uǝǝɹɔS ɹǝɯɯɐH ꞁᴉʌuⱯ",
+  "anvilcraft.configuration.anvil_hammer_screen_scale.tooltip": "uǝǝɹɔs ɹǝɯɯɐɥ ꞁᴉʌuɐ ɟo I∩⅁ ɟo ǝꞁɐɔS",
   "anvilcraft.configuration.batch_crafter_cooldown": "uʍopꞁooƆ ɹǝʇɟɐɹƆ ɥɔʇɐᗺ",
   "anvilcraft.configuration.batch_crafter_cooldown.tooltip": "(sʞɔᴉʇ uᴉ) ɹǝʇɟɐɹɔ ɥɔʇɐq ɟo ǝɯᴉʇ uʍopꞁooɔ ɯnɯᴉxɐW",
   "anvilcraft.configuration.batch_cutter_cooldown": "uʍopꞁooƆ ɹǝʇʇnƆ ɥɔʇɐᗺ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -131,6 +131,8 @@
   "anvilcraft.configuration.amulet_box_take_out_all_totem.tooltip": "Press shift and right click to take out all totem stored in the holding amulet box",
   "anvilcraft.configuration.anvil_collision_craft_speed": "Anvil Collision Craft Speed",
   "anvilcraft.configuration.anvil_collision_craft_speed.tooltip": "Anvil collision craft speed (m/tick)",
+  "anvilcraft.configuration.anvil_hammer_screen_scale": "Anvil Hammer Screen Scale",
+  "anvilcraft.configuration.anvil_hammer_screen_scale.tooltip": "Scale of GUI of anvil hammer screen",
   "anvilcraft.configuration.batch_crafter_cooldown": "Batch Crafter Cooldown",
   "anvilcraft.configuration.batch_crafter_cooldown.tooltip": "Maximum cooldown time of batch crafter (in ticks)",
   "anvilcraft.configuration.batch_cutter_cooldown": "Batch Cutter Cooldown",

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
@@ -15,6 +15,7 @@ import dev.dubhe.anvilcraft.api.hammer.IHasHammerEffect;
 import dev.dubhe.anvilcraft.api.input.IMouseHandlerExtension;
 import dev.dubhe.anvilcraft.block.multipart.FlexibleMultiPartBlock;
 import dev.dubhe.anvilcraft.block.multipart.IMultiPartBlockModelHolder;
+import dev.dubhe.anvilcraft.client.AnvilCraftClient;
 import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
 import dev.dubhe.anvilcraft.client.init.ModShaders;
 import dev.dubhe.anvilcraft.client.support.RenderSupport;
@@ -156,7 +157,7 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             float rotation = degreeEachRotation * i;
             Vector2f rotated = MathUtil.rotationDegrees(ROTATION_START, rotation)
                 .mul(-1, 1)
-                .mul(RADIUS)
+                .mul(radius())
                 .add(centerX, centerY);
             try {
                 float detectionStart = (float) (Math.toRadians(rotation - degreeEachRotation / 2f) + Math.PI);
@@ -198,7 +199,7 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
         this.targetAngle = selected.angle;
         this.selectionEffectPosFromCenter = MathUtil.rotate(
             MathUtil.copy(ROTATION_START)
-                .mul(RADIUS),
+                .mul(radius()),
             -this.targetAngle
         ).mul(1, -1);
     }
@@ -285,11 +286,12 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
         float z,
         float scale
     ) {
+        float guiScale = guiScale();
         final float partialTick = minecraft.getTimer().getGameTimeDeltaPartialTick(true);
         poseStack.pushPose();
-        poseStack.translate(-7, 7, 0);
+        poseStack.translate(-7 * guiScale, 7 * guiScale, 0);
         poseStack.translate(x, y, z);
-        poseStack.scale(scale, scale, scale);
+        poseStack.scale(scale * guiScale, scale * guiScale, scale * guiScale);
         poseStack.mulPose(new Matrix4f().scaling(1, -1, 1));
         poseStack.translate(0.5f, 0.5f, 0.5f);
         poseStack.mulPose(Axis.XP.rotationDegrees(this.camera.getEntity().getXRot()));
@@ -371,8 +373,8 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             this.width / 2f,
             this.height / 2f,
             RING_COLOR,
-            RING_INNER_DIAMETER * progress,
-            RING_OUTER_DIAMETER * progress
+            innerDiameter() * progress,
+            outerDiameter() * progress
         );
         poseStack.popPose();
         float finalProgress = progress;
@@ -381,23 +383,23 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             .findFirst()
             .ifPresent(it -> {
                 Vector2f center = new Vector2f(
-                    (it.center.x - centerX) / RADIUS,
-                    (it.center.y - centerY) / RADIUS
-                ).mul(RADIUS * finalProgress)
+                    (it.center.x - centerX) / radius(),
+                    (it.center.y - centerY) / radius()
+                ).mul(radius() * finalProgress)
                     .add(centerX, centerY);
                 renderSelectionEffect(
                     guiGraphics,
                     center.x,
                     center.y,
                     SELECTION_EFFECT_COLOR,
-                    SELECTION_EFFECT_RADIUS
+                    selectionEffectRadius()
                 );
             });
         for (SelectionItem value : items) {
             Vector2f center = new Vector2f(
-                (value.center.x - centerX) / RADIUS,
-                (value.center.y - centerY) / RADIUS
-            ).mul(RADIUS * progress)
+                (value.center.x - centerX) / radius(),
+                (value.center.y - centerY) / radius()
+            ).mul(radius() * progress)
                 .add(centerX, centerY);
             float x = center.x;
             float y = center.y;
@@ -422,15 +424,16 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             }
             final int textAlpha = (int) (progress * 0xff) << 24;
             poseStack.pushPose();
-            float coordinateScale = 0.7f;
-            float offsetX = 0.1f * this.width;
-            float offsetY = 0.1f * this.height;
+            float coordinateScale = 0.7f  * guiScale();
+            float offsetX = 0.1f * this.width * guiScale();
+            float offsetY = 0.1f * this.height * guiScale();
             float adjustedX = (x - offsetX) / coordinateScale;
-            float adjustedY = (y - offsetY - 20) / coordinateScale;
+            float adjustedY = (y - offsetY - 20 * guiScale()) / coordinateScale;
             poseStack.translate(offsetX, offsetY, 0);
             poseStack.scale(coordinateScale, coordinateScale, coordinateScale);
             poseStack.translate(adjustedX, adjustedY, 0);
-            poseStack.scale(TEXT_SCALE / coordinateScale, TEXT_SCALE / coordinateScale, TEXT_SCALE / coordinateScale);
+            float textScale = TEXT_SCALE * guiScale() / coordinateScale;
+            poseStack.scale(textScale, textScale, textScale);
             guiGraphics.drawCenteredString(
                 this.minecraft.font,
                 value.description,
@@ -477,8 +480,8 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             this.width / 2f,
             this.height / 2f,
             RING_COLOR,
-            RING_INNER_DIAMETER,
-            RING_OUTER_DIAMETER
+            innerDiameter(),
+            outerDiameter()
         );
         renderSelection(guiGraphics);
         for (SelectionItem value : this.items) {
@@ -504,16 +507,17 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 );
             }
             poseStack.pushPose();
-            float coordinateScale = 0.7f;
-            float offsetX = 0.1f * this.width;
-            float offsetY = 0.1f * this.height;
+            float coordinateScale = 0.7f * guiScale();
+            float offsetX = 0.1f * this.width * guiScale();
+            float offsetY = 0.1f * this.height * guiScale();
             float adjustedX = (x - offsetX) / coordinateScale;
-            float adjustedY = (y - offsetY - 20) / coordinateScale;
+            float adjustedY = (y - offsetY - 20 * guiScale()) / coordinateScale;
 
             poseStack.translate(offsetX, offsetY, 0);
             poseStack.scale(coordinateScale, coordinateScale, coordinateScale);
             poseStack.translate(adjustedX, adjustedY, 0);
-            poseStack.scale(TEXT_SCALE / coordinateScale, TEXT_SCALE / coordinateScale, TEXT_SCALE / coordinateScale);
+            float textScale = TEXT_SCALE * guiScale() / coordinateScale;
+            poseStack.scale(textScale, textScale, textScale);
             guiGraphics.drawCenteredString(
                 this.minecraft.font,
                 value.description,
@@ -555,7 +559,7 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             pos.x,
             pos.y,
             SELECTION_EFFECT_COLOR,
-            SELECTION_EFFECT_RADIUS
+            selectionEffectRadius()
         );
     }
 
@@ -768,6 +772,26 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             return RenderType.translucent();
         }
         return ModRenderTypes.TRANSLUCENT_COLORED_OVERLAY;
+    }
+
+    private float radius() {
+        return RADIUS * guiScale();
+    }
+
+    private float selectionEffectRadius() {
+        return SELECTION_EFFECT_RADIUS * guiScale();
+    }
+
+    private float innerDiameter() {
+        return RING_INNER_DIAMETER * guiScale();
+    }
+
+    private float outerDiameter() {
+        return RING_OUTER_DIAMETER * guiScale();
+    }
+
+    private float guiScale() {
+        return AnvilCraftClient.CONFIG.anvilHammerScreenScale * 0.5f;
     }
 
     private record SelectionItem(

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/AnvilHammerScreen.java
@@ -242,7 +242,7 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
             (float) mouseX - screenCenterX,
             (float) mouseY - screenCenterY
         );
-        if (cursorVec2.length() < IGNORE_CURSOR_MOVE_LENGTH) {
+        if (cursorVec2.length() < IGNORE_CURSOR_MOVE_LENGTH * guiScale()) {
             return true;
         }
         Vector2f rotationStart = new Vector2f(0, 1);
@@ -407,8 +407,8 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 renderRotatedBlock(
                     poseStack,
                     value.modelBlock,
-                    x + 5,
-                    y - 4,
+                    x + 5 * guiScale(),
+                    y - 4 * guiScale(),
                     100,
                     5
                 );
@@ -491,8 +491,8 @@ public class AnvilHammerScreen extends Screen implements IHasHammerEffect {
                 renderRotatedBlock(
                     poseStack,
                     value.modelBlock,
-                    x + 4,
-                    y - 4,
+                    x + 4 * guiScale(),
+                    y - 4 * guiScale(),
                     -100,
                     5
                 );

--- a/src/main/java/dev/dubhe/anvilcraft/config/AnvilCraftClientConfig.java
+++ b/src/main/java/dev/dubhe/anvilcraft/config/AnvilCraftClientConfig.java
@@ -47,6 +47,10 @@ public class AnvilCraftClientConfig {
     @Comment("Scanline post-processing effect on 3D structure previews.")
     public boolean renderScanPreviewEffect = true;
 
+    @Comment("Scale of GUI of anvil hammer screen")
+    @BoundedDiscrete(max = 4.0, min = 1.0)
+    public float anvilHammerScreenScale = 2.0f;
+
     @CollapsibleObject
     public GravitationalLens gravitationalLens = new GravitationalLens();
 


### PR DESCRIPTION
- 实现了 #4063。
    - 配置数值最小为1.0，最大为4.0，其中2.0为默认值（和原来相比保持不变）。
    - 其实本来应该是最小0.5，最大2.0，默认1.0的，但是谁叫沙币的anvillib有bug呢？你填最小0.5，他直接给你整成最小0.0了，真是服了
- resolved #4063