### PR TITLE
Optimize container fluid handling and emitter behavior. 优化容器流体处理及发射器行为

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/FluidHandlerWrapper.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/FluidHandlerWrapper.java
@@ -260,7 +260,7 @@ public class FluidHandlerWrapper {
 
     @Nullable
     public ItemStack drainToItem(ItemStack emptyContainer, boolean simulateOnly) {
-        if (emptyContainer.isEmpty()) return null;
+        if (!isSupportedEmptyContainer(emptyContainer)) return null;
         int amount = emptyContainer.is(Items.GLASS_BOTTLE)
             ? FluidType.BUCKET_VOLUME / 4
             : FluidType.BUCKET_VOLUME;
@@ -277,6 +277,8 @@ public class FluidHandlerWrapper {
      */
     @Nullable
     public ItemStack drainToItem(ItemStack emptyContainer, int amount, boolean simulateOnly) {
+        if (!isSupportedEmptyContainer(emptyContainer)) return null;
+
         // 模拟：从目标处理器抽取
         FluidStack drained = handler.drain(amount, IFluidHandler.FluidAction.SIMULATE);
         if (drained.getAmount() < amount) return null;
@@ -322,6 +324,10 @@ public class FluidHandlerWrapper {
         }
 
         return ItemStack.EMPTY;
+    }
+
+    private static boolean isSupportedEmptyContainer(ItemStack stack) {
+        return stack.is(Items.BUCKET) || stack.is(Items.GLASS_BOTTLE);
     }
 
     // endregion

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModDispenserBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModDispenserBehavior.java
@@ -111,11 +111,12 @@ public class ModDispenserBehavior {
         DispenserBlock.registerBehavior(ModBlocks.RESIN_BLOCK, ModDispenserBehavior::resinBlock);
         DispenserBlock.registerBehavior(ModBlocks.MENGER_SPONGE, ModDispenserBehavior::mengerSponge);
 
-        // 特殊桶：油桶、水泥桶等（走原版空容器排放逻辑）
-        DispenserBlock.registerBehavior(ModItems.OIL_BUCKET, DISPENSIBLE_BUCKET);
-        DispenserBlock.registerBehavior(ModItems.MELT_GEM_BUCKET, DISPENSIBLE_BUCKET);
+        // 特殊桶：优先与流体容器交互，失败后走原版排放逻辑
+        DispenserBlock.registerBehavior(ModItems.EXP_BUCKET, wrapFluidInteraction(DISPENSIBLE_BUCKET));
+        DispenserBlock.registerBehavior(ModItems.OIL_BUCKET, wrapFluidInteraction(DISPENSIBLE_BUCKET));
+        DispenserBlock.registerBehavior(ModItems.MELT_GEM_BUCKET, wrapFluidInteraction(DISPENSIBLE_BUCKET));
         for (ItemEntry<BucketItem> cementBucket : ModItems.CEMENT_BUCKETS.values()) {
-            DispenserBlock.registerBehavior(cementBucket, DISPENSIBLE_BUCKET);
+            DispenserBlock.registerBehavior(cementBucket, wrapFluidInteraction(DISPENSIBLE_BUCKET));
         }
 
         // 通用流体物品：FluidHandlerWrapper 优先，失败回退原版


### PR DESCRIPTION
- 修改drainToItem方法，限制只支持空桶和玻璃瓶
- 新增isSupportedEmptyContainer辅助方法判断支持的空容器类型
- 发射器注册行为改为优先尝试流体交互，失败后回退原版逻辑
- 包装特殊桶行为，使其支持流体容器交互流程
- 统一水泥桶发射器行为，确保一致的流体处理机制
- fixed #4116