### PR TITLE
fix: guarantee royal steel template trade and prevent block squeeze exception

### DIFF
--- a/src/generated/resources/data/anvilcraft/trade_set/jeweler/level_3.json
+++ b/src/generated/resources/data/anvilcraft/trade_set/jeweler/level_3.json
@@ -4,7 +4,6 @@
   "trades": [
     "anvilcraft:jeweler/topaz_block_for_emerald",
     "anvilcraft:jeweler/sapphire_block_for_emerald",
-    "anvilcraft:jeweler/ruby_block_for_emerald",
-    "anvilcraft:jeweler/emerald_for_royal_steel_template"
+    "anvilcraft:jeweler/ruby_block_for_emerald"
   ]
 }

--- a/src/main/java/dev/dubhe/anvilcraft/init/entity/ModTradeSets.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/entity/ModTradeSets.java
@@ -36,12 +36,11 @@ public class ModTradeSets {
             context.lookup(Registries.VILLAGER_TRADE).getOrThrow(ModVillagerTrades.AMBER_FOR_EMERALD)
         ));
 
-        // Level 3: 4 trades (3 gem variants + template trade)
+        // Level 3: 2 random gem trades; the template trade is added separately
         register(context, JEWELER_LEVEL_3, HolderSet.direct(
             context.lookup(Registries.VILLAGER_TRADE).getOrThrow(ModVillagerTrades.TOPAZ_BLOCK_FOR_EMERALD),
             context.lookup(Registries.VILLAGER_TRADE).getOrThrow(ModVillagerTrades.SAPPHIRE_BLOCK_FOR_EMERALD),
-            context.lookup(Registries.VILLAGER_TRADE).getOrThrow(ModVillagerTrades.RUBY_BLOCK_FOR_EMERALD),
-            context.lookup(Registries.VILLAGER_TRADE).getOrThrow(ModVillagerTrades.EMERALD_FOR_ROYAL_STEEL_TEMPLATE)
+            context.lookup(Registries.VILLAGER_TRADE).getOrThrow(ModVillagerTrades.RUBY_BLOCK_FOR_EMERALD)
         ));
 
         // Level 4: 3 trades

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/AbstractVillagerMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/AbstractVillagerMixin.java
@@ -1,0 +1,51 @@
+package dev.dubhe.anvilcraft.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.init.entity.ModVillagerTrades;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.npc.villager.AbstractVillager;
+import net.minecraft.world.item.trading.MerchantOffers;
+import net.minecraft.world.item.trading.TradeSet;
+import net.minecraft.world.item.trading.VillagerTrade;
+import net.minecraft.world.level.storage.loot.LootContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Optional;
+
+@Mixin(AbstractVillager.class)
+public class AbstractVillagerMixin {
+
+    @Unique
+    private static final Identifier JEWELER_TRADE_SET = AnvilCraft.of("jeweler/level_3");
+
+    @SuppressWarnings("checkstyle:LineLength")
+    @Inject(
+        method = "addOffersFromTradeSet",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/item/trading/TradeSet;calculateNumberOfTrades(Lnet/minecraft/world/level/storage/loot/LootContext;)I"
+        )
+    )
+    void addTrades(
+        ServerLevel level,
+        MerchantOffers offers,
+        ResourceKey<TradeSet> resourceKey,
+        CallbackInfo ci,
+        @Local LootContext lootContext
+    ) {
+        if (resourceKey.identifier().equals(JEWELER_TRADE_SET)) {
+            Optional<VillagerTrade> tradeSet = level.registryAccess().lookupOrThrow(Registries.VILLAGER_TRADE)
+                .getOptional(ModVillagerTrades.EMERALD_FOR_ROYAL_STEEL_TEMPLATE.identifier());
+            if (tradeSet.isEmpty()) return;
+            offers.add(tradeSet.get().getOffer(lootContext));
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
@@ -228,7 +228,10 @@ public record HasCauldron(
         }
         try (Transaction transaction = Transaction.openRoot()) {
             FluidResource resource = FluidResource.of(BuiltInRegistries.FLUID.getOrThrow(ResourceKey.create(Registries.FLUID, fluid)));
-            if (!handler.getResource(0).equals(resource)) handler.extract(handler.getResource(0), Integer.MAX_VALUE, transaction);
+            FluidResource handlerResource = handler.getResource(0);
+            if (!handlerResource.equals(resource) && !handlerResource.isEmpty()) {
+                handler.extract(handlerResource, Integer.MAX_VALUE, transaction);
+            }
             int amount = (int) Math.round(mb);
             amount -= handler.getAmountAsInt(0);
             if (amount < 0) {

--- a/src/main/resources/anvilcraft.mixins.json
+++ b/src/main/resources/anvilcraft.mixins.json
@@ -4,6 +4,7 @@
   "package": "dev.dubhe.anvilcraft.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "AbstractVillagerMixin",
     "AnvilBlockMixin",
     "AnvilMenuMixin",
     "AvoidEntityGoalMixin",


### PR DESCRIPTION
## Summary
- Always add the royal steel upgrade smithing template trade for level 3 jewelers
- Keep the two random level 3 gem trades separate from the guaranteed template trade
- Avoid extracting an empty fluid resource when applying block squeeze cauldron recipes

## Verification
- `.\gradlew.bat test --console=plain` (BUILD SUCCESSFUL; no test sources)
- `.\gradlew.bat runData --console=plain` (BUILD SUCCESSFUL)
- IntelliJ project build (successful, no problems)
- `git diff --check`