### PR TITLE
Fix item collector interception, add 2gt interception after leaving power network, fix corrupted beacon beam sodium compatibility and adjust neutron irradiator recipe 修复物品收集器截胡逻辑，新增离开电网后仍可 2gt 截胡效果，修复腐化信标光柱与钠渲染兼容问题，修改中子辐照器配方

### DIFF
--- a/src/generated/resources/data/anvilcraft/advancement/recipes/misc/neutron_irradiator.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipes/misc/neutron_irradiator.json
@@ -11,21 +11,11 @@
       },
       "trigger": "minecraft:inventory_changed"
     },
-    "has_ember_metal_ingot": {
+    "has_negative_matter": {
       "conditions": {
         "items": [
           {
-            "items": "anvilcraft:ember_metal_ingot"
-          }
-        ]
-      },
-      "trigger": "minecraft:inventory_changed"
-    },
-    "has_negative_matter_block": {
-      "conditions": {
-        "items": [
-          {
-            "items": "anvilcraft:negative_matter_block"
+            "items": "anvilcraft:negative_matter"
           }
         ]
       },
@@ -64,8 +54,7 @@
       "has_neutronium_ingot",
       "has_charged_neutronium_ingot",
       "has_stable_neutronium_ingot",
-      "has_negative_matter_block",
-      "has_ember_metal_ingot"
+      "has_negative_matter"
     ]
   ],
   "rewards": {

--- a/src/generated/resources/data/anvilcraft/recipe/neutron_irradiator.json
+++ b/src/generated/resources/data/anvilcraft/recipe/neutron_irradiator.json
@@ -14,15 +14,12 @@
       }
     ],
     "B": {
-      "item": "anvilcraft:ember_metal_ingot"
-    },
-    "C": {
-      "item": "anvilcraft:negative_matter_block"
+      "item": "anvilcraft:negative_matter"
     }
   },
   "pattern": [
     " A ",
-    "BCB",
+    "B B",
     "BBB"
   ],
   "result": {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemCollectorBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/ItemCollectorBlockEntity.java
@@ -10,8 +10,8 @@ import dev.dubhe.anvilcraft.block.ItemCollectorBlock;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.inventory.ItemCollectorMenu;
 import dev.dubhe.anvilcraft.util.WatchableCyclingValue;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -51,8 +51,11 @@ public class ItemCollectorBlockEntity extends BlockEntity
     IDiskCloneable,
     IHasAffectRange,
     IItemHandlerHolder {
-    @Setter
+    private static final int POACHING_POWER_GRACE_TICKS = 2;
+
     private PowerGrid grid;
+    @Getter(AccessLevel.NONE)
+    private long poachingPowerGraceEndTick = Long.MIN_VALUE;
 
     private final WatchableCyclingValue<Integer> rangeRadius = new WatchableCyclingValue<>(
         "rangeRadius", thiz -> this.setChanged(),
@@ -108,6 +111,19 @@ public class ItemCollectorBlockEntity extends BlockEntity
     @Override
     public BlockPos getPos() {
         return this.getBlockPos();
+    }
+
+    @Override
+    public void setGrid(@Nullable PowerGrid grid) {
+        if (grid == null && this.grid != null && this.grid.isWorking() && this.level != null) {
+            this.poachingPowerGraceEndTick = this.level.getGameTime() + POACHING_POWER_GRACE_TICKS;
+        }
+        this.grid = grid;
+    }
+
+    public boolean canPoach() {
+        return this.isGridWorking()
+            || this.level != null && this.level.getGameTime() < this.poachingPowerGraceEndTick;
     }
 
     private static final Map<Integer, Map<Integer, Integer>> POWER_CONSUMPTION = Map.of(

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/RenderEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/RenderEventListener.java
@@ -57,15 +57,20 @@ public class RenderEventListener {
     }
 
     @SubscribeEvent
-    public static void onRenderAfterWeather(RenderLevelStageEvent event) {
-        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_WEATHER) return;
+    public static void onRenderAfterLevel(RenderLevelStageEvent event) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_LEVEL) return;
         PoseStack poseStack = event.getPoseStack();
         MultiBufferSource.BufferSource bufferSource =
             event.getLevelRenderer().renderBuffers.bufferSource();
         Vec3 camera = event.getCamera().getPosition();
+
+        poseStack.pushPose();
+        poseStack.last().pose().mul(event.getModelViewMatrix());
         CelestialForgingAnvilBlockEntityRenderer.renderDeferredTractorBeams(poseStack, bufferSource, camera);
         CorruptedBeaconRenderer.renderDeferredBeams(poseStack, bufferSource, camera);
+        bufferSource.endBatch(ModRenderTypes.STELLAR_BEAM);
         bufferSource.endBatch(ModRenderTypes.CORRUPTED_BEACON_BEAM);
+        poseStack.popPose();
     }
 
     @SubscribeEvent

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/RenderEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/RenderEventListener.java
@@ -60,15 +60,20 @@ public class RenderEventListener {
     public static void onRenderAfterLevel(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_LEVEL) return;
         PoseStack poseStack = event.getPoseStack();
-        MultiBufferSource.BufferSource bufferSource =
-            event.getLevelRenderer().renderBuffers.bufferSource();
+        LevelRenderer levelRenderer = event.getLevelRenderer();
+        var mainTarget = Minecraft.getInstance().getMainRenderTarget();
+        var weatherTarget = levelRenderer.getWeatherTarget();
+        if (weatherTarget != null) {
+            mainTarget.copyDepthFrom(weatherTarget);
+            mainTarget.bindWrite(false);
+        }
+        MultiBufferSource.BufferSource bufferSource = levelRenderer.renderBuffers.bufferSource();
         Vec3 camera = event.getCamera().getPosition();
-
         poseStack.pushPose();
         poseStack.last().pose().mul(event.getModelViewMatrix());
         CelestialForgingAnvilBlockEntityRenderer.renderDeferredTractorBeams(poseStack, bufferSource, camera);
         CorruptedBeaconRenderer.renderDeferredBeams(poseStack, bufferSource, camera);
-        bufferSource.endBatch(ModRenderTypes.STELLAR_BEAM);
+        bufferSource.endBatch(ModRenderTypes.TRACTOR_BEAM);
         bufferSource.endBatch(ModRenderTypes.CORRUPTED_BEACON_BEAM);
         poseStack.popPose();
     }

--- a/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderTypes.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/init/ModRenderTypes.java
@@ -296,13 +296,29 @@ public class ModRenderTypes {
             .createCompositeState(false)
     );
 
+    public static final RenderType TRACTOR_BEAM = RenderType.create(
+        "anvilcraft:tractor_beam",
+        DefaultVertexFormat.POSITION_COLOR,
+        VertexFormat.Mode.TRIANGLES,
+        1536,
+        false,
+        false,
+        RenderType.CompositeState.builder()
+            .setShaderState(RenderStateShard.POSITION_COLOR_SHADER)
+            .setTransparencyState(ADDITIVE_TRANSPARENCY)
+            .setCullState(NO_CULL)
+            .setDepthTestState(LEQUAL_DEPTH_TEST)
+            .setWriteMaskState(COLOR_WRITE)
+            .createCompositeState(false)
+    );
+
     public static final RenderType CORRUPTED_BEACON_BEAM = RenderType.create(
         "anvilcraft:corrupted_beacon_beam",
         DefaultVertexFormat.POSITION_COLOR,
-        VertexFormat.Mode.QUADS,
+        VertexFormat.Mode.TRIANGLES,
         1536,
         false,
-        true,
+        false,
         RenderType.CompositeState.builder()
             .setShaderState(RenderStateShard.POSITION_COLOR_SHADER)
             .setTransparencyState(TRANSLUCENT_TRANSPARENCY)

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
@@ -1138,13 +1138,13 @@ public class CelestialForgingAnvilBlockEntityRenderer implements BlockEntityRend
     private static final int BEAM_GLOW_LAYERS = 4;
     private static final float BEAM_GLOW_HALF_STEP = 0.06f; /// 每层相对核心额外加宽的半宽
 
-    /// 延迟渲染队列：托举光束在 AFTER_WEATHER 阶段渲染以解决云层遮挡
+    /// 延迟渲染队列：托举光束在 AFTER_LEVEL 阶段渲染以解决云层遮挡
     private static final java.util.List<TractorBeamData> deferredTractorBeams = new java.util.ArrayList<>();
 
     private record TractorBeamData(BlockPos pos, float beamHeight, float animProgress) {}
 
     /**
-     * 在 AFTER_WEATHER 阶段由 RenderEventListener 调用，渲染所有延迟托举光束。
+     * 在 AFTER_LEVEL 阶段由 RenderEventListener 调用，渲染所有延迟托举光束。
      */
     public static void renderDeferredTractorBeams(PoseStack poseStack, MultiBufferSource bufferSource, Vec3 camera) {
         if (deferredTractorBeams.isEmpty()) return;

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
@@ -433,7 +433,7 @@ public class CelestialForgingAnvilBlockEntityRenderer implements BlockEntityRend
         if (canRender) {
             float rotationBoost = blockEntity.getAnimationRotationBoost(partialTick);
             float bodyRot = (blockEntity.getBodyRotation() + partialTick) * rotationBoost;
-            /// 锥形托举光束放入延迟队列，在 AFTER_WEATHER 阶段渲染以避免云层遮挡。
+            /// 锥形托举光束放入延迟队列，在 AFTER_LEVEL 阶段渲染以避免云层遮挡。
             if (beamHeight > 0.01f && animProgress > 0.01f) {
                 deferredTractorBeams.add(new TractorBeamData(blockEntity.getBlockPos(), beamHeight, animProgress));
             }
@@ -1169,7 +1169,7 @@ public class CelestialForgingAnvilBlockEntityRenderer implements BlockEntityRend
     ) {
         if (beamHeight <= 0.01f || animProgress <= 0.01f) return;
 
-        VertexConsumer vc = bufferSource.getBuffer(ModRenderTypes.STELLAR_BEAM);
+        VertexConsumer vc = bufferSource.getBuffer(ModRenderTypes.TRACTOR_BEAM);
         PoseStack.Pose pose = poseStack.last();
         float apexY = BEAM_BASE_Y + beamHeight;
 
@@ -1220,7 +1220,6 @@ public class CelestialForgingAnvilBlockEntityRenderer implements BlockEntityRend
             float[] c1 = corners[(i + 1) % 4];
             vc.addVertex(pose, c0[0], BEAM_BASE_Y, c0[1]).setColor(r, g, b, 1.0f);
             vc.addVertex(pose, c1[0], BEAM_BASE_Y, c1[1]).setColor(r, g, b, 1.0f);
-            vc.addVertex(pose, cx, apexY, cz).setColor(ar, ag, ab, 1.0f);
             vc.addVertex(pose, cx, apexY, cz).setColor(ar, ag, ab, 1.0f);
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CorruptedBeaconRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CorruptedBeaconRenderer.java
@@ -42,7 +42,7 @@ public class CorruptedBeaconRenderer implements BlockEntityRenderer<CorruptedBea
     private static final float BEAM_G = 0.0f;
     private static final float BEAM_B = 0.05f;
 
-    /// 延迟渲染队列：光束在 AFTER_WEATHER 阶段渲染
+    /// 延迟渲染队列：光束在 AFTER_LEVEL 阶段渲染
     private static final List<BeamRenderData> deferredBeams = new ArrayList<>();
     private static final List<WeaponBeamRenderData> deferredWeaponBeams = new ArrayList<>();
 
@@ -109,7 +109,7 @@ public class CorruptedBeaconRenderer implements BlockEntityRenderer<CorruptedBea
     }
 
     /**
-     * 在 AFTER_WEATHER 阶段由 RenderEventListener 调用，渲染所有延迟光束。
+     * 在 AFTER_LEVEL 阶段由 RenderEventListener 调用，渲染所有延迟光束。
      * 事件回调会立即提交对应的渲染批次。
      */
     public static void renderDeferredBeams(PoseStack poseStack, MultiBufferSource bufferSource, Vec3 camera) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CorruptedBeaconRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CorruptedBeaconRenderer.java
@@ -138,9 +138,7 @@ public class CorruptedBeaconRenderer implements BlockEntityRenderer<CorruptedBea
             if (direction.lengthSqr() < 1.0E-6) continue;
             poseStack.pushPose();
             if (data.viewBobCompensation != null) {
-                poseStack.last().pose().set(
-                    data.viewBobCompensation.mul(poseStack.last().pose(), new Matrix4f())
-                );
+                poseStack.last().pose().mul(data.viewBobCompensation);
             }
             poseStack.translate(
                 data.start.x - camera.x,
@@ -229,7 +227,6 @@ public class CorruptedBeaconRenderer implements BlockEntityRenderer<CorruptedBea
             float[] c1 = corners[(i + 1) % 4];
             vc.addVertex(pose, c0[0], baseY, c0[1]).setColor(r, g, b, alpha);
             vc.addVertex(pose, c1[0], baseY, c1[1]).setColor(r, g, b, alpha);
-            vc.addVertex(pose, cx, apexY, cz).setColor(r, g, b, tipAlpha);
             vc.addVertex(pose, cx, apexY, cz).setColor(r, g, b, tipAlpha);
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/RegistrumBlockRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/RegistrumBlockRecipeLoader.java
@@ -286,11 +286,10 @@ public class RegistrumBlockRecipeLoader {
     public static <T extends Block> void neutronIrradiator(DataGenContext<Block, T> ctx, RegistrumRecipeProvider provider) {
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC, ctx.get())
             .pattern(" A ")
-            .pattern("BCB")
+            .pattern("B B")
             .pattern("BBB")
             .define('A', Ingredient.of(ModItems.NEUTRONIUM_INGOT, ModItems.CHARGED_NEUTRONIUM_INGOT, ModItems.STABLE_NEUTRONIUM_INGOT))
-            .define('B', ModItems.EMBER_METAL_INGOT)
-            .define('C', ModBlocks.NEGATIVE_MATTER_BLOCK)
+            .define('B', ModItems.NEGATIVE_MATTER)
             .unlockedBy(AnvilCraftDatagen.hasItem(ModItems.NEUTRONIUM_INGOT), AnvilCraftDatagen.has(ModItems.NEUTRONIUM_INGOT))
             .unlockedBy(
                 AnvilCraftDatagen.hasItem(ModItems.CHARGED_NEUTRONIUM_INGOT),
@@ -300,8 +299,7 @@ public class RegistrumBlockRecipeLoader {
                 AnvilCraftDatagen.hasItem(ModItems.STABLE_NEUTRONIUM_INGOT),
                 AnvilCraftDatagen.has(ModItems.STABLE_NEUTRONIUM_INGOT)
             )
-            .unlockedBy(AnvilCraftDatagen.hasItem(ModBlocks.NEGATIVE_MATTER_BLOCK), AnvilCraftDatagen.has(ModBlocks.NEGATIVE_MATTER_BLOCK))
-            .unlockedBy(AnvilCraftDatagen.hasItem(ModItems.EMBER_METAL_INGOT), AnvilCraftDatagen.has(ModItems.EMBER_METAL_INGOT))
+            .unlockedBy(AnvilCraftDatagen.hasItem(ModItems.NEGATIVE_MATTER), AnvilCraftDatagen.has(ModItems.NEGATIVE_MATTER))
             .save(provider);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ItemEntityMixin.java
@@ -357,7 +357,7 @@ abstract class ItemEntityMixin extends Entity implements IItemEntityExtension {
         ItemStack itemStack = this.getItem().copy();
         boolean flag = false;
         for (ItemCollectorBlockEntity collector : list) {
-            if (collector.isGridWorking()
+            if (collector.canPoach()
                 && !collector.getBlockState().getValue(ItemCollectorBlock.POWERED)
                 && collector.shape().contains(this.position())
                 && !collector.isRemoved()) {


### PR DESCRIPTION
- 修物品收集器截胡，增加了一个离开电网也能继续截胡2gt fixed #4139 
- 修腐化信标光柱和钠的兼容问题
- 修改中子辐照器配方