### PR TITLE
refactor(cfa): batch block model tessellation states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Treat the project-root `style.xml` as the source of truth for Java code style and Checkstyle requirements.
 - Do not add a Checkstyle suppression merely to bypass a violation. Fix the code or document a genuinely required
   exception within the requested scope.
+- Prefer self-explanatory code and avoid comments that merely restate what the code already makes clear.
 - Keep text files UTF-8 encoded and preserve the existing line-ending style of files being edited.
 
 ## Nullness Annotations

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelRenderer.java
@@ -1,0 +1,62 @@
+package dev.dubhe.anvilcraft.api.rendering;
+
+import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
+import lombok.Getter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.renderer.block.ModelBlockRenderer;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
+import org.jspecify.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BlockStateModelRenderer {
+    public static final BlockStateModelRenderer INSTANCE = new BlockStateModelRenderer();
+    private final Map<BlockStateModelTessellateState, WrappedBlockStateModel> cache = new HashMap<>();
+
+    @Getter
+    private final ModelBlockRenderer tessellator = new ModelBlockRenderer(
+        false,
+        true,
+        Minecraft.getInstance().getBlockColors()
+    );
+
+    @Nullable
+    public WrappedBlockStateModel getModel(BlockStateModelTessellateState state) {
+        return this.cache.get(state);
+    }
+
+    public BlockStateModelTessellateState prepare(
+        StandaloneModelKey<BlockStateModel> key,
+        boolean translucent,
+        boolean lighting
+    ) {
+        RenderType renderType;
+        if (!lighting) {
+            renderType = ModRenderTypes.CUTOUT_BLOCK;
+        } else {
+            if (translucent) {
+                renderType = Sheets.translucentBlockSheet();
+            } else {
+                renderType = Sheets.cutoutBlockSheet();
+            }
+        }
+        BlockStateModelTessellateState state = new BlockStateModelTessellateState(
+            key,
+            renderType,
+            translucent,
+            lighting
+        );
+        WrappedBlockStateModel model = this.cache.get(state);
+        if (model == null) {
+            this.cache.put(
+                state,
+                new WrappedBlockStateModel(state, this)
+            );
+        }
+        return state;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelRenderer.java
@@ -36,7 +36,11 @@ public class BlockStateModelRenderer {
     ) {
         RenderType renderType;
         if (!lighting) {
-            renderType = ModRenderTypes.CUTOUT_BLOCK;
+            if (translucent) {
+                renderType = ModRenderTypes.TRANSLUCENT_BLOCK;
+            } else {
+                renderType = ModRenderTypes.CUTOUT_BLOCK;
+            }
         } else {
             if (translucent) {
                 renderType = Sheets.translucentBlockSheet();

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelTessellateState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelTessellateState.java
@@ -1,0 +1,32 @@
+package dev.dubhe.anvilcraft.api.rendering;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
+
+public record BlockStateModelTessellateState(
+    StandaloneModelKey<BlockStateModel> key,
+    RenderType renderType,
+    boolean translucent,
+    boolean lighting
+) {
+
+    public void submit(SubmitNodeCollector collector, PoseStack poseStack, int overlayCoords, int packedLight, int tint) {
+        WrappedBlockStateModel model = BlockStateModelRenderer.INSTANCE.getModel(this);
+        if (model == null) return;
+        collector.submitModel(
+            model,
+            this,
+            poseStack,
+            this.renderType,
+            packedLight,
+            overlayCoords,
+            tint,
+            null,
+            0,
+            null
+        );
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelTessellateState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelTessellateState.java
@@ -13,7 +13,13 @@ public record BlockStateModelTessellateState(
     boolean lighting
 ) {
 
-    public void submit(SubmitNodeCollector collector, PoseStack poseStack, int overlayCoords, int packedLight, int tint) {
+    public void submit(
+        SubmitNodeCollector collector,
+        PoseStack poseStack,
+        int overlayCoords,
+        int packedLight,
+        int tint
+    ) {
         WrappedBlockStateModel model = BlockStateModelRenderer.INSTANCE.getModel(this);
         if (model == null) return;
         collector.submitModel(

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/WrappedBlockStateModel.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/WrappedBlockStateModel.java
@@ -1,0 +1,64 @@
+package dev.dubhe.anvilcraft.api.rendering;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.Model;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.renderer.block.ModelBlockRenderer;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Blocks;
+import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Map;
+
+@NullMarked
+public class WrappedBlockStateModel extends Model<BlockStateModelTessellateState> {
+    private static final ModelPart EMPTY = new ModelPart(List.of(), Map.of());
+
+    private final BlockStateModelTessellateState state;
+    private final BlockStateModelRenderer renderer;
+
+    public WrappedBlockStateModel(BlockStateModelTessellateState state, BlockStateModelRenderer renderer) {
+        super(
+            EMPTY,
+            RenderTypes::entityCutout
+        );
+        this.state = state;
+        this.renderer = renderer;
+    }
+
+    public void renderToBuffer(
+        PoseStack poseStack,
+        VertexConsumer buffer,
+        int lightCoords,
+        int overlayCoords,
+        int color
+    ) {
+        Minecraft mc = Minecraft.getInstance();
+        StandaloneModelKey<BlockStateModel> key = this.state.key();
+        ModelBlockRenderer tessellator = this.renderer.getTessellator();
+        BlockStateModel model = mc.getModelManager().getStandaloneModel(key);
+
+        tessellator.tesselateBlock(
+            ((x, y, z, bakedQuad, quadInstance) -> buffer.putBakedQuad(
+                poseStack.last(),
+                bakedQuad,
+                quadInstance
+            )),
+            0,
+            0,
+            0,
+            mc.level,
+            BlockPos.ZERO,
+            Blocks.AIR.defaultBlockState(),
+            model,
+            42
+        );
+    }
+
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/WrappedBlockStateModel.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/WrappedBlockStateModel.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.Model;
 import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.ModelBlockRenderer;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
@@ -45,15 +46,19 @@ public class WrappedBlockStateModel extends Model<BlockStateModelTessellateState
         BlockStateModel model = mc.getModelManager().getStandaloneModel(key);
 
         tessellator.tesselateBlock(
-            ((x, y, z, bakedQuad, quadInstance) -> buffer.putBakedQuad(
-                poseStack.last(),
-                bakedQuad,
-                quadInstance
-            )),
+            ((_, _, _, bakedQuad, quadInstance) -> {
+                quadInstance.setLightCoords(lightCoords);
+                quadInstance.setOverlayCoords(overlayCoords);
+                buffer.putBakedQuad(
+                    poseStack.last(),
+                    bakedQuad,
+                    quadInstance
+                );
+            }),
             0,
             0,
             0,
-            mc.level,
+            BlockAndTintGetter.EMPTY,
             BlockPos.ZERO,
             Blocks.AIR.defaultBlockState(),
             model,

--- a/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderTypes.java
@@ -126,10 +126,6 @@ public class ModRenderTypes {
             )
     );
 
-    /**
-     * 使用方块图集并保留半透明混合的模型渲染类型。
-     * 配合全亮光照值和显式模型提交使用，可绕过方块模型的环境光遮蔽。
-     */
     public static final Function<Identifier, RenderType> TRANSLUCENT_NO_LIGHTING = Util.memoize(
             tex -> RenderType.create(
                     "anvilcraft:translucent_no_lighting",

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CFARenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CFARenderer.java
@@ -1,9 +1,9 @@
 package dev.dubhe.anvilcraft.client.renderer.blockentity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.QuadInstance;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import dev.dubhe.anvilcraft.api.rendering.BlockStateModelTessellateState;
 import dev.dubhe.anvilcraft.block.cfa.CelestialForgingAnvilBlock;
 import dev.dubhe.anvilcraft.block.entity.CelestialForgingAnvilBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyClass;
@@ -19,26 +19,20 @@ import dev.dubhe.anvilcraft.client.renderer.blockentity.celestial.CelestialBodyR
 import dev.dubhe.anvilcraft.client.renderer.blockentity.celestial.CelestialBodyTextureBakery;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.state.CFARenderState;
 import dev.dubhe.anvilcraft.client.support.FeatureRendererSupport;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.object.skull.SkullModelBase;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
-import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.SkullBlockRenderer;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
-import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.LightCoordsUtil;
-import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.component.ResolvableProfile;
 import net.minecraft.world.level.block.SkullBlock;
@@ -47,11 +41,10 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
 import org.joml.Matrix4f;
+import org.joml.Vector3f;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.IdentityHashMap;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -59,15 +52,9 @@ import java.util.Map;
  * 负责束星环骨骼层级、红石驱动的平滑缩放、天体自转、动态行星贴图、恒星颜色与光晕、
  * 大气层、天体环、托举光束以及超新星闪光和放射光束。
  */
-@SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
+@SuppressWarnings({"checkstyle:VariableDeclarationUsageDistance", "checkstyle:OverloadMethodsDeclarationOrder"})
 public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlockEntity, CFARenderState> {
-    private static final int[] NO_TINTS = new int[0];
-    private static final Direction[] DIRECTIONS = Direction.values();
     private final @Nullable SkullModelBase playerHeadModel;
-    private final Map<StandaloneModelKey<BlockStateModel>, CachedModel> cutoutModelCache = new IdentityHashMap<>();
-    private final Map<StandaloneModelKey<BlockStateModel>, CachedModel> translucentModelCache = new IdentityHashMap<>();
-    private final QuadInstance modelBatchQuadInstance = new QuadInstance();
-    private final RandomSource supernovaRandom = RandomSource.create();
     // ==================== 束星环模型 ====================
     public static final StandaloneModelKey<BlockStateModel> RING1 = key("CFA Ring 1");
     public static final StandaloneModelKey<BlockStateModel> RING2 = key("CFA Ring 2");
@@ -75,6 +62,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     public static final StandaloneModelKey<BlockStateModel> RING4 = key("CFA Ring 4");
     public static final StandaloneModelKey<BlockStateModel> RING5 = key("CFA Ring 5");
     public static final StandaloneModelKey<BlockStateModel> RING6 = key("CFA Ring 6");
+
     // ==================== 巨构模型 ====================
     public static final StandaloneModelKey<BlockStateModel> R1_EXCAVATOR = key("CFA Ring 1 Excavator");
     public static final StandaloneModelKey<BlockStateModel> R1_EXCAVATOR_OFF = key("CFA Ring 1 Excavator Off");
@@ -91,58 +79,43 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE = key("CFA Ring 4 Penrose Sphere");
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_FIX = key("CFA Ring 4 Penrose Fix");
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER = key("CFA Ring 4 Penrose Laser");
-    public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER_OFF = key("CFA Ring 4 Penrose Laser Off");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR = key("CFA Ring 4 Matter Decompressor");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_FIX = key("CFA Ring 4 Decompressor Fix");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_RING = key("CFA Ring 4 Decompressor Ring");
-    public static final StandaloneModelKey<BlockStateModel> R4_WORMHOLE_STABILIZER = key("CFA Ring 4 Wormhole Stabilizer");
+    public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER_OFF = key(
+        "CFA Ring 4 Penrose Laser Off");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR = key(
+        "CFA Ring 4 Matter Decompressor");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_FIX = key(
+        "CFA Ring 4 Decompressor Fix");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_RING = key(
+        "CFA Ring 4 Decompressor Ring");
+    public static final StandaloneModelKey<BlockStateModel> R4_WORMHOLE_STABILIZER = key(
+        "CFA Ring 4 Wormhole Stabilizer");
     public static final StandaloneModelKey<BlockStateModel> R5_ACCELERATOR = key("CFA Ring 5 Accelerator");
     public static final StandaloneModelKey<BlockStateModel> R6_ACCELERATOR = key("CFA Ring 6 Accelerator");
+
     // ==================== 天体模型 ====================
     public static final StandaloneModelKey<BlockStateModel> BODY_STAR = key("CFA Body Star");
     public static final StandaloneModelKey<BlockStateModel> BODY_NEUTRON_STAR = key("CFA Body Neutron Star");
     public static final StandaloneModelKey<BlockStateModel> BODY_NEUTRON_STAR_JET = key("CFA Body Neutron Star Jet");
     public static final StandaloneModelKey<BlockStateModel> BODY_BLACK_HOLE = key("CFA Body Black Hole");
+
     // 使用独立复杂模型的特殊天体。
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ARID = key("CFA Body Planet Arid");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_WET = key("CFA Body Planet Wet");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_BOGGY = key("CFA Body Planet Boggy");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_OCEANIC = key("CFA Body Planet Oceanic");
-    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ATMOSPHERELESS = key("CFA Body Planet Atmosphereless");
+    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ATMOSPHERELESS = key(
+        "CFA Body Planet Atmosphereless");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_GIANT = key("CFA Body Planet Giant");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_OVERWORLD = key("CFA Body Planet Overworld");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_FLESH = key("CFA Body Planet Flesh");
-    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_INTELLIGENCE = key("CFA Body Planet Intelligence");
+    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_INTELLIGENCE = key(
+        "CFA Body Planet Intelligence");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_SHATTERED = key("CFA Body Planet Shattered");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_HOLLOW = key("CFA Body Planet Hollow");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ERROR = key("CFA Body Planet Error");
 
     private static StandaloneModelKey<BlockStateModel> key(String desc) {
         return new StandaloneModelKey<>(() -> "AnvilCraft: " + desc + " Model");
-    }
-
-    private BlockModelRenderState initializeModel(
-        StandaloneModelKey<BlockStateModel> key,
-        CelestialForgingAnvilBlockEntity be
-    ) {
-        return this.initializeModel(key, be, false);
-    }
-
-    private BlockModelRenderState initializeModel(
-        StandaloneModelKey<BlockStateModel> key,
-        CelestialForgingAnvilBlockEntity be,
-        boolean translucent
-    ) {
-        BlockStateModel source = Minecraft.getInstance().getModelManager().getStandaloneModel(key);
-        Map<StandaloneModelKey<BlockStateModel>, CachedModel> cache = translucent
-            ? this.translucentModelCache : this.cutoutModelCache;
-        CachedModel cached = cache.get(key);
-        if (cached != null && cached.source() == source) {
-            return cached.renderState();
-        }
-        BlockModelRenderState renderState = FeatureRendererSupport.initialize(key, be, translucent);
-        cache.put(key, new CachedModel(source, renderState));
-        return renderState;
     }
 
     public CFARenderer(BlockEntityRendererProvider.Context context) {
@@ -159,28 +132,12 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     private static final float BEAM_INNER_HALF = 0.08f;
     private static final int BEAM_GLOW_LAYERS = 4;
     private static final float BEAM_GLOW_HALF_STEP = 0.06f;
-    private static final List<TractorBeamData> DEFERRED_TRACTOR_BEAMS = new ArrayList<>();
-    private static int deferredTractorBeamCount;
+    private static final Map<BlockPos, TractorBeamData> DEFERRED_TRACTOR_BEAMS = new LinkedHashMap<>();
     private static final float SUPERNOVA_MAX_RADIUS = 8.0f;
     private static final int SUPERNOVA_RAY_COUNT = 24;
     private static final float SUPERNOVA_RAY_LENGTH = 12.0f;
 
-    private record CachedModel(@Nullable BlockStateModel source, BlockModelRenderState renderState) {
-    }
-
-    private record BatchedModel(BlockModelRenderState model, PoseStack.Pose pose) {
-    }
-
-    private static class TractorBeamData {
-        private BlockPos pos = BlockPos.ZERO;
-        private float beamHeight;
-        private float animationProgress;
-
-        private void set(BlockPos pos, float beamHeight, float animationProgress) {
-            this.pos = pos;
-            this.beamHeight = beamHeight;
-            this.animationProgress = animationProgress;
-        }
+    private record TractorBeamData(BlockPos pos, float beamHeight, float animationProgress) {
     }
 
     @Override
@@ -280,9 +237,9 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         int middleIndex = isAmplify ? 5 : 2;
         int innerIndex = isAmplify ? 4 : 1;
 
-        state.setOuterRingModel(this.initializeModel(outerKey, be));
-        state.setMiddleRingModel(this.initializeModel(middleKey, be));
-        state.setInnerRingModel(this.initializeModel(innerKey, be));
+        state.setOuterRingModel(FeatureRendererSupport.createTessellation(outerKey, false));
+        state.setMiddleRingModel(FeatureRendererSupport.createTessellation(middleKey, false));
+        state.setInnerRingModel(FeatureRendererSupport.createTessellation(innerKey, false));
         state.setHasOuterRing(true);
         state.setHasMiddleRing(true);
         state.setHasInnerRing(true);
@@ -414,31 +371,41 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         if (!state.isAmplified() || !(bodyData instanceof StarData)) return;
         if (state.isDysonSphereR4() || state.isDysonSphereR5()) {
             if (state.isDysonSphereR4()) {
-                state.setR4DysonModel(this.initializeModel(R4_DYSON_SPHERE, be));
+                state.setR4DysonModel(FeatureRendererSupport.createTessellation(
+                    R4_DYSON_SPHERE, false, false));
             }
             if (state.isDysonSphereR5()) {
-                state.setR5DysonModel(this.initializeModel(R5_DYSON_SPHERE, be));
+                state.setR5DysonModel(FeatureRendererSupport.createTessellation(
+                    R5_DYSON_SPHERE, false, false));
             }
             boolean isSmallStar = bodyData.size() < 48;
             state.setDysonSmallStar(isSmallStar);
             if (state.isDysonSphereR4() && isSmallStar) {
-                state.setDysonOuterRingModel(this.initializeModel(this.getRing5Model(be), be));
+                state.setDysonOuterRingModel(FeatureRendererSupport.createTessellation(
+                    this.getRing5Model(be), false, false));
             } else if (state.isDysonSphereR5() && !isSmallStar) {
-                state.setDysonOuterRingModel(this.initializeModel(this.getRing6Model(be), be));
+                state.setDysonOuterRingModel(FeatureRendererSupport.createTessellation(
+                    this.getRing6Model(be), false, false));
             }
         }
         if (state.isPenroseSphere()) {
-            state.setPenroseFixModel(this.initializeModel(R4_PENROSE_SPHERE_FIX, be));
-            state.setPenroseLaserModel(this.initializeModel(
-                state.isPenroseLaserActive() ? R4_PENROSE_SPHERE_LASER : R4_PENROSE_SPHERE_LASER_OFF, be));
+            state.setPenroseFixModel(FeatureRendererSupport.createTessellation(
+                R4_PENROSE_SPHERE_FIX, false, false));
+            state.setPenroseLaserModel(FeatureRendererSupport.createTessellation(
+                state.isPenroseLaserActive() ? R4_PENROSE_SPHERE_LASER : R4_PENROSE_SPHERE_LASER_OFF,
+                false,
+                false
+            ));
         }
         if (state.isMagnetarCoil()) {
-            state.setCoilFixModel(this.initializeModel(R4_COIL_FIX, be));
-            state.setCoilRingModel(this.initializeModel(R4_COIL_RING, be));
+            state.setCoilFixModel(FeatureRendererSupport.createTessellation(R4_COIL_FIX, false, false));
+            state.setCoilRingModel(FeatureRendererSupport.createTessellation(R4_COIL_RING, false, false));
         }
         if (state.isMatterDecompressor()) {
-            state.setDecompressorFixModel(this.initializeModel(R4_MATTER_DECOMPRESSOR_FIX, be));
-            state.setDecompressorRingModel(this.initializeModel(R4_MATTER_DECOMPRESSOR_RING, be));
+            state.setDecompressorFixModel(FeatureRendererSupport.createTessellation(
+                R4_MATTER_DECOMPRESSOR_FIX, false, false));
+            state.setDecompressorRingModel(FeatureRendererSupport.createTessellation(
+                R4_MATTER_DECOMPRESSOR_RING, false, false));
         }
     }
 
@@ -467,13 +434,15 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
                 }
             }
             // 粉碎、空洞、血肉、智慧和错误天体使用独立复杂模型。
-            case SpecialCelestialBodyData special when special.needsCustomModel() ->
-            state.setComplexBodyModel(this.initializeModel(selectComplexBodyModel(special), be));
+            case SpecialCelestialBodyData special when special.needsCustomModel() -> state.setComplexBodyModel(
+                FeatureRendererSupport.createTessellation(selectComplexBodyModel(special), false, true));
             case StarData star -> {
                 boolean translucent = star.bodyClass() == CelestialBodyClass.BLACK_HOLE;
-                state.setBodyModel(this.initializeModel(getStarModelKey(star), be, translucent));
+                state.setBodyModel(FeatureRendererSupport.createTessellation(
+                    getStarModelKey(star), translucent, false));
                 if (star.bodyClass() == CelestialBodyClass.NEUTRON_STAR && star.rotationSpeed() >= 5) {
-                    state.setNeutronJetModel(this.initializeModel(BODY_NEUTRON_STAR_JET, be, true));
+                    state.setNeutronJetModel(FeatureRendererSupport.createTessellation(
+                        BODY_NEUTRON_STAR_JET, true, false));
                 }
             }
             // 普通行星使用色板动态烘焙贴图。
@@ -531,7 +500,6 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float rot = state.getRotation();
         float ringScale = state.getRingScale();
         float centerY = state.getCenterY();
-        List<BatchedModel> modelBatch = new ArrayList<>(8);
 
         pose.pushPose();
         pose.translate(0.5, centerY, 0.5);
@@ -551,7 +519,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             state.isOuterWasVisible(),
             state,
             pose,
-            modelBatch
+            collector
         );
 
         // 中层骨骼绕 X 轴旋转。
@@ -563,7 +531,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             state.isMiddleWasVisible(),
             state,
             pose,
-            modelBatch
+            collector
         );
 
         // 内层骨骼绕 Z 轴旋转。
@@ -575,13 +543,12 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             state.isInnerWasVisible(),
             state,
             pose,
-            modelBatch
+            collector
         );
         pose.popPose();
 
         // 提交随恒星同步的巨构环渲染层。
-        this.submitMegastructureRings(state, pose, modelBatch);
-        this.submitModelBatch(modelBatch, pose, collector);
+        this.submitMegastructureRings(state, pose, collector);
 
         // 提交天体及其天体环。
         if (state.isCanRenderBody() && state.getEffectiveBodyData() != null) {
@@ -591,7 +558,10 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
 
         // 仅记录本帧托举光束，在 AFTER_WEATHER 阶段绘制，确保光束位于云层上方。
         if (state.isCanRenderBody() && state.getBeamHeight() > 0.01f && state.getAnimationProgress() > 0.01f) {
-            queueTractorBeam(state.blockPos, state.getBeamHeight(), state.getAnimationProgress());
+            DEFERRED_TRACTOR_BEAMS.put(
+                state.blockPos,
+                new TractorBeamData(state.blockPos, state.getBeamHeight(), state.getAnimationProgress())
+            );
         }
 
         // 超新星闪光独立于当前天体，即使天体已变为残骸也继续播放。
@@ -602,133 +572,68 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
 
     /// 渲染机械束星环，并在可见性变化时执行淡入淡出。
     private void submitRingMaybe(
-        @Nullable BlockModelRenderState model,
+        @Nullable BlockStateModelTessellateState model,
         boolean present,
         boolean visibleNow,
         boolean wasVisible,
         CFARenderState state,
         PoseStack pose,
-        List<BatchedModel> modelBatch
+        SubmitNodeCollector collector
     ) {
         if (model == null || !present) return;
         if (!state.isAnimating()) {
             if (visibleNow) {
-                batchModel(model, pose, modelBatch);
+                this.tessellateModel(model, pose, collector);
             }
             return;
         }
         if (visibleNow && wasVisible) {
-            batchModel(model, pose, modelBatch);
-        } else if (visibleNow) {
-            float scale = state.isAnimationForward() ? state.getAnimationProgress() : (1.0f - state.getAnimationProgress());
-            if (scale > 0.01f) this.submitRingScaled(model, scale, pose, modelBatch);
-        } else if (wasVisible) {
-            float scale = state.isAnimationForward() ? (1.0f - state.getAnimationProgress()) : state.getAnimationProgress();
-            if (scale > 0.01f) this.submitRingScaled(model, scale, pose, modelBatch);
+            this.tessellateModel(model, pose, collector);
+        } else {
+            if (visibleNow) {
+                float scale = state.isAnimationForward() ? state.getAnimationProgress() : (1.0f - state.getAnimationProgress());
+                if (scale > 0.01f) {
+                    this.submitRingScaled(model, scale, pose, collector);
+                }
+            } else {
+                if (wasVisible) {
+                    float scale = state.isAnimationForward() ? (1.0f - state.getAnimationProgress()) : state.getAnimationProgress();
+                    if (scale > 0.01f) {
+                        this.submitRingScaled(model, scale, pose, collector);
+                    }
+                }
+            }
         }
     }
 
     private void submitRingScaled(
-        BlockModelRenderState model,
+        BlockStateModelTessellateState model,
         float scale,
         PoseStack pose,
-        List<BatchedModel> modelBatch
+        SubmitNodeCollector collector
     ) {
         pose.pushPose();
         pose.scale(scale, scale, scale);
-        batchModel(model, pose, modelBatch);
+        this.tessellateModel(model, pose, collector);
         pose.popPose();
     }
 
-    private static void batchModel(
-        BlockModelRenderState model,
-        PoseStack pose,
-        List<BatchedModel> modelBatch
-    ) {
-        if (model.modelParts != null && !model.modelParts.isEmpty()) {
-            modelBatch.add(new BatchedModel(model, pose.last().copy()));
-        }
-    }
-
-    private void submitModelBatch(
-        List<BatchedModel> modelBatch,
-        PoseStack pose,
+    private void tessellateModel(
+        BlockStateModelTessellateState state,
+        PoseStack poseStack,
         SubmitNodeCollector collector
     ) {
-        if (modelBatch.isEmpty()) return;
-        collector.submitCustomGeometry(pose, ModRenderTypes.CUTOUT_BLOCK, (last, consumer) -> {
-            QuadInstance instance = this.modelBatchQuadInstance;
-            instance.setLightCoords(LightCoordsUtil.FULL_BRIGHT);
-            instance.setOverlayCoords(OverlayTexture.NO_OVERLAY);
-            for (BatchedModel entry : modelBatch) {
-                BlockModelRenderState model = entry.model();
-                int[] tints = model.tintLayers == null ? NO_TINTS : model.tintLayers.toArray(NO_TINTS);
-                for (BlockStateModelPart part : model.modelParts) {
-                    putPartQuads(part, entry.pose(), instance, tints, consumer);
-                }
-            }
-        });
-    }
-
-    private static void putPartQuads(
-        BlockStateModelPart part,
-        PoseStack.Pose pose,
-        QuadInstance instance,
-        int[] tints,
-        VertexConsumer consumer
-    ) {
-        for (Direction direction : DIRECTIONS) {
-            for (BakedQuad quad : part.getQuads(direction)) {
-                putQuad(quad, pose, instance, tints, consumer);
-            }
-        }
-        for (BakedQuad quad : part.getQuads(null)) {
-            putQuad(quad, pose, instance, tints, consumer);
-        }
-    }
-
-    private static void putQuad(
-        BakedQuad quad,
-        PoseStack.Pose pose,
-        QuadInstance instance,
-        int[] tints,
-        VertexConsumer consumer
-    ) {
-        int tintIndex = quad.materialInfo().tintIndex();
-        instance.setColor(tintIndex >= 0 && tintIndex < tints.length ? tints[tintIndex] : -1);
-        consumer.putBakedQuad(pose, quad, instance);
-    }
-
-    private static void submitModel(
-        BlockModelRenderState model,
-        PoseStack pose,
-        SubmitNodeCollector collector
-    ) {
-        model.submit(pose, collector, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY, 0);
-    }
-
-    /**
-     * 以全亮光照直接提交模型，避免默认方块模型提交重新引入环境光遮蔽。
-     * 半透明模型仍使用带排序和混合的方块图集渲染层。
-     */
-    private static void submitFullBrightModel(
-        BlockModelRenderState model,
-        boolean translucent,
-        PoseStack pose,
-        SubmitNodeCollector collector
-    ) {
-        model.submitModel(
-            translucent ? ModRenderTypes.TRANSLUCENT_BLOCK : ModRenderTypes.CUTOUT_BLOCK,
-            pose,
+        state.submit(
             collector,
-            LightCoordsUtil.FULL_BRIGHT,
+            poseStack,
             OverlayTexture.NO_OVERLAY,
-            0
+            15728880,
+            -1
         );
     }
 
     /// 渲染戴森球、彭罗斯球、磁星线圈和物质解压器的恒星同步层。
-    private void submitMegastructureRings(CFARenderState state, PoseStack pose, List<BatchedModel> modelBatch) {
+    private void submitMegastructureRings(CFARenderState state, PoseStack pose, SubmitNodeCollector collector) {
         if (!state.isAmplified() || !(state.getBodyData() instanceof StarData star)) return;
         float centerY = state.getCenterY();
         float ringScale = state.getRingScale();
@@ -743,17 +648,17 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             pose.mulPose(Axis.XP.rotationDegrees(tilt));
             pose.mulPose(Axis.YP.rotationDegrees(bodyRot * visSpeed));
             if (state.getR4DysonModel() != null) {
-                batchModel(state.getR4DysonModel(), pose, modelBatch);
+                this.tessellateModel(state.getR4DysonModel(), pose, collector);
             }
             if (state.getR5DysonModel() != null) {
-                batchModel(state.getR5DysonModel(), pose, modelBatch);
+                this.tessellateModel(state.getR5DysonModel(), pose, collector);
             }
             pose.popPose();
             if (state.getDysonOuterRingModel() != null) {
                 pushRing(pose, centerY, ringScale);
                 pose.mulPose(Axis.XP.rotationDegrees(tilt));
                 pose.mulPose(Axis.YP.rotationDegrees(bodyRot * visSpeed));
-                batchModel(state.getDysonOuterRingModel(), pose, modelBatch);
+                this.tessellateModel(state.getDysonOuterRingModel(), pose, collector);
                 pose.popPose();
             }
         }
@@ -764,14 +669,14 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
                 pushRing(pose, centerY, ringScale);
                 pose.mulPose(Axis.XP.rotationDegrees(tilt));
                 pose.mulPose(Axis.YP.rotationDegrees(-bodyRot * visSpeed));
-                batchModel(state.getPenroseLaserModel(), pose, modelBatch);
+                this.tessellateModel(state.getPenroseLaserModel(), pose, collector);
                 pose.popPose();
             }
             if (state.getPenroseFixModel() != null) {
                 pushRing(pose, centerY, ringScale);
                 pose.mulPose(Axis.XP.rotationDegrees(tilt));
                 pose.mulPose(Axis.YP.rotationDegrees(bodyRot * visSpeed));
-                batchModel(state.getPenroseFixModel(), pose, modelBatch);
+                this.tessellateModel(state.getPenroseFixModel(), pose, collector);
                 pose.popPose();
             }
         }
@@ -781,12 +686,12 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             if (state.getCoilRingModel() != null) {
                 pushRing(pose, centerY, ringScale);
                 applyMechanicalInnerBone(pose, rot);
-                batchModel(state.getCoilRingModel(), pose, modelBatch);
+                this.tessellateModel(state.getCoilRingModel(), pose, collector);
                 pose.popPose();
             }
             if (state.getCoilFixModel() != null) {
                 pushRing(pose, centerY, ringScale);
-                batchModel(state.getCoilFixModel(), pose, modelBatch);
+                this.tessellateModel(state.getCoilFixModel(), pose, collector);
                 pose.popPose();
             }
         }
@@ -796,14 +701,14 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             if (state.getDecompressorRingModel() != null) {
                 pushRing(pose, centerY, ringScale);
                 applyMechanicalInnerBone(pose, rot);
-                batchModel(state.getDecompressorRingModel(), pose, modelBatch);
+                this.tessellateModel(state.getDecompressorRingModel(), pose, collector);
                 pose.popPose();
             }
             if (state.getDecompressorFixModel() != null) {
                 pushRing(pose, centerY, ringScale);
                 pose.mulPose(Axis.XP.rotationDegrees(tilt));
                 pose.mulPose(Axis.YP.rotationDegrees(bodyRot * visSpeed));
-                batchModel(state.getDecompressorFixModel(), pose, modelBatch);
+                this.tessellateModel(state.getDecompressorFixModel(), pose, collector);
                 pose.popPose();
             }
         }
@@ -854,7 +759,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
                 this.submitPlayerHead(state, pose, collector);
             } else {
                 if (state.getComplexBodyModel() != null) {
-                    submitModel(state.getComplexBodyModel(), pose, collector);
+                    this.tessellateModel(state.getComplexBodyModel(), pose, collector);
                 }
                 if (special.hasAtmosphere() && special.temperature() != null) {
                     this.submitAtmosphere(pose, collector, special.temperature(), 1.125f, seed);
@@ -897,13 +802,13 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         // 黑洞和中子星使用独立烘焙模型，不叠加普通恒星颜色或光晕。
         if (star.bodyClass() == CelestialBodyClass.BLACK_HOLE) {
             if (state.getBodyModel() != null) {
-                submitFullBrightModel(state.getBodyModel(), true, pose, collector);
+                this.tessellateModel(state.getBodyModel(), pose, collector);
             }
             return;
         }
         if (star.bodyClass() == CelestialBodyClass.NEUTRON_STAR) {
             if (state.getBodyModel() != null) {
-                submitFullBrightModel(state.getBodyModel(), false, pose, collector);
+                this.tessellateModel(state.getBodyModel(), pose, collector);
             }
             if (state.getNeutronJetModel() != null) {
                 float visualSpeed = CelestialBodyData.getVisualRotationSpeed(star.rotationSpeed());
@@ -914,7 +819,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
                 pose.mulPose(Axis.YP.rotationDegrees(extraJetRotation));
                 pose.mulPose(Axis.XP.rotationDegrees(magneticTilt));
                 pose.translate(-0.5, -0.5, -0.5);
-                submitFullBrightModel(state.getNeutronJetModel(), true, pose, collector);
+                this.tessellateModel(state.getNeutronJetModel(), pose, collector);
                 pose.popPose();
             }
             return;
@@ -922,7 +827,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
 
         // 主序星使用带动画的灰度烘焙模型。
         if (state.getBodyModel() != null) {
-            submitFullBrightModel(state.getBodyModel(), false, pose, collector);
+            this.tessellateModel(state.getBodyModel(), pose, collector);
         }
 
         // 叠加乘法恒星颜色。
@@ -935,7 +840,18 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         pose.popPose();
 
         // 绘制恒星光晕。
-        this.submitHalo(pose, collector, rgb[0], rgb[1], rgb[2], 10, 1.0f, 0.6f, 1.2f, 1.125f);
+        int haloIterations = 10;
+        for (int i = 0; i < haloIterations; i++) {
+            float progress = (float) i / haloIterations;
+            float haloScale = 1.0f + progress * 0.6f;
+            float alpha = (1.2f - 1.125f * progress) / haloIterations;
+            pose.pushPose();
+            pose.translate(0.5, 0.5, 0.5);
+            pose.scale(haloScale, haloScale, haloScale);
+            pose.translate(-0.5, -0.5, -0.5);
+            this.submitTranslucentCube(pose, collector, rgb[0], rgb[1], rgb[2], alpha);
+            pose.popPose();
+        }
     }
 
     private void submitPlanet(
@@ -977,7 +893,18 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         // 褐矮星使用较弱的恒星式光晕。
         if (bodyData instanceof GiantPlanetData gp && gp.brownDwarf()) {
             float[] rgb = CelestialBodyRenderer.getAtmosphereColor(Temperature.SCORCHED);
-            this.submitHalo(pose, collector, rgb[0], rgb[1], rgb[2], 3, 1.15f, 0.25f, 0.45f, 0.38f);
+            int haloIterations = 3;
+            for (int i = 0; i < haloIterations; i++) {
+                float progress = (float) i / haloIterations;
+                float haloScale = 1.15f + progress * 0.25f;
+                float alpha = (0.45f - 0.38f * progress) / haloIterations;
+                pose.pushPose();
+                pose.translate(0.5, 0.5, 0.5);
+                pose.scale(haloScale, haloScale, haloScale);
+                pose.translate(-0.5, -0.5, -0.5);
+                this.submitTranslucentCube(pose, collector, rgb[0], rgb[1], rgb[2], alpha);
+                pose.popPose();
+            }
         }
     }
 
@@ -1021,44 +948,27 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         );
     }
 
-    private void submitHalo(
+    private void submitTranslucentCube(
         PoseStack pose,
         SubmitNodeCollector collector,
         float r,
         float g,
         float b,
-        int iterations,
-        float baseScale,
-        float scaleRange,
-        float baseAlpha,
-        float alphaRange
+        float a
     ) {
         collector.submitCustomGeometry(
             pose,
             ModRenderTypes.CELESTIAL_ATMOSPHERE,
-            (last, consumer) -> {
-                PoseStack haloPose = poseOf(last);
-                for (int i = 0; i < iterations; i++) {
-                    float progress = (float) i / iterations;
-                    float scale = baseScale + progress * scaleRange;
-                    float alpha = (baseAlpha - alphaRange * progress) / iterations;
-                    haloPose.pushPose();
-                    haloPose.translate(0.5, 0.5, 0.5);
-                    haloPose.scale(scale, scale, scale);
-                    haloPose.translate(-0.5, -0.5, -0.5);
-                    CelestialBodyRenderer.renderColorCube(
-                        haloPose.last(),
-                        consumer,
-                        r,
-                        g,
-                        b,
-                        alpha,
-                        LightCoordsUtil.FULL_BRIGHT,
-                        OverlayTexture.NO_OVERLAY
-                    );
-                    haloPose.popPose();
-                }
-            }
+            (last, consumer) -> CelestialBodyRenderer.renderColorCube(
+                last,
+                consumer,
+                r,
+                g,
+                b,
+                a,
+                LightCoordsUtil.FULL_BRIGHT,
+                OverlayTexture.NO_OVERLAY
+            )
         );
     }
 
@@ -1132,8 +1042,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         collector.submitCustomGeometry(
             pose, ModRenderTypes.STELLAR_BEAM, (last, consumer) -> {
                 Matrix4f matrix = last.pose();
-                RandomSource rand = this.supernovaRandom;
-                rand.setSeed(seed);
+                RandomSource rand = RandomSource.create(seed);
                 for (int i = 0; i < SUPERNOVA_RAY_COUNT; i++) {
                     float u = rand.nextFloat() * 2.0f - 1.0f;
                     float theta = rand.nextFloat() * (float) (Math.PI * 2.0);
@@ -1166,68 +1075,26 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float g,
         float b
     ) {
-        float inverseLength = Mth.invSqrt(dx * dx + dy * dy + dz * dz);
-        dx *= inverseLength;
-        dy *= inverseLength;
-        dz *= inverseLength;
+        Vector3f dir = new Vector3f(dx, dy, dz).normalize();
+        Vector3f up = Math.abs(dir.y) > 0.99f ? new Vector3f(1f, 0f, 0f) : new Vector3f(0f, 1f, 0f);
+        Vector3f n1 = new Vector3f(dir).cross(up).normalize().mul(halfWidth);
+        Vector3f n2 = new Vector3f(dir).cross(n1).normalize().mul(halfWidth);
+        Vector3f tip = new Vector3f(dir).mul(length);
 
-        float n1x = Math.abs(dy) > 0.99f ? 0.0f : -dz;
-        float n1y = Math.abs(dy) > 0.99f ? dz : 0.0f;
-        float n1z = Math.abs(dy) > 0.99f ? -dy : dx;
-        float n1Scale = halfWidth * Mth.invSqrt(n1x * n1x + n1y * n1y + n1z * n1z);
-        n1x *= n1Scale;
-        n1y *= n1Scale;
-        n1z *= n1Scale;
-
-        float n2x = dy * n1z - dz * n1y;
-        float n2y = dz * n1x - dx * n1z;
-        float n2z = dx * n1y - dy * n1x;
-        float n2Scale = halfWidth * Mth.invSqrt(n2x * n2x + n2y * n2y + n2z * n2z);
-        n2x *= n2Scale;
-        n2y *= n2Scale;
-        n2z *= n2Scale;
-
-        float tipX = dx * length;
-        float tipY = dy * length;
-        float tipZ = dz * length;
-        float c0x = -n1x - n2x;
-        float c0y = -n1y - n2y;
-        float c0z = -n1z - n2z;
-        float c1x = n1x - n2x;
-        float c1y = n1y - n2y;
-        float c1z = n1z - n2z;
-        float c2x = n1x + n2x;
-        float c2y = n1y + n2y;
-        float c2z = n1z + n2z;
-        float c3x = -n1x + n2x;
-        float c3y = -n1y + n2y;
-        float c3z = -n1z + n2z;
-        emitRaySide(consumer, matrix, c0x, c0y, c0z, c1x, c1y, c1z, tipX, tipY, tipZ, r, g, b);
-        emitRaySide(consumer, matrix, c1x, c1y, c1z, c2x, c2y, c2z, tipX, tipY, tipZ, r, g, b);
-        emitRaySide(consumer, matrix, c2x, c2y, c2z, c3x, c3y, c3z, tipX, tipY, tipZ, r, g, b);
-        emitRaySide(consumer, matrix, c3x, c3y, c3z, c0x, c0y, c0z, tipX, tipY, tipZ, r, g, b);
-    }
-
-    private static void emitRaySide(
-        VertexConsumer consumer,
-        Matrix4f matrix,
-        float x0,
-        float y0,
-        float z0,
-        float x1,
-        float y1,
-        float z1,
-        float tipX,
-        float tipY,
-        float tipZ,
-        float r,
-        float g,
-        float b
-    ) {
-        beamVertex(consumer, matrix, x0, y0, z0, r, g, b, 1.0f);
-        beamVertex(consumer, matrix, x1, y1, z1, r, g, b, 1.0f);
-        beamVertex(consumer, matrix, tipX, tipY, tipZ, 0f, 0f, 0f, 1.0f);
-        beamVertex(consumer, matrix, tipX, tipY, tipZ, 0f, 0f, 0f, 1.0f);
+        float[][] base = {
+            {-n1.x - n2.x, -n1.y - n2.y, -n1.z - n2.z},
+            {n1.x - n2.x, n1.y - n2.y, n1.z - n2.z},
+            {n1.x + n2.x, n1.y + n2.y, n1.z + n2.z},
+            {-n1.x + n2.x, -n1.y + n2.y, -n1.z + n2.z}
+        };
+        for (int i = 0; i < 4; i++) {
+            float[] c0 = base[i];
+            float[] c1 = base[(i + 1) % 4];
+            beamVertex(consumer, matrix, c0[0], c0[1], c0[2], r, g, b, 1.0f);
+            beamVertex(consumer, matrix, c1[0], c1[1], c1[2], r, g, b, 1.0f);
+            beamVertex(consumer, matrix, tip.x, tip.y, tip.z, 0f, 0f, 0f, 1.0f);
+            beamVertex(consumer, matrix, tip.x, tip.y, tip.z, 0f, 0f, 0f, 1.0f);
+        }
     }
 
     private static void beamVertex(
@@ -1268,39 +1135,25 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     /**
      * 在天气与云层完成后渲染本帧收集的锻星砧托举光束。
      */
-    private static void queueTractorBeam(BlockPos pos, float beamHeight, float animationProgress) {
-        TractorBeamData data;
-        if (deferredTractorBeamCount < DEFERRED_TRACTOR_BEAMS.size()) {
-            data = DEFERRED_TRACTOR_BEAMS.get(deferredTractorBeamCount);
-        } else {
-            data = new TractorBeamData();
-            DEFERRED_TRACTOR_BEAMS.add(data);
-        }
-        data.set(pos, beamHeight, animationProgress);
-        deferredTractorBeamCount++;
-    }
-
     public static void renderDeferredTractorBeams(
         PoseStack pose,
         MultiBufferSource.BufferSource bufferSource,
         Vec3 cameraPosition
     ) {
-        if (deferredTractorBeamCount == 0) return;
+        if (DEFERRED_TRACTOR_BEAMS.isEmpty()) return;
         VertexConsumer consumer = bufferSource.getBuffer(ModRenderTypes.STELLAR_BEAM);
-        for (int i = 0; i < deferredTractorBeamCount; i++) {
-            TractorBeamData data = DEFERRED_TRACTOR_BEAMS.get(i);
+        for (TractorBeamData data : DEFERRED_TRACTOR_BEAMS.values()) {
             pose.pushPose();
             pose.translate(
-                data.pos.getX() - cameraPosition.x(),
-                data.pos.getY() - cameraPosition.y(),
-                data.pos.getZ() - cameraPosition.z()
+                data.pos().getX() - cameraPosition.x(),
+                data.pos().getY() - cameraPosition.y(),
+                data.pos().getZ() - cameraPosition.z()
             );
-            emitTractorBeam(consumer, pose.last().pose(), data.beamHeight, data.animationProgress);
+            emitTractorBeam(consumer, pose.last().pose(), data.beamHeight(), data.animationProgress());
             pose.popPose();
-            data.pos = BlockPos.ZERO;
         }
         bufferSource.endBatch(ModRenderTypes.STELLAR_BEAM);
-        deferredTractorBeamCount = 0;
+        DEFERRED_TRACTOR_BEAMS.clear();
     }
 
     private static void emitTractorBeam(
@@ -1342,41 +1195,23 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float x1 = cx + halfWidth;
         float z0 = cz - halfWidth;
         float z1 = cz + halfWidth;
+        float[][] corners = {{x0, z0}, {x1, z0}, {x1, z1}, {x0, z1}};
         float ar = r * apexFade;
         float ag = g * apexFade;
         float ab = b * apexFade;
-        emitBeamSide(vc, matrix, x0, z0, x1, z0, cx, apexY, cz, r, g, b, ar, ag, ab);
-        emitBeamSide(vc, matrix, x1, z0, x1, z1, cx, apexY, cz, r, g, b, ar, ag, ab);
-        emitBeamSide(vc, matrix, x1, z1, x0, z1, cx, apexY, cz, r, g, b, ar, ag, ab);
-        emitBeamSide(vc, matrix, x0, z1, x0, z0, cx, apexY, cz, r, g, b, ar, ag, ab);
-    }
-
-    private static void emitBeamSide(
-        VertexConsumer consumer,
-        Matrix4f matrix,
-        float x0,
-        float z0,
-        float x1,
-        float z1,
-        float apexX,
-        float apexY,
-        float apexZ,
-        float r,
-        float g,
-        float b,
-        float apexR,
-        float apexG,
-        float apexB
-    ) {
-        beamVertex(consumer, matrix, x0, BEAM_BASE_Y, z0, r, g, b, 1.0f);
-        beamVertex(consumer, matrix, x1, BEAM_BASE_Y, z1, r, g, b, 1.0f);
-        beamVertex(consumer, matrix, apexX, apexY, apexZ, apexR, apexG, apexB, 1.0f);
-        beamVertex(consumer, matrix, apexX, apexY, apexZ, apexR, apexG, apexB, 1.0f);
+        for (int i = 0; i < 4; i++) {
+            float[] c0 = corners[i];
+            float[] c1 = corners[(i + 1) % 4];
+            beamVertex(vc, matrix, c0[0], BEAM_BASE_Y, c0[1], r, g, b, 1.0f);
+            beamVertex(vc, matrix, c1[0], BEAM_BASE_Y, c1[1], r, g, b, 1.0f);
+            beamVertex(vc, matrix, cx, apexY, cz, ar, ag, ab, 1.0f);
+            beamVertex(vc, matrix, cx, apexY, cz, ar, ag, ab, 1.0f);
+        }
     }
 
     @Override
     public boolean shouldRenderOffScreen() {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CFARenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CFARenderer.java
@@ -33,6 +33,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.LightCoordsUtil;
+import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.component.ResolvableProfile;
 import net.minecraft.world.level.block.SkullBlock;
@@ -41,7 +42,6 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
 import org.joml.Matrix4f;
-import org.joml.Vector3f;
 import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
@@ -55,6 +55,7 @@ import java.util.Map;
 @SuppressWarnings({"checkstyle:VariableDeclarationUsageDistance", "checkstyle:OverloadMethodsDeclarationOrder"})
 public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlockEntity, CFARenderState> {
     private final @Nullable SkullModelBase playerHeadModel;
+    private final RandomSource supernovaRandom = RandomSource.create();
     // ==================== 束星环模型 ====================
     public static final StandaloneModelKey<BlockStateModel> RING1 = key("CFA Ring 1");
     public static final StandaloneModelKey<BlockStateModel> RING2 = key("CFA Ring 2");
@@ -79,16 +80,16 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE = key("CFA Ring 4 Penrose Sphere");
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_FIX = key("CFA Ring 4 Penrose Fix");
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER = key("CFA Ring 4 Penrose Laser");
-    public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER_OFF = key(
-        "CFA Ring 4 Penrose Laser Off");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR = key(
-        "CFA Ring 4 Matter Decompressor");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_FIX = key(
-        "CFA Ring 4 Decompressor Fix");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_RING = key(
-        "CFA Ring 4 Decompressor Ring");
-    public static final StandaloneModelKey<BlockStateModel> R4_WORMHOLE_STABILIZER = key(
-        "CFA Ring 4 Wormhole Stabilizer");
+    public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER_OFF =
+        key("CFA Ring 4 Penrose Laser Off");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR =
+        key("CFA Ring 4 Matter Decompressor");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_FIX =
+        key("CFA Ring 4 Decompressor Fix");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_RING =
+        key("CFA Ring 4 Decompressor Ring");
+    public static final StandaloneModelKey<BlockStateModel> R4_WORMHOLE_STABILIZER =
+        key("CFA Ring 4 Wormhole Stabilizer");
     public static final StandaloneModelKey<BlockStateModel> R5_ACCELERATOR = key("CFA Ring 5 Accelerator");
     public static final StandaloneModelKey<BlockStateModel> R6_ACCELERATOR = key("CFA Ring 6 Accelerator");
 
@@ -103,13 +104,13 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_WET = key("CFA Body Planet Wet");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_BOGGY = key("CFA Body Planet Boggy");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_OCEANIC = key("CFA Body Planet Oceanic");
-    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ATMOSPHERELESS = key(
-        "CFA Body Planet Atmosphereless");
+    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ATMOSPHERELESS =
+        key("CFA Body Planet Atmosphereless");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_GIANT = key("CFA Body Planet Giant");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_OVERWORLD = key("CFA Body Planet Overworld");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_FLESH = key("CFA Body Planet Flesh");
-    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_INTELLIGENCE = key(
-        "CFA Body Planet Intelligence");
+    public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_INTELLIGENCE =
+        key("CFA Body Planet Intelligence");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_SHATTERED = key("CFA Body Planet Shattered");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_HOLLOW = key("CFA Body Planet Hollow");
     public static final StandaloneModelKey<BlockStateModel> BODY_PLANET_ERROR = key("CFA Body Planet Error");
@@ -840,18 +841,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         pose.popPose();
 
         // 绘制恒星光晕。
-        int haloIterations = 10;
-        for (int i = 0; i < haloIterations; i++) {
-            float progress = (float) i / haloIterations;
-            float haloScale = 1.0f + progress * 0.6f;
-            float alpha = (1.2f - 1.125f * progress) / haloIterations;
-            pose.pushPose();
-            pose.translate(0.5, 0.5, 0.5);
-            pose.scale(haloScale, haloScale, haloScale);
-            pose.translate(-0.5, -0.5, -0.5);
-            this.submitTranslucentCube(pose, collector, rgb[0], rgb[1], rgb[2], alpha);
-            pose.popPose();
-        }
+        this.submitHalo(pose, collector, rgb[0], rgb[1], rgb[2], 10, 1.0f, 0.6f, 1.2f, 1.125f);
     }
 
     private void submitPlanet(
@@ -893,18 +883,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         // 褐矮星使用较弱的恒星式光晕。
         if (bodyData instanceof GiantPlanetData gp && gp.brownDwarf()) {
             float[] rgb = CelestialBodyRenderer.getAtmosphereColor(Temperature.SCORCHED);
-            int haloIterations = 3;
-            for (int i = 0; i < haloIterations; i++) {
-                float progress = (float) i / haloIterations;
-                float haloScale = 1.15f + progress * 0.25f;
-                float alpha = (0.45f - 0.38f * progress) / haloIterations;
-                pose.pushPose();
-                pose.translate(0.5, 0.5, 0.5);
-                pose.scale(haloScale, haloScale, haloScale);
-                pose.translate(-0.5, -0.5, -0.5);
-                this.submitTranslucentCube(pose, collector, rgb[0], rgb[1], rgb[2], alpha);
-                pose.popPose();
-            }
+            this.submitHalo(pose, collector, rgb[0], rgb[1], rgb[2], 3, 1.15f, 0.25f, 0.45f, 0.38f);
         }
     }
 
@@ -948,27 +927,44 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         );
     }
 
-    private void submitTranslucentCube(
+    private void submitHalo(
         PoseStack pose,
         SubmitNodeCollector collector,
         float r,
         float g,
         float b,
-        float a
+        int iterations,
+        float baseScale,
+        float scaleRange,
+        float baseAlpha,
+        float alphaRange
     ) {
         collector.submitCustomGeometry(
             pose,
             ModRenderTypes.CELESTIAL_ATMOSPHERE,
-            (last, consumer) -> CelestialBodyRenderer.renderColorCube(
-                last,
-                consumer,
-                r,
-                g,
-                b,
-                a,
-                LightCoordsUtil.FULL_BRIGHT,
-                OverlayTexture.NO_OVERLAY
-            )
+            (last, consumer) -> {
+                PoseStack haloPose = poseOf(last);
+                for (int i = 0; i < iterations; i++) {
+                    float progress = (float) i / iterations;
+                    float scale = baseScale + progress * scaleRange;
+                    float alpha = (baseAlpha - alphaRange * progress) / iterations;
+                    haloPose.pushPose();
+                    haloPose.translate(0.5, 0.5, 0.5);
+                    haloPose.scale(scale, scale, scale);
+                    haloPose.translate(-0.5, -0.5, -0.5);
+                    CelestialBodyRenderer.renderColorCube(
+                        haloPose.last(),
+                        consumer,
+                        r,
+                        g,
+                        b,
+                        alpha,
+                        LightCoordsUtil.FULL_BRIGHT,
+                        OverlayTexture.NO_OVERLAY
+                    );
+                    haloPose.popPose();
+                }
+            }
         );
     }
 
@@ -1042,7 +1038,8 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         collector.submitCustomGeometry(
             pose, ModRenderTypes.STELLAR_BEAM, (last, consumer) -> {
                 Matrix4f matrix = last.pose();
-                RandomSource rand = RandomSource.create(seed);
+                RandomSource rand = this.supernovaRandom;
+                rand.setSeed(seed);
                 for (int i = 0; i < SUPERNOVA_RAY_COUNT; i++) {
                     float u = rand.nextFloat() * 2.0f - 1.0f;
                     float theta = rand.nextFloat() * (float) (Math.PI * 2.0);
@@ -1075,26 +1072,68 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float g,
         float b
     ) {
-        Vector3f dir = new Vector3f(dx, dy, dz).normalize();
-        Vector3f up = Math.abs(dir.y) > 0.99f ? new Vector3f(1f, 0f, 0f) : new Vector3f(0f, 1f, 0f);
-        Vector3f n1 = new Vector3f(dir).cross(up).normalize().mul(halfWidth);
-        Vector3f n2 = new Vector3f(dir).cross(n1).normalize().mul(halfWidth);
-        Vector3f tip = new Vector3f(dir).mul(length);
+        float inverseLength = Mth.invSqrt(dx * dx + dy * dy + dz * dz);
+        dx *= inverseLength;
+        dy *= inverseLength;
+        dz *= inverseLength;
 
-        float[][] base = {
-            {-n1.x - n2.x, -n1.y - n2.y, -n1.z - n2.z},
-            {n1.x - n2.x, n1.y - n2.y, n1.z - n2.z},
-            {n1.x + n2.x, n1.y + n2.y, n1.z + n2.z},
-            {-n1.x + n2.x, -n1.y + n2.y, -n1.z + n2.z}
-        };
-        for (int i = 0; i < 4; i++) {
-            float[] c0 = base[i];
-            float[] c1 = base[(i + 1) % 4];
-            beamVertex(consumer, matrix, c0[0], c0[1], c0[2], r, g, b, 1.0f);
-            beamVertex(consumer, matrix, c1[0], c1[1], c1[2], r, g, b, 1.0f);
-            beamVertex(consumer, matrix, tip.x, tip.y, tip.z, 0f, 0f, 0f, 1.0f);
-            beamVertex(consumer, matrix, tip.x, tip.y, tip.z, 0f, 0f, 0f, 1.0f);
-        }
+        float n1x = Math.abs(dy) > 0.99f ? 0.0f : -dz;
+        float n1y = Math.abs(dy) > 0.99f ? dz : 0.0f;
+        float n1z = Math.abs(dy) > 0.99f ? -dy : dx;
+        float n1Scale = halfWidth * Mth.invSqrt(n1x * n1x + n1y * n1y + n1z * n1z);
+        n1x *= n1Scale;
+        n1y *= n1Scale;
+        n1z *= n1Scale;
+
+        float n2x = dy * n1z - dz * n1y;
+        float n2y = dz * n1x - dx * n1z;
+        float n2z = dx * n1y - dy * n1x;
+        float n2Scale = halfWidth * Mth.invSqrt(n2x * n2x + n2y * n2y + n2z * n2z);
+        n2x *= n2Scale;
+        n2y *= n2Scale;
+        n2z *= n2Scale;
+
+        float tipX = dx * length;
+        float tipY = dy * length;
+        float tipZ = dz * length;
+        float c0x = -n1x - n2x;
+        float c0y = -n1y - n2y;
+        float c0z = -n1z - n2z;
+        float c1x = n1x - n2x;
+        float c1y = n1y - n2y;
+        float c1z = n1z - n2z;
+        float c2x = n1x + n2x;
+        float c2y = n1y + n2y;
+        float c2z = n1z + n2z;
+        float c3x = -n1x + n2x;
+        float c3y = -n1y + n2y;
+        float c3z = -n1z + n2z;
+        emitRaySide(consumer, matrix, c0x, c0y, c0z, c1x, c1y, c1z, tipX, tipY, tipZ, r, g, b);
+        emitRaySide(consumer, matrix, c1x, c1y, c1z, c2x, c2y, c2z, tipX, tipY, tipZ, r, g, b);
+        emitRaySide(consumer, matrix, c2x, c2y, c2z, c3x, c3y, c3z, tipX, tipY, tipZ, r, g, b);
+        emitRaySide(consumer, matrix, c3x, c3y, c3z, c0x, c0y, c0z, tipX, tipY, tipZ, r, g, b);
+    }
+
+    private static void emitRaySide(
+        VertexConsumer consumer,
+        Matrix4f matrix,
+        float x0,
+        float y0,
+        float z0,
+        float x1,
+        float y1,
+        float z1,
+        float tipX,
+        float tipY,
+        float tipZ,
+        float r,
+        float g,
+        float b
+    ) {
+        beamVertex(consumer, matrix, x0, y0, z0, r, g, b, 1.0f);
+        beamVertex(consumer, matrix, x1, y1, z1, r, g, b, 1.0f);
+        beamVertex(consumer, matrix, tipX, tipY, tipZ, 0f, 0f, 0f, 1.0f);
+        beamVertex(consumer, matrix, tipX, tipY, tipZ, 0f, 0f, 0f, 1.0f);
     }
 
     private static void beamVertex(
@@ -1120,14 +1159,30 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         int light
     ) {
         int overlay = OverlayTexture.NO_OVERLAY;
-        vc.addVertex(pose, -r, 0f, -r).setColor(1.0f, 1.0f, 1.0f, alpha).setUv(0f, 0f)
-            .setOverlay(overlay).setLight(light).setNormal(pose, 0f, 1f, 0f);
-        vc.addVertex(pose, -r, 0f, r).setColor(1.0f, 1.0f, 1.0f, alpha).setUv(0f, 1f)
-            .setOverlay(overlay).setLight(light).setNormal(pose, 0f, 1f, 0f);
-        vc.addVertex(pose, r, 0f, r).setColor(1.0f, 1.0f, 1.0f, alpha).setUv(1f, 1f)
-            .setOverlay(overlay).setLight(light).setNormal(pose, 0f, 1f, 0f);
-        vc.addVertex(pose, r, 0f, -r).setColor(1.0f, 1.0f, 1.0f, alpha).setUv(1f, 0f)
-            .setOverlay(overlay).setLight(light).setNormal(pose, 0f, 1f, 0f);
+        vc.addVertex(pose, -r, 0f, -r)
+            .setColor(1.0f, 1.0f, 1.0f, alpha)
+            .setUv(0f, 0f)
+            .setOverlay(overlay)
+            .setLight(light)
+            .setNormal(pose, 0f, 1f, 0f);
+        vc.addVertex(pose, -r, 0f, r)
+            .setColor(1.0f, 1.0f, 1.0f, alpha)
+            .setUv(0f, 1f)
+            .setOverlay(overlay)
+            .setLight(light)
+            .setNormal(pose, 0f, 1f, 0f);
+        vc.addVertex(pose, r, 0f, r)
+            .setColor(1.0f, 1.0f, 1.0f, alpha)
+            .setUv(1f, 1f)
+            .setOverlay(overlay)
+            .setLight(light)
+            .setNormal(pose, 0f, 1f, 0f);
+        vc.addVertex(pose, r, 0f, -r)
+            .setColor(1.0f, 1.0f, 1.0f, alpha)
+            .setUv(1f, 0f)
+            .setOverlay(overlay)
+            .setLight(light)
+            .setNormal(pose, 0f, 1f, 0f);
     }
 
     // ==================== 托举光束 ====================
@@ -1195,23 +1250,41 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float x1 = cx + halfWidth;
         float z0 = cz - halfWidth;
         float z1 = cz + halfWidth;
-        float[][] corners = {{x0, z0}, {x1, z0}, {x1, z1}, {x0, z1}};
         float ar = r * apexFade;
         float ag = g * apexFade;
         float ab = b * apexFade;
-        for (int i = 0; i < 4; i++) {
-            float[] c0 = corners[i];
-            float[] c1 = corners[(i + 1) % 4];
-            beamVertex(vc, matrix, c0[0], BEAM_BASE_Y, c0[1], r, g, b, 1.0f);
-            beamVertex(vc, matrix, c1[0], BEAM_BASE_Y, c1[1], r, g, b, 1.0f);
-            beamVertex(vc, matrix, cx, apexY, cz, ar, ag, ab, 1.0f);
-            beamVertex(vc, matrix, cx, apexY, cz, ar, ag, ab, 1.0f);
-        }
+        emitBeamSide(vc, matrix, x0, z0, x1, z0, cx, apexY, cz, r, g, b, ar, ag, ab);
+        emitBeamSide(vc, matrix, x1, z0, x1, z1, cx, apexY, cz, r, g, b, ar, ag, ab);
+        emitBeamSide(vc, matrix, x1, z1, x0, z1, cx, apexY, cz, r, g, b, ar, ag, ab);
+        emitBeamSide(vc, matrix, x0, z1, x0, z0, cx, apexY, cz, r, g, b, ar, ag, ab);
+    }
+
+    private static void emitBeamSide(
+        VertexConsumer consumer,
+        Matrix4f matrix,
+        float x0,
+        float z0,
+        float x1,
+        float z1,
+        float apexX,
+        float apexY,
+        float apexZ,
+        float r,
+        float g,
+        float b,
+        float apexR,
+        float apexG,
+        float apexB
+    ) {
+        beamVertex(consumer, matrix, x0, BEAM_BASE_Y, z0, r, g, b, 1.0f);
+        beamVertex(consumer, matrix, x1, BEAM_BASE_Y, z1, r, g, b, 1.0f);
+        beamVertex(consumer, matrix, apexX, apexY, apexZ, apexR, apexG, apexB, 1.0f);
+        beamVertex(consumer, matrix, apexX, apexY, apexZ, apexR, apexG, apexB, 1.0f);
     }
 
     @Override
     public boolean shouldRenderOffScreen() {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/state/CFARenderState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/state/CFARenderState.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.client.renderer.blockentity.state;
 
+import dev.dubhe.anvilcraft.api.rendering.BlockStateModelTessellateState;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyData;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,11 +29,11 @@ public class CFARenderState extends BlockEntityRenderState {
 
     // 机械束星环模型。
     @Nullable
-    private BlockModelRenderState innerRingModel;   // R1 (non-amp) / R4 (amp)
+    private BlockStateModelTessellateState innerRingModel;   // R1 (non-amp) / R4 (amp)
     @Nullable
-    private BlockModelRenderState middleRingModel;  // R2 (non-amp) / R5 (amp)
+    private BlockStateModelTessellateState middleRingModel;  // R2 (non-amp) / R5 (amp)
     @Nullable
-    private BlockModelRenderState outerRingModel;    // R3 (non-amp) / R6 (amp)
+    private BlockStateModelTessellateState outerRingModel;    // R3 (non-amp) / R6 (amp)
     private boolean hasInnerRing;
     private boolean hasMiddleRing;
     private boolean hasOuterRing;

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/state/CFARenderState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/state/CFARenderState.java
@@ -4,7 +4,6 @@ import dev.dubhe.anvilcraft.api.rendering.BlockStateModelTessellateState;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyData;
 import lombok.Getter;
 import lombok.Setter;
-import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.component.ResolvableProfile;
@@ -63,24 +62,24 @@ public class CFARenderState extends BlockEntityRenderState {
     private boolean acceleratorActive;
 
     @Nullable
-    private BlockModelRenderState r4DysonModel;
+    private BlockStateModelTessellateState r4DysonModel;
     @Nullable
-    private BlockModelRenderState r5DysonModel;
+    private BlockStateModelTessellateState r5DysonModel;
     @Nullable
-    private BlockModelRenderState coilFixModel;
+    private BlockStateModelTessellateState coilFixModel;
     @Nullable
-    private BlockModelRenderState coilRingModel;
+    private BlockStateModelTessellateState coilRingModel;
     @Nullable
-    private BlockModelRenderState penroseFixModel;
+    private BlockStateModelTessellateState penroseFixModel;
     @Nullable
-    private BlockModelRenderState penroseLaserModel;
+    private BlockStateModelTessellateState penroseLaserModel;
     @Nullable
-    private BlockModelRenderState decompressorFixModel;
+    private BlockStateModelTessellateState decompressorFixModel;
     @Nullable
-    private BlockModelRenderState decompressorRingModel;
+    private BlockStateModelTessellateState decompressorRingModel;
     // 戴森球使用恒星同步方式渲染的外环模型。
     @Nullable
-    private BlockModelRenderState dysonOuterRingModel;
+    private BlockStateModelTessellateState dysonOuterRingModel;
     private boolean dysonSmallStar;
 
     // 动画状态。
@@ -92,15 +91,15 @@ public class CFARenderState extends BlockEntityRenderState {
     private boolean canRenderBody;
     // 主序星、中子星和黑洞使用的烘焙动画模型。
     @Nullable
-    private BlockModelRenderState bodyModel;
+    private BlockStateModelTessellateState bodyModel;
     @Nullable
-    private BlockModelRenderState neutronJetModel;
+    private BlockStateModelTessellateState neutronJetModel;
     // 色板行星的动态烘焙贴图标识；恒星和复杂模型天体不使用。
     @Nullable
     private Identifier bodyTexture;
     // 粉碎、空洞、血肉、智慧和错误天体的复杂模型。
     @Nullable
-    private BlockModelRenderState complexBodyModel;
+    private BlockStateModelTessellateState complexBodyModel;
     @Nullable
     private ResolvableProfile playerHeadProfile;
     // 使用烘焙贴图的天体环。

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/FeatureRendererSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/FeatureRendererSupport.java
@@ -27,8 +27,8 @@ public class FeatureRendererSupport {
     ) {
         return createTessellation(
             key,
-            lighting,
-            false
+            false,
+            lighting
         );
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/FeatureRendererSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/FeatureRendererSupport.java
@@ -1,5 +1,7 @@
 package dev.dubhe.anvilcraft.client.support;
 
+import dev.dubhe.anvilcraft.api.rendering.BlockStateModelRenderer;
+import dev.dubhe.anvilcraft.api.rendering.BlockStateModelTessellateState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
@@ -17,7 +19,30 @@ import org.slf4j.LoggerFactory;
 
 public class FeatureRendererSupport {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger("anvilcraft:FeatureRendererSupport");
+    private static final Logger LOGGER = LoggerFactory.getLogger("FeatureRendererSupport");
+
+    public static BlockStateModelTessellateState createTessellation(
+        StandaloneModelKey<BlockStateModel> key,
+        boolean lighting
+    ) {
+        return createTessellation(
+            key,
+            lighting,
+            false
+        );
+    }
+
+    public static BlockStateModelTessellateState createTessellation(
+        StandaloneModelKey<BlockStateModel> key,
+        boolean translucent,
+        boolean lighting
+    ) {
+        return BlockStateModelRenderer.INSTANCE.prepare(key, translucent, lighting);
+    }
+
+    public static BlockModelRenderState initialize(StandaloneModelKey<BlockStateModel> standalone, BlockEntity be) {
+        return initialize(standalone, be, false);
+    }
 
     public static BlockModelRenderState initialize(BlockState blockState, BlockEntity be) {
         BlockModelRenderState state = new BlockModelRenderState();
@@ -30,10 +55,6 @@ public class FeatureRendererSupport {
             state.setupModel(new Matrix4f(), false)
         );
         return state;
-    }
-
-    public static BlockModelRenderState initialize(StandaloneModelKey<BlockStateModel> standalone, BlockEntity be) {
-        return initialize(standalone, be, false);
     }
 
     /**

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -166,4 +166,3 @@ public net.minecraft.client.renderer.block.BlockModelRenderState submitModel(Lne
 public-f net.minecraft.world.level.block.entity.BlockEntity worldPosition
 
 public-f net.minecraft.client.model.Model renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
-public net.minecraft.client.renderer.block.BlockModelRenderState renderType

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -163,7 +163,7 @@ public com.mojang.blaze3d.opengl.GlCommandEncoder
 public com.mojang.blaze3d.opengl.GlRenderPass
 
 public net.minecraft.client.renderer.block.BlockModelRenderState submitModel(Lnet/minecraft/client/renderer/rendertype/RenderType;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;III)V
-public net.minecraft.client.renderer.block.BlockModelRenderState modelParts
-public net.minecraft.client.renderer.block.BlockModelRenderState tintLayers
-
 public-f net.minecraft.world.level.block.entity.BlockEntity worldPosition
+
+public-f net.minecraft.client.model.Model renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
+public net.minecraft.client.renderer.block.BlockModelRenderState renderType


### PR DESCRIPTION
## Summary
- Add cached block-state model tessellation states and a wrapped model submission path
- Migrate all CFA block model render-state fields while preserving their translucency and lighting parameters
- Correct tessellation overload forwarding and remove CFA-local legacy submission helpers

## Verification
- `.\gradlew.bat check --console=plain` (BUILD SUCCESSFUL; test sources are NO-SOURCE)
- IntelliJ project build (successful, no problems)
- Structural migration checks for remaining `BlockModelRenderState` fields and legacy CFA helpers
- In-game CFA rendering verified by the author