### PR TITLE
Modified the method for the Smart Block Placer blueprint to change block states during movement on 26.1. 修改了26.1智能方块放置器蓝图/移动模式修改方块状态的方法 

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/entity/player/IAnvilCraftBlockPlacer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/entity/player/IAnvilCraftBlockPlacer.java
@@ -2,7 +2,7 @@ package dev.dubhe.anvilcraft.api.entity.player;
 
 import dev.dubhe.anvilcraft.api.entity.fakeplayer.AnvilCraftFakePlayers;
 import dev.dubhe.anvilcraft.block.state.Orientation;
-import dev.dubhe.anvilcraft.mixin.invoker.BlockItemInvoker;
+import dev.dubhe.anvilcraft.util.BlockItemPlacementStateOverride;
 import dev.dubhe.anvilcraft.util.TriggerUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -18,29 +18,54 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import org.jspecify.annotations.Nullable;
 
-/// 假人方块放置器
+/// Fake player block placer.
 public interface IAnvilCraftBlockPlacer {
     ServerPlayer getPlayer();
 
-    /// 放置方块
+    /// Places a block.
     ///
-    /// @param level       放置世界
-    /// @param pos         放置位置
-    /// @param orientation 放置方向
-    /// @param blockItem   放置方块物品
-    /// @return 放置结果
+    /// @param level       target level
+    /// @param pos         target position
+    /// @param orientation placement orientation
+    /// @param blockItem   block item
+    /// @param itemStack   source item stack
+    /// @return placement result
     default InteractionResult placeBlock(
         Level level, BlockPos pos, Orientation orientation, BlockItem blockItem, ItemStack itemStack) {
+        return this.placeBlock(level, pos, orientation, blockItem, itemStack, null);
+    }
+
+    /// Places a block with an optional target state.
+    ///
+    /// @param level          target level
+    /// @param pos            target position
+    /// @param orientation    placement orientation
+    /// @param blockItem      block item
+    /// @param itemStack      source item stack
+    /// @param placementState optional target state
+    /// @return placement result
+    default InteractionResult placeBlock(
+        Level level,
+        BlockPos pos,
+        Orientation orientation,
+        BlockItem blockItem,
+        ItemStack itemStack,
+        @Nullable BlockState placementState
+    ) {
         if (AnvilCraftFakePlayers.BLOCK_PLACER_BLACKLIST.contains(BuiltInRegistries.BLOCK.getKey(blockItem.getBlock()).toString())) {
             return InteractionResult.FAIL;
         }
+        if (placementState != null
+            && placementState.getBlock() != blockItem.getBlock()
+            && placementState.getBlock().asItem() != blockItem) {
+            return InteractionResult.FAIL;
+        }
         if (level instanceof ServerLevel serverLevel) this.getPlayer().setServerLevel(serverLevel);
-        // 获取fakePlayer的方向 与放置器的方向不太一样
         Orientation fakePlayerOrientation = orientation.flipHorizontalIfVertical();
         this.getPlayer().setYRot(fakePlayerOrientation.getYRotation());
-        // net.minecraft.core.Direction#orderedByNearest 方法判断的是玩家的yHeadRot，设置YRot时需要将
-        // 该字段一并设置，以使得部分方块的方向检测正确
+        // Direction#orderedByNearest checks yHeadRot, so keep it in sync with yRot.
         this.getPlayer().setYHeadRot(fakePlayerOrientation.getYRotation());
         this.getPlayer().setXRot(fakePlayerOrientation.getXRotation());
         Vec3 clickClickLocation = this.getPosFromOrientation(orientation);
@@ -61,10 +86,19 @@ public interface IAnvilCraftBlockPlacer {
                 itemStack,
                 blockHitResult
             );
-        BlockState blockState = ((BlockItemInvoker) blockItem).invokerGetPlacementState(blockPlaceContext);
-        // 实际上，如果需要nbt的话，直接用NeoForge自带的就行
-        InteractionResult ir = blockItem.place(blockPlaceContext);
+        InteractionResult ir;
+        if (placementState == null) {
+            ir = blockItem.place(blockPlaceContext);
+        } else {
+            BlockItemPlacementStateOverride.set(placementState);
+            try {
+                ir = blockItem.place(blockPlaceContext);
+            } finally {
+                BlockItemPlacementStateOverride.clear();
+            }
+        }
         if (ir == InteractionResult.FAIL) return ir;
+        BlockState blockState = level.getBlockState(pos);
         SoundType soundType = blockState.getSoundType(level, pos, this.getPlayer());
         level.playSound(
             this.getPlayer(),

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/SmartBlockPlacerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/SmartBlockPlacerBlockEntity.java
@@ -1799,6 +1799,18 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
         return level.getBlockState(pos).getValue(HorizontalDirectionalBlock.FACING);
     }
 
+    private BlockState getMovedPlacementState(BlockState sourceState, Level level, BlockPos targetPos) {
+        BlockState stateToPlace = sourceState;
+        if (stateToPlace.is(Blocks.OBSERVER)
+            && stateToPlace.hasProperty(BlockStateProperties.POWERED)) {
+            stateToPlace = stateToPlace.setValue(BlockStateProperties.POWERED, false);
+        }
+        if (stateToPlace.hasProperty(BlockStateProperties.WATERLOGGED)) {
+            stateToPlace = stateToPlace.setValue(BlockStateProperties.WATERLOGGED, false);
+        }
+        return Block.updateFromNeighbourShapes(stateToPlace, level, targetPos);
+    }
+
     /**
      * 放置方块（pickup模式）
      */
@@ -1900,15 +1912,7 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
                 continue;
             }
 
-            BlockState stateToPlace = sourceState;
-
-            if (stateToPlace.is(Blocks.OBSERVER)
-                && stateToPlace.hasProperty(BlockStateProperties.POWERED)) {
-                stateToPlace = stateToPlace.setValue(BlockStateProperties.POWERED, false);
-            }
-            if (sourceState.hasProperty(BlockStateProperties.WATERLOGGED)) {
-                stateToPlace = sourceState.setValue(BlockStateProperties.WATERLOGGED, false);
-            }
+            BlockState stateToPlace = this.getMovedPlacementState(sourceState, level, targetPos);
 
             // 先删除源方块，再放置，放置失败则回滚
             IS_BEING_MOVED_BY_PLACER.set(true);
@@ -1920,7 +1924,7 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
 
             boolean placeSuccess = this.tryPlaceBlockWithFakePlayer(
                 level, targetPos, facing, upsideDown,
-                (BlockItem) sourceItem.getItem(), sourceItem
+                (BlockItem) sourceItem.getItem(), sourceItem, stateToPlace
             );
 
             if (!placeSuccess) {
@@ -1945,9 +1949,7 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
                 return;
             }
 
-            // 修正朝向
-            level.setBlock(targetPos, stateToPlace, Block.UPDATE_CLIENTS);
-
+            // 恢复方块实体数据
             if (sourceBlockEntityData != null) {
                 BlockEntity targetBlockEntity = level.getBlockEntity(targetPos);
                 if (targetBlockEntity != null) {
@@ -1957,7 +1959,8 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
                 }
             }
 
-            level.neighborChanged(targetPos, stateToPlace.getBlock(), null);
+            BlockState placedState = level.getBlockState(targetPos);
+            level.neighborChanged(targetPos, placedState.getBlock(), null);
 
             if (targetPos.equals(this.expectedShuttleTarget)) {
                 TriggerUtil.placerShuttle(level, targetPos);
@@ -2297,6 +2300,9 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
 
             // 获取蓝图中的目标状态（已经包含旋转、倒挂和状态过滤处理）
             BlockState blueprintState = this.getBlueprintBlockState(index, level);
+            final BlockState placementState = StructureLoadUtil.isMultiblockBlock(requiredBlock)
+                ? blueprintState
+                : Block.updateFromNeighbourShapes(blueprintState, level, targetPos);
 
             // 多方块方块使用蓝图中的朝向进行放置，确保所有部件位置正确
             Direction placementFacing = facing;
@@ -2315,17 +2321,9 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
                 IS_BEING_MOVED_BY_PLACER.set(false);
             }
 
-            // 先删除源方块
-            IS_BEING_MOVED_BY_PLACER.set(true);
-            try {
-                level.removeBlock(sourcePos, false);
-            } finally {
-                IS_BEING_MOVED_BY_PLACER.set(false);
-            }
-
             boolean placeSuccess = this.tryPlaceBlockWithFakePlayer(
                 level, targetPos, placementFacing, upsideDown,
-                (BlockItem) sourceItem.getItem(), sourceItem
+                (BlockItem) sourceItem.getItem(), sourceItem, placementState
             );
 
             if (!placeSuccess) {
@@ -2354,10 +2352,6 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
             if (StructureLoadUtil.isMultiblockBlock(requiredBlock)) {
                 // 多方块方块：应用蓝图状态到所有部件（包括 setPlacedBy 创建的次要部件）
                 this.applyMultiBlockBlueprintStates(level, allPositions, rotatedData, index, requiredBlock);
-            } else {
-                this.applyBlueprintBlockFacing(level, targetPos, index);
-                // 使用蓝图的状态覆盖目标位置的方块（包含正确的朝向），只更新客户端
-                level.setBlock(targetPos, blueprintState, Block.UPDATE_CLIENTS);
             }
 
             if (sourceBlockEntityData != null) {
@@ -2370,7 +2364,8 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
             }
 
             // 在目标位置发送方块更新通知
-            level.neighborChanged(targetPos, blueprintState.getBlock(), null);
+            BlockState placedState = level.getBlockState(targetPos);
+            level.neighborChanged(targetPos, placedState.getBlock(), null);
 
             // 放置成功，清空 currentHeldBlock；下一轮 prepareHeldBlock 会重新设置
             this.currentHeldBlock = ItemStack.EMPTY;
@@ -2879,9 +2874,21 @@ public class SmartBlockPlacerBlockEntity extends BlockEntity
         Level level, BlockPos targetPos, Direction facing,
         boolean upsideDown, BlockItem blockItemObj, ItemStack blockItem
     ) {
+        return this.tryPlaceBlockWithFakePlayer(level, targetPos, facing, upsideDown, blockItemObj, blockItem, null);
+    }
+
+    private boolean tryPlaceBlockWithFakePlayer(
+        Level level,
+        BlockPos targetPos,
+        Direction facing,
+        boolean upsideDown,
+        BlockItem blockItemObj,
+        ItemStack blockItem,
+        @Nullable BlockState placementState
+    ) {
         Orientation orientation = this.calculatePlacementOrientation(facing, upsideDown);
         return AnvilCraftFakePlayers.anvilcraftBlockPlacer.placeBlock(
-            level, targetPos, orientation, blockItemObj, blockItem) != InteractionResult.FAIL;
+            level, targetPos, orientation, blockItemObj, blockItem, placementState) != InteractionResult.FAIL;
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/BlockItemMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/BlockItemMixin.java
@@ -1,0 +1,36 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.dubhe.anvilcraft.util.BlockItemPlacementStateOverride;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(BlockItem.class)
+public class BlockItemMixin {
+    @WrapOperation(
+        method = "place",
+        at = @At(
+            value = "INVOKE",
+            target =
+                "Lnet/minecraft/world/item/BlockItem;getPlacementState"
+                    + "(Lnet/minecraft/world/item/context/BlockPlaceContext;)"
+                    + "Lnet/minecraft/world/level/block/state/BlockState;"
+        )
+    )
+    private @Nullable BlockState anvilcraft$overridePlacementState(
+        BlockItem instance,
+        BlockPlaceContext context,
+        Operation<BlockState> original
+    ) {
+        BlockState override = BlockItemPlacementStateOverride.get();
+        if (override == null) {
+            return original.call(instance, context);
+        }
+        return original.call(instance, context) == null ? null : override;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/util/BlockItemPlacementStateOverride.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/BlockItemPlacementStateOverride.java
@@ -1,0 +1,23 @@
+package dev.dubhe.anvilcraft.util;
+
+import net.minecraft.world.level.block.state.BlockState;
+import org.jspecify.annotations.Nullable;
+
+public final class BlockItemPlacementStateOverride {
+    private static final ThreadLocal<BlockState> OVERRIDE = new ThreadLocal<>();
+
+    private BlockItemPlacementStateOverride() {
+    }
+
+    public static void set(BlockState state) {
+        OVERRIDE.set(state);
+    }
+
+    public static void clear() {
+        OVERRIDE.remove();
+    }
+
+    public static @Nullable BlockState get() {
+        return OVERRIDE.get();
+    }
+}

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -9,6 +9,7 @@
     "AvoidEntityGoalMixin",
     "BeaconMenuMixin",
     "BlockBehaviourMixin",
+    "BlockItemMixin",
     "BlockMixin",
     "BlockStateMixin",
     "BucketResourceHandlerMixin",


### PR DESCRIPTION
- 新增 BlockItemPlacementStateOverride 以支持线程级方块状态覆盖
- 在 IAnvilCraftBlockPlacer 接口中添加带可选方块状态参数的 placeBlock 方法重载
- 修改放置逻辑，若传入放置状态则优先使用该状态
- 在 SmartBlockPlacerBlockEntity 中调整方块搬运时的放置状态处理，确保状态正确且去除高频属性影响
- 调整蓝图加载时放置状态计算，确保邻居形状更新正确
- 增加 BlockItemMixin 通过 Mixin 注入，支持放置时拦截和覆盖方块状态的获取
- 优化邻居方块更新调用，使用实际放置后状态替代缓存状态，保证状态一致性