### PR TITLE
Fix Transcendence Resonator can break bedrock 修复超限共振器破环基岩的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/item/TranscendenceResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/TranscendenceResonatorItem.java
@@ -25,7 +25,6 @@ import net.minecraft.world.item.component.Unbreakable;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -225,7 +224,7 @@ public class TranscendenceResonatorItem extends ResonatorItem {
 
     static boolean canResonanceMine(BlockState state, Level level, BlockPos pos) {
         if (state.isAir()) return false;
-        return state.is(Blocks.BEDROCK) || state.getDestroySpeed(level, pos) >= 0.0f;
+        return state.getDestroySpeed(level, pos) >= 0.0f;
     }
 
     private record MiningTarget(


### PR DESCRIPTION
- 修复了 #4108。
   - #2057 明确说明了共振器不应该能够破坏基岩。此外，原版的铁头功属于未定义行为，不应视为原版特性的一部分。