### PR TITLE
Fixed the issue of incorrect item output from the chute, and resolved the problem where the small text indicating capacity limits wasn’t displayed. 修复溜槽错误输出物品，修复容量限制小字不渲染的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/FilteredItemStackHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/FilteredItemStackHandler.java
@@ -98,6 +98,11 @@ public class FilteredItemStackHandler extends ItemStacksResourceHandler {
     }
 
     @Override
+    protected int getCapacity(int index, ItemResource resource) {
+        return Math.min(super.getCapacity(index, resource), this.getSlotLimit(index));
+    }
+
+    @Override
     public void set(int index, ItemResource resource, int amount) {
         if (!this.filterEnabled && !resource.isEmpty()) {
             this.setSlotDisabled(index, false);

--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -33,6 +33,7 @@ public class ItemHandlerUtil {
         BiPredicate<ItemResource, Integer> predicate,
         @Nullable ResourceHandler<ItemResource> target
     ) {
+        if (target == null) return false;
         boolean success = false;
         int maxAmount = maxAmountWeight;
         try (Transaction root = Transaction.openRoot()) {
@@ -40,15 +41,17 @@ public class ItemHandlerUtil {
                 ItemResource resource = source.getResource(srcIndex);
                 if (resource.isEmpty()) continue;
                 try (Transaction transaction = Transaction.open(root)) {
-                    int extracted = source.extract(srcIndex, resource, maxAmount, transaction);
+                    int transferAmount = Math.min(maxAmount, source.getAmountAsInt(srcIndex));
+                    int inserted = target.insert(resource, transferAmount, transaction);
+                    if (inserted <= 0) continue;
+                    int extracted = source.extract(srcIndex, resource, inserted, transaction);
                     if (extracted <= 0 || !predicate.test(resource, extracted)) continue;
-                    int inserted = target.insert(resource, extracted, transaction);
-                    if (inserted == 0) continue;
+                    if (extracted != inserted) continue;
                     success = true;
-                    maxAmount -= inserted;
-                    if (maxAmount < 0) break;
+                    maxAmount -= extracted;
                     transaction.commit();
                 }
+                if (maxAmount <= 0) break;
             }
             root.commit();
         }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IFilterScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/IFilterScreen.java
@@ -180,13 +180,13 @@ public interface IFilterScreen<T extends AbstractContainerMenu & IFilterMenu> ex
         int width = Minecraft.getInstance().font.width(text);
         int height = Minecraft.getInstance().font.lineHeight;
         int x = (int) ((slot.x + 16.25 - width * scale) / scale);
-        int y = (int) ((slot.y + 14 - height * 2 * scale + 1) / scale);
+        int y = (int) ((slot.y + 12 - height * 2 * scale + 1) / scale);
         graphics.text(
             Minecraft.getInstance().font,
             text,
             x,
             y,
-            0xFFA0A0,
+            0xFFFFA0A0,
             true
         );
         graphics.pose().popMatrix();


### PR DESCRIPTION
- 优化FilteredItemStackHandler中getCapacity方法，确保容量不超过槽位限制
- 修改ItemHandlerUtil以防止目标为空时执行操作，避免空指针异常
- 调整资源转移逻辑，先计算可插入数量再提取，保证插入与提取量一致
- 改进循环终止条件，防止超出最大转移量
- 修正IFilterScreen中文本绘制纵坐标和颜色，使显示更准确