### PR TITLE
Adjust large cauldron collision while holding giant anvil, fix pot/tank damage & optical‑loop bugs, multi‑block break logic, redstone wire tweaks and expose gravity API 手持巨型铁砧时大锅顶部视为完整碰撞，修复锅缸伤害、环形光路等漏洞，完善多方块破坏逻辑，修改红石导线并开放引力 API

### DIFF
--- a/src/generated/resources/assets/anvilcraft/blockstates/redstone_wire.json
+++ b/src/generated/resources/assets/anvilcraft/blockstates/redstone_wire.json
@@ -191,6 +191,15 @@
     },
     {
       "apply": {
+        "model": "anvilcraft:block/redstone_wire/north/side_corner_sp_0"
+      },
+      "when": {
+        "attachment": "north",
+        "north": "corner_sp"
+      }
+    },
+    {
+      "apply": {
         "model": "anvilcraft:block/redstone_wire/north/up_0"
       },
       "when": {
@@ -304,6 +313,15 @@
       "when": {
         "attachment": "south",
         "north": "corner"
+      }
+    },
+    {
+      "apply": {
+        "model": "anvilcraft:block/redstone_wire/south/side_corner_sp_0"
+      },
+      "when": {
+        "attachment": "south",
+        "north": "corner_sp"
       }
     },
     {
@@ -425,6 +443,15 @@
     },
     {
       "apply": {
+        "model": "anvilcraft:block/redstone_wire/west/side_corner_sp_0"
+      },
+      "when": {
+        "attachment": "west",
+        "north": "corner_sp"
+      }
+    },
+    {
+      "apply": {
         "model": "anvilcraft:block/redstone_wire/west/up_0"
       },
       "when": {
@@ -538,6 +565,15 @@
       "when": {
         "attachment": "east",
         "north": "corner"
+      }
+    },
+    {
+      "apply": {
+        "model": "anvilcraft:block/redstone_wire/east/side_corner_sp_0"
+      },
+      "when": {
+        "attachment": "east",
+        "north": "corner_sp"
       }
     },
     {

--- a/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/east/side_corner_sp_0.json
+++ b/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/east/side_corner_sp_0.json
@@ -1,0 +1,136 @@
+{
+  "ambientocclusion": false,
+  "elements": [
+    {
+      "faces": {
+        "east": {
+          "cullface": "east",
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            11.0,
+            0.0,
+            5.0,
+            8.0
+          ]
+        },
+        "north": {
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            5.0,
+            8.0,
+            6.0,
+            0.0
+          ]
+        },
+        "south": {
+          "texture": "#0",
+          "uv": [
+            10.0,
+            0.0,
+            11.0,
+            8.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "rotation": 270,
+          "texture": "#0",
+          "uv": [
+            5.0,
+            0.0,
+            11.0,
+            1.0
+          ]
+        },
+        "west": {
+          "texture": "#0"
+        }
+      },
+      "from": [
+        15,
+        8,
+        5
+      ],
+      "to": [
+        16,
+        16,
+        11
+      ]
+    },
+    {
+      "faces": {
+        "east": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        },
+        "north": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        },
+        "south": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "rotation": 270,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            1.0
+          ]
+        },
+        "west": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        }
+      },
+      "from": [
+        14,
+        8,
+        6
+      ],
+      "to": [
+        15.99,
+        17,
+        10
+      ]
+    }
+  ],
+  "textures": {
+    "0": "anvilcraft:block/redstone_wire_line",
+    "1": "anvilcraft:block/redstone_wire_line_overlay",
+    "particle": "anvilcraft:block/redstone_wire_line"
+  }
+}

--- a/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/north/side_corner_sp_0.json
+++ b/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/north/side_corner_sp_0.json
@@ -1,0 +1,130 @@
+{
+  "ambientocclusion": false,
+  "elements": [
+    {
+      "faces": {
+        "east": {
+          "texture": "#0",
+          "uv": [
+            10.0,
+            0.0,
+            11.0,
+            8.0
+          ]
+        },
+        "north": {
+          "cullface": "north",
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            11.0,
+            0.0,
+            5.0,
+            8.0
+          ]
+        },
+        "south": {
+          "texture": "#0"
+        },
+        "up": {
+          "cullface": "up",
+          "rotation": 180,
+          "texture": "#0"
+        },
+        "west": {
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            5.0,
+            8.0,
+            6.0,
+            0.0
+          ]
+        }
+      },
+      "from": [
+        5,
+        8,
+        0
+      ],
+      "to": [
+        11,
+        16,
+        1
+      ]
+    },
+    {
+      "faces": {
+        "east": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        },
+        "north": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        },
+        "south": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            1.0
+          ]
+        },
+        "west": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        }
+      },
+      "from": [
+        6,
+        8,
+        0.01
+      ],
+      "to": [
+        10,
+        17,
+        2
+      ]
+    }
+  ],
+  "textures": {
+    "0": "anvilcraft:block/redstone_wire_line",
+    "1": "anvilcraft:block/redstone_wire_line_overlay",
+    "particle": "anvilcraft:block/redstone_wire_line"
+  }
+}

--- a/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/south/side_corner_sp_0.json
+++ b/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/south/side_corner_sp_0.json
@@ -1,0 +1,134 @@
+{
+  "ambientocclusion": false,
+  "elements": [
+    {
+      "faces": {
+        "east": {
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            5.0,
+            8.0,
+            6.0,
+            0.0
+          ]
+        },
+        "north": {
+          "texture": "#0"
+        },
+        "south": {
+          "cullface": "south",
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            11.0,
+            0.0,
+            5.0,
+            8.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "texture": "#0",
+          "uv": [
+            5.0,
+            0.0,
+            11.0,
+            1.0
+          ]
+        },
+        "west": {
+          "texture": "#0",
+          "uv": [
+            10.0,
+            0.0,
+            11.0,
+            8.0
+          ]
+        }
+      },
+      "from": [
+        5,
+        8,
+        15
+      ],
+      "to": [
+        11,
+        16,
+        16
+      ]
+    },
+    {
+      "faces": {
+        "east": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        },
+        "north": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        },
+        "south": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            1.0
+          ]
+        },
+        "west": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        }
+      },
+      "from": [
+        6,
+        8,
+        14
+      ],
+      "to": [
+        10,
+        17,
+        15.99
+      ]
+    }
+  ],
+  "textures": {
+    "0": "anvilcraft:block/redstone_wire_line",
+    "1": "anvilcraft:block/redstone_wire_line_overlay",
+    "particle": "anvilcraft:block/redstone_wire_line"
+  }
+}

--- a/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/west/side_corner_sp_0.json
+++ b/src/generated/resources/assets/anvilcraft/models/block/redstone_wire/west/side_corner_sp_0.json
@@ -1,0 +1,136 @@
+{
+  "ambientocclusion": false,
+  "elements": [
+    {
+      "faces": {
+        "east": {
+          "texture": "#0"
+        },
+        "north": {
+          "texture": "#0",
+          "uv": [
+            10.0,
+            0.0,
+            11.0,
+            8.0
+          ]
+        },
+        "south": {
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            5.0,
+            8.0,
+            6.0,
+            0.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "rotation": 90,
+          "texture": "#0",
+          "uv": [
+            5.0,
+            0.0,
+            11.0,
+            1.0
+          ]
+        },
+        "west": {
+          "cullface": "west",
+          "rotation": 180,
+          "texture": "#0",
+          "uv": [
+            11.0,
+            0.0,
+            5.0,
+            8.0
+          ]
+        }
+      },
+      "from": [
+        0,
+        8,
+        5
+      ],
+      "to": [
+        1,
+        16,
+        11
+      ]
+    },
+    {
+      "faces": {
+        "east": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        },
+        "north": {
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        },
+        "south": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            7.0,
+            9.0
+          ]
+        },
+        "up": {
+          "cullface": "up",
+          "rotation": 90,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            1.0
+          ]
+        },
+        "west": {
+          "rotation": 180,
+          "texture": "#1",
+          "tintindex": 0,
+          "uv": [
+            6.0,
+            0.0,
+            10.0,
+            9.0
+          ]
+        }
+      },
+      "from": [
+        0.01,
+        8,
+        6
+      ],
+      "to": [
+        2,
+        17,
+        10
+      ]
+    }
+  ],
+  "textures": {
+    "0": "anvilcraft:block/redstone_wire_line",
+    "1": "anvilcraft:block/redstone_wire_line_overlay",
+    "particle": "anvilcraft:block/redstone_wire_line"
+  }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/anvil/TimeWarpPlayerBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/anvil/TimeWarpPlayerBehavior.java
@@ -5,6 +5,7 @@ import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.block.CorruptedBeaconBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.entity.ModDamageTypes;
+import dev.dubhe.anvilcraft.util.CauldronUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -17,12 +18,19 @@ public class TimeWarpPlayerBehavior implements IAnvilBehavior {
     @Override
     public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!(level instanceof ServerLevel serverLevel)) return false;
-        BlockState below = level.getBlockState(hitBlockPos.below());
-        if (!below.is(ModBlocks.CORRUPTED_BEACON)) return false;
-        if (!below.getValue(CorruptedBeaconBlock.LIT)) return false;
-        List<ServerPlayer> players = serverLevel.getPlayers(player -> player.getOnPos().equals(hitBlockPos));
+        boolean activeBeacon = CauldronUtil.getBottomPositions(hitBlockPos, hitBlockState).stream()
+            .map(level::getBlockState)
+            .anyMatch(TimeWarpPlayerBehavior::isActiveCorruptedBeacon);
+        if (!activeBeacon) return false;
+        List<ServerPlayer> players = serverLevel.getPlayers(
+            player -> CauldronUtil.isEntityInside(hitBlockPos, hitBlockState, player)
+        );
         if (players.isEmpty()) return false;
         for (ServerPlayer player : players) player.hurt(ModDamageTypes.lostInTime(level), Float.MAX_VALUE);
         return true;
+    }
+
+    private static boolean isActiveCorruptedBeacon(BlockState state) {
+        return state.is(ModBlocks.CORRUPTED_BEACON) && state.getValue(CorruptedBeaconBlock.LIT);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/block/ICauldronGeometry.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/block/ICauldronGeometry.java
@@ -1,0 +1,16 @@
+package dev.dubhe.anvilcraft.api.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+
+import java.util.List;
+
+/**
+ * Describes the interior and supporting blocks of a non-standard cauldron.
+ */
+public interface ICauldronGeometry {
+    AABB getCauldronInnerArea(BlockPos pos, BlockState state);
+
+    List<BlockPos> getCauldronBottomPositions(BlockPos pos, BlockState state);
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/block/IDamagingHeater.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/block/IDamagingHeater.java
@@ -1,0 +1,10 @@
+package dev.dubhe.anvilcraft.api.block;
+
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * A heater that damages entities standing on it or in a cauldron above it.
+ */
+public interface IDamagingHeater {
+    boolean isActive(BlockState state);
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/entity/IAnvilCraftEntityExtension.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/entity/IAnvilCraftEntityExtension.java
@@ -1,0 +1,28 @@
+package dev.dubhe.anvilcraft.api.entity;
+
+import dev.dubhe.anvilcraft.util.GravityType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
+
+public interface IAnvilCraftEntityExtension {
+    default GravityType anvilcraft$getGravityType() {
+        return null;
+    }
+
+    default Vec3 anvilcraft$getAdditionalGravity(double baseGravity) {
+        return Vec3.ZERO;
+    }
+
+    default boolean anvilcraft$isMagnetized() {
+        return false;
+    }
+
+    default boolean anvilcraft$canCollisionCraft() {
+        return true;
+    }
+
+    default boolean anvilcraft$acceptMagnetization(Player player, ItemStack stack) {
+        return false;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/entity/IEntityCauldron.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/entity/IEntityCauldron.java
@@ -1,0 +1,12 @@
+package dev.dubhe.anvilcraft.api.entity;
+
+import dev.dubhe.anvilcraft.api.fluid.IFluidHandlerHolder;
+
+public interface IEntityCauldron extends IFluidHandlerHolder {
+    default boolean anvilcraft$isIgnited() {
+        return false;
+    }
+
+    default void anvilcraft$setIgnited(boolean ignited) {
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/block/BurningHeaterBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/BurningHeaterBlock.java
@@ -1,15 +1,15 @@
 package dev.dubhe.anvilcraft.block;
 
 import com.mojang.serialization.MapCodec;
+import dev.dubhe.anvilcraft.api.block.IDamagingHeater;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.block.entity.BurningHeaterBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
-import dev.dubhe.anvilcraft.init.entity.ModDamageTypes;
+import dev.dubhe.anvilcraft.util.HeaterUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -26,7 +26,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.neoforged.neoforge.items.ItemStackHandler;
 import org.jetbrains.annotations.Nullable;
 
-public class BurningHeaterBlock extends BaseEntityBlock implements IHammerRemovable {
+public class BurningHeaterBlock extends BaseEntityBlock implements IHammerRemovable, IDamagingHeater {
     /**
      * 燃烧等级：0=熄灭，1=阴燃(0-300s)，2=点燃(≥300s)
      */
@@ -118,11 +118,12 @@ public class BurningHeaterBlock extends BaseEntityBlock implements IHammerRemova
 
     @Override
     public void stepOn(Level level, BlockPos pos, BlockState state, Entity entity) {
-        if (state.getValue(LEVEL) > 0
-            && !entity.isSteppingCarefully()
-            && entity instanceof LivingEntity) {
-            entity.hurt(ModDamageTypes.heaterBurn(level), 4.0F);
-        }
+        HeaterUtil.hurtEntity(level, state, entity);
         super.stepOn(level, pos, state, entity);
+    }
+
+    @Override
+    public boolean isActive(BlockState state) {
+        return state.getValue(LEVEL) > 0;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/HeaterBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/HeaterBlock.java
@@ -1,15 +1,14 @@
 package dev.dubhe.anvilcraft.block;
 
 import com.mojang.serialization.MapCodec;
+import dev.dubhe.anvilcraft.api.block.IDamagingHeater;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.power.IPowerComponent;
 import dev.dubhe.anvilcraft.block.entity.HeaterBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
-import dev.dubhe.anvilcraft.init.entity.ModDamageTypes;
+import dev.dubhe.anvilcraft.util.HeaterUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -29,7 +28,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
-public class HeaterBlock extends BaseEntityBlock implements IHammerRemovable {
+public class HeaterBlock extends BaseEntityBlock implements IHammerRemovable, IDamagingHeater {
     public static final VoxelShape SHAPE = Shapes.or(Block.box(0, 2, 0, 16, 16, 16), Block.box(1, 0, 1, 15, 2, 15));
     public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
     public static final BooleanProperty OVERLOAD = IPowerComponent.OVERLOAD;
@@ -95,14 +94,13 @@ public class HeaterBlock extends BaseEntityBlock implements IHammerRemovable {
 
     @Override
     public void stepOn(Level level, BlockPos pos, BlockState state, Entity entity) {
-        if (state.is(ModBlocks.HEATER.get())
-            && !state.getValue(POWERED)
-            && !state.getValue(OVERLOAD)
-            && !entity.isSteppingCarefully()
-            && entity instanceof LivingEntity) {
-            entity.hurt(ModDamageTypes.heaterBurn(level), 4.0F);
-        }
+        HeaterUtil.hurtEntity(level, state, entity);
         super.stepOn(level, pos, state, entity);
+    }
+
+    @Override
+    public boolean isActive(BlockState state) {
+        return !state.getValue(POWERED) && !state.getValue(OVERLOAD);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/LargeCauldronBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/LargeCauldronBlock.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.block;
 
+import dev.dubhe.anvilcraft.api.block.ICauldronGeometry;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
 import dev.dubhe.anvilcraft.block.item.SimpleMultiPartBlockItem;
@@ -44,13 +45,14 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 import static dev.dubhe.anvilcraft.block.PropelPiston.createTickerHelper;
 
 public class LargeCauldronBlock
     extends SimpleMultiPartBlock<Cube3x3PartHalf>
-    implements MultiPartBlockEntity<Cube3x3PartHalf, LargeCauldronBlock>, IHammerRemovable {
+    implements MultiPartBlockEntity<Cube3x3PartHalf, LargeCauldronBlock>, IHammerRemovable, ICauldronGeometry {
     public static final EnumProperty<Cube3x3PartHalf> HALF = EnumProperty.create("half", Cube3x3PartHalf.class);
     private static final double WALL_THICKNESS = 0.25;
     private static final double BOTTOM_WALL_MIN_Y = 0.5;
@@ -98,6 +100,27 @@ public class LargeCauldronBlock
     }
 
     @Override
+    public AABB getCauldronInnerArea(BlockPos pos, BlockState state) {
+        BlockPos mainPos = this.getMainPartPos(pos, state);
+        return new AABB(
+            mainPos.getX() - 0.75,
+            mainPos.getY() - 0.5,
+            mainPos.getZ() - 0.75,
+            mainPos.getX() + 1.75,
+            mainPos.getY() + 1.75,
+            mainPos.getZ() + 1.75
+        );
+    }
+
+    @Override
+    public List<BlockPos> getCauldronBottomPositions(BlockPos pos, BlockState state) {
+        BlockPos center = this.getMainPartPos(pos, state).below(2);
+        return BlockPos.betweenClosedStream(center.offset(-1, 0, -1), center.offset(1, 0, 1))
+            .map(BlockPos::immutable)
+            .toList();
+    }
+
+    @Override
     public @Nullable BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return this.createBlockEntity(pos, state);
     }
@@ -120,7 +143,11 @@ public class LargeCauldronBlock
 
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        return SHAPES.get(state.getValue(HALF));
+        Cube3x3PartHalf part = state.getValue(HALF);
+        if (part.getOffsetY() == 2 && context.isHoldingItem(ModBlocks.GIANT_ANVIL.asItem())) {
+            return Shapes.block();
+        }
+        return SHAPES.get(part);
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/MagnetBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/MagnetBlock.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.block;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.entity.IAnvilCraftEntityExtension;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.entity.AnimateAscendingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
@@ -109,6 +110,7 @@ public class MagnetBlock extends Block implements IHammerRemovable {
             List<FallingBlockEntity> entities =
                 level.getEntitiesOfClass(FallingBlockEntity.class, new AABB(currentPos));
             for (FallingBlockEntity entity : entities) {
+                if (entity instanceof IAnvilCraftEntityExtension) continue;
                 BlockState state2 = entity.getBlockState();
                 if (state2.is(BlockTags.ANVIL) && !state2.is(ModBlockTags.NON_MAGNETIC)) {
                     level.destroyBlock(magnetPos.below(), true);

--- a/src/main/java/dev/dubhe/anvilcraft/block/RedstoneWireBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/RedstoneWireBlock.java
@@ -54,6 +54,7 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
     private static final Map<Direction, VoxelShape> DOT_SHAPES = new EnumMap<>(Direction.class);
     private static final Map<Direction, List<VoxelShape>> SIDE_SHAPES = new EnumMap<>(Direction.class);
     private static final Map<Direction, List<VoxelShape>> CORNER_SHAPES = new EnumMap<>(Direction.class);
+    private static final Map<Direction, List<VoxelShape>> CORNER_SP_SHAPES = new EnumMap<>(Direction.class);
     private static final Map<Direction, List<VoxelShape>> UP_SHAPES = new EnumMap<>(Direction.class);
 
     static {
@@ -63,15 +64,18 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
             DOT_SHAPES.put(attachment, transformedBox(attachment, north, 4.0, 0.0, 4.0, 12.0, 2.5, 12.0));
             List<VoxelShape> sides = new ArrayList<>(4);
             List<VoxelShape> corners = new ArrayList<>(4);
+            List<VoxelShape> specialCorners = new ArrayList<>(4);
             List<VoxelShape> ups = new ArrayList<>(4);
             for (int index = 0; index < 4; index++) {
                 Direction tangent = getLocalDirection(attachment, index);
                 sides.add(transformedBox(attachment, tangent, 5.0, 0.0, 0.0, 11.0, 2.0, 8.0));
                 corners.add(transformedBox(attachment, tangent, 5.0, 0.0, -2.0, 11.0, 2.0, 8.0));
+                specialCorners.add(transformedBox(attachment, tangent, 5.0, 0.0, -1.0, 11.0, 2.0, 8.0));
                 ups.add(transformedBox(attachment, tangent, 5.0, 1.0, -0.1, 11.0, 18.0, 2.0));
             }
             SIDE_SHAPES.put(attachment, List.copyOf(sides));
             CORNER_SHAPES.put(attachment, List.copyOf(corners));
+            CORNER_SP_SHAPES.put(attachment, List.copyOf(specialCorners));
             UP_SHAPES.put(attachment, List.copyOf(ups));
         }
     }
@@ -124,11 +128,14 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
         VoxelShape shape = state.getValue(DOT) ? DOT_SHAPES.get(attachment) : Shapes.empty();
         for (int index = 0; index < 4; index++) {
             ConnectionType side = state.getValue(CONNECTION_PROPERTIES.get(index));
-            if (side.isConnected() && side != ConnectionType.CORNER) {
+            if (side.isConnected() && side != ConnectionType.CORNER && side != ConnectionType.CORNER_SP) {
                 shape = Shapes.or(shape, SIDE_SHAPES.get(attachment).get(index));
             }
             if (side == ConnectionType.CORNER) {
                 shape = Shapes.or(shape, CORNER_SHAPES.get(attachment).get(index));
+            }
+            if (side == ConnectionType.CORNER_SP) {
+                shape = Shapes.or(shape, CORNER_SP_SHAPES.get(attachment).get(index));
             }
             if (side == ConnectionType.UP) {
                 shape = Shapes.or(shape, UP_SHAPES.get(attachment).get(index));
@@ -180,17 +187,21 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
     public boolean canConnectRedstone(
         BlockState state, BlockGetter level, BlockPos pos, @Nullable Direction direction
     ) {
-        if (direction == null || !direction.getAxis().isHorizontal()) {
+        Direction terminalDirection;
+        if (direction == null) {
+            // 原版红石粉检查斜向下方的方块时不带方向；此时只暴露侧面导线的向上开放断口。
+            terminalDirection = Direction.UP;
+        } else if (!direction.getAxis().isHorizontal()) {
             return false;
+        } else {
+            terminalDirection = direction.getOpposite();
         }
-        Direction terminalDirection = direction.getOpposite();
         int index = getLocalIndex(state.getValue(ATTACHMENT), terminalDirection);
         if (index < 0 || !state.getValue(CONNECTION_PROPERTIES.get(index)).isConnected()) {
             return false;
         }
-        Connection[] cached = RedstoneWireNetworkManager.getConnections(level, pos);
         // 内部接线端只负责连通网络；仅开放端点应被外部元件视为红石接口。
-        return (cached == null ? findConnection(level, pos, state, index) : cached[index]) == null;
+        return this.isOpenTerminal(level, pos, state, index);
     }
 
     @Override
@@ -231,6 +242,38 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
         return (cached == null ? findConnection(level, pos, state, index) : cached[index]) != null;
     }
 
+    private boolean isOpenTerminal(BlockGetter level, BlockPos pos, BlockState state, int index) {
+        Connection[] cached = RedstoneWireNetworkManager.getConnections(level, pos);
+        return (cached == null ? findConnection(level, pos, state, index) : cached[index]) == null;
+    }
+
+    /** 供原版红石粉采样斜下方导线的非粉线信号，避免该特殊连接只改变外观。 */
+    public static int getUpwardDustSignal(BlockGetter level, BlockPos dustPos) {
+        int power = 0;
+        for (Direction towardWire : Direction.Plane.HORIZONTAL) {
+            BlockPos wirePos = dustPos.relative(towardWire).below();
+            BlockState wireState = level.getBlockState(wirePos);
+            if (!(wireState.getBlock() instanceof RedstoneWireBlock wire)) {
+                continue;
+            }
+            Direction attachment = towardWire.getOpposite();
+            if (wireState.getValue(ATTACHMENT) != attachment) {
+                continue;
+            }
+            int index = getLocalIndex(attachment, Direction.UP);
+            if (index < 0
+                || !wireState.getValue(CONNECTION_PROPERTIES.get(index)).isConnected()
+                || !hasUpwardDustConnection(level, wirePos, wireState, index)
+                || !wire.isOpenTerminal(level, wirePos, wireState, index)) {
+                continue;
+            }
+            power = Math.max(power, RedstoneWireNetworkManager.getNonDustPower(
+                level, wirePos, wireState.getValue(POWER)
+            ));
+        }
+        return power;
+    }
+
     /** 根据当前世界重新计算指定导线的四向外观状态。 */
     BlockState connectionState(BlockGetter level, BlockPos pos, BlockState oldState) {
         return this.connectionState(level, pos, oldState, findConnections(level, pos, oldState));
@@ -249,8 +292,11 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
         int second = -1;
         for (int index = 0; index < 4; index++) {
             Connection connection = connections[index];
-            ConnectionType side = getConnection(level, pos, result, index, connection);
-            result = result.setValue(CONNECTION_PROPERTIES.get(index), side);
+            EnumProperty<ConnectionType> property = CONNECTION_PROPERTIES.get(index);
+            ConnectionType side = getConnection(
+                level, pos, result, index, connection, oldState.getValue(property).isConnected()
+            );
+            result = result.setValue(property, side);
             if (side.isConnected()) {
                 if (first < 0) {
                     first = index;
@@ -284,11 +330,20 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
     }
 
     private static ConnectionType getConnection(
-        BlockGetter level, BlockPos pos, BlockState state, int index, @Nullable Connection connection
+        BlockGetter level,
+        BlockPos pos,
+        BlockState state,
+        int index,
+        @Nullable Connection connection,
+        boolean wasConnected
     ) {
         if (connection != null) {
             // 导线到导线的几何关系决定 SIDE、CORNER 或 UP，应优先于普通红石接口外观。
             return connection.side();
+        }
+        if (wasConnected && hasUpwardDustConnection(level, pos, state, index)) {
+            // 原版粉线通过 canConnectRedstone(null) 吸引到这个断口，使用专用短拐角避免模型插入粉线。
+            return ConnectionType.CORNER_SP;
         }
         Direction tangent = getLocalDirection(state.getValue(ATTACHMENT), index);
         BlockPos adjacentPos = pos.relative(tangent);
@@ -306,6 +361,24 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
             || state.is(Blocks.TARGET)
             || state.is(Blocks.REDSTONE_TORCH)
             || state.is(Blocks.REDSTONE_WALL_TORCH);
+    }
+
+    /** 侧面导线向上断开时，检查支撑方块顶面的原版红石粉斜角连接。 */
+    private static boolean hasUpwardDustConnection(BlockGetter level, BlockPos pos, BlockState state, int index) {
+        Direction attachment = state.getValue(ATTACHMENT);
+        if (!attachment.getAxis().isHorizontal() || getLocalDirection(attachment, index) != Direction.UP) {
+            return false;
+        }
+        return level.getBlockState(pos.relative(attachment).above()).is(Blocks.REDSTONE_WIRE);
+    }
+
+    /** 返回开放端点实际对应的外部方块位置；斜角红石粉位于支撑方块的顶面。 */
+    static BlockPos terminalTarget(BlockGetter level, BlockPos pos, BlockState state, Direction tangent) {
+        int index = getLocalIndex(state.getValue(ATTACHMENT), tangent);
+        if (index >= 0 && hasUpwardDustConnection(level, pos, state, index)) {
+            return pos.relative(state.getValue(ATTACHMENT)).above();
+        }
+        return pos.relative(tangent);
     }
 
     /**
@@ -672,7 +745,9 @@ public class RedstoneWireBlock extends Block implements IHammerRemovable {
         /** 沿前方完整方块的侧面向上爬升。 */
         UP("up", true),
         /** 绕同一支撑方块的边缘连接到另一个附着面。 */
-        CORNER("corner", true);
+        CORNER("corner", true),
+        /** 向上的开放断口连接支撑方块顶面的原版红石粉。 */
+        CORNER_SP("corner_sp", true);
 
         private final String name;
         @Getter

--- a/src/main/java/dev/dubhe/anvilcraft/block/RedstoneWireNetworkManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/RedstoneWireNetworkManager.java
@@ -460,7 +460,10 @@ public final class RedstoneWireNetworkManager {
                 for (int index = 0; index < network.terminalWires.size(); index++) {
                     BlockPos wirePos = BlockPos.of(network.terminalWires.getLong(index));
                     Direction tangent = Direction.values()[network.terminalDirections.getByte(index)];
-                    BlockPos inputPos = wirePos.relative(tangent);
+                    BlockState wireState = this.level.getBlockState(wirePos);
+                    BlockPos inputPos = wireState.getBlock() instanceof RedstoneWireBlock
+                        ? RedstoneWireBlock.terminalTarget(this.level, wirePos, wireState, tangent)
+                        : wirePos.relative(tangent);
                     BlockState inputState = this.level.getBlockState(inputPos);
                     int inputPower = this.level.getSignal(inputPos, tangent);
                     totalPower = Math.max(totalPower, inputPower);
@@ -512,7 +515,11 @@ public final class RedstoneWireNetworkManager {
                 long source = network.terminalWires.getLong(index);
                 BlockPos sourcePos = BlockPos.of(source);
                 Direction tangent = Direction.values()[network.terminalDirections.getByte(index)];
-                long target = sourcePos.relative(tangent).asLong();
+                BlockState sourceState = this.level.getBlockState(sourcePos);
+                BlockPos targetPos = sourceState.getBlock() instanceof RedstoneWireBlock
+                    ? RedstoneWireBlock.terminalTarget(this.level, sourcePos, sourceState, tangent)
+                    : sourcePos.relative(tangent);
+                long target = targetPos.asLong();
                 byte mask = (byte) (excludedFaces.get(target) | 1 << tangent.getOpposite().ordinal());
                 excludedFaces.put(target, mask);
                 // 多个端点指向同一方块时只需任选一个真实导线作为邻居变化来源。

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BaseLaserBlockEntity.java
@@ -404,14 +404,15 @@ public abstract class BaseLaserBlockEntity extends BlockEntity {
     public void setRemoved() {
         super.setRemoved();
         if (this.level == null) return;
+        if (this.level.isClientSide()) {
+            CacheableBERenderingPipeline.getInstance().blockRemoved(this);
+            return;
+        }
         if (this.irradiateBlockPos == null) return;
         if (!this.level.isLoaded(this.irradiateBlockPos)) return;
         BlockEntity targetBe = this.level.getBlockEntity(this.irradiateBlockPos);
         if (targetBe instanceof BaseLaserBlockEntity irradiateBlockEntity) {
             irradiateBlockEntity.onCancelingIrradiation(this);
-        }
-        if (this.level.isClientSide()) {
-            CacheableBERenderingPipeline.getInstance().update(this);
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/BurningHeaterBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/BurningHeaterBlockEntity.java
@@ -181,39 +181,16 @@ public class BurningHeaterBlockEntity extends BlockEntity implements IItemHandle
     /**
      * 消耗燃烧时间（用于铁砧合成）
      *
-     * <p>直接从燃料槽扣除物品来抵消耗，避免 tryConsumeFuel 下个 tick 立刻补满导致消耗不可见。
-     * 同时强制向客户端同步，让 tooltip/Jade 显示最新值。</p>
+     * <p>从当前缓存中精确扣除燃烧时间，并立即更新燃烧状态和客户端显示。</p>
      *
      * @param ticks 消耗的tick数
      */
     public void consumeBurnTime(int ticks) {
-        int remaining = ticks;
-
-        // 1. 优先从燃料槽中直接扣除物品
-        while (remaining > 0) {
-            ItemStack fuel = this.itemHandler.getStackInSlot(0);
-            int burnTimePerItem = getItemBurnTime(fuel);
-            if (burnTimePerItem <= 0) break;
-
-            int itemsToConsume = (remaining + burnTimePerItem - 1) / burnTimePerItem;
-            itemsToConsume = Math.min(itemsToConsume, fuel.getCount());
-            if (itemsToConsume <= 0) break;
-
-            remaining -= itemsToConsume * burnTimePerItem;
-            this.itemHandler.extractItem(0, itemsToConsume, false);
-            if (fuel.hasCraftingRemainingItem() && this.itemHandler.getStackInSlot(0).isEmpty()) {
-                this.itemHandler.setStackInSlot(0, fuel.getCraftingRemainingItem());
-            }
-        }
-
-        // 2. 物品不够的部分从 burnTime 缓冲区扣除
-        if (remaining > 0) {
-            this.burnTime = Math.max(0, this.burnTime - remaining);
-        }
-
+        if (ticks <= 0) return;
+        this.burnTime = Math.max(0, this.burnTime - ticks);
         setChanged();
-        // 强制向客户端同步，确保 tooltip/Jade 显示最新值
         if (level != null && !level.isClientSide()) {
+            updateBurningState(level, worldPosition, getBlockState());
             level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), 3);
             level.updateNeighbourForOutputSignal(worldPosition, getBlockState().getBlock());
         }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/LargeCauldronBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/LargeCauldronBlockEntity.java
@@ -27,7 +27,6 @@ import dev.dubhe.anvilcraft.block.NeutronIrradiatorBlock;
 import dev.dubhe.anvilcraft.block.state.Cube3x3PartHalf;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModFluidTags;
-import dev.dubhe.anvilcraft.init.entity.ModDamageTypes;
 import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTriggers;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
@@ -36,7 +35,7 @@ import dev.dubhe.anvilcraft.recipe.anvil.outcome.DamageAnvil;
 import dev.dubhe.anvilcraft.recipe.anvil.predicate.block.HasAnvil;
 import dev.dubhe.anvilcraft.recipe.anvil.predicate.block.HasCauldron;
 import dev.dubhe.anvilcraft.recipe.anvil.wrap.ItemCompressRecipe;
-import dev.dubhe.anvilcraft.recipe.anvil.wrap.SuperHeatingRecipe;
+import dev.dubhe.anvilcraft.util.CauldronUtil;
 import dev.dubhe.anvilcraft.util.FireReforgingUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -186,7 +185,7 @@ public class LargeCauldronBlockEntity extends BlockEntity
         entity.absorbFluidSources(level);
         entity.refreshIgnited();
         entity.applyFluidEffects((ServerLevel) level);
-        entity.hurtEntitiesInside((ServerLevel) level);
+        entity.hurtEntitiesInsideFromCampfire((ServerLevel) level);
         entity.reforgeItemsInLava(level);
     }
 
@@ -481,7 +480,6 @@ public class LargeCauldronBlockEntity extends BlockEntity
         for (int slot = 0; slot < main.output.getSlots(); slot++) {
             if (!main.output.getStackInSlot(slot).isEmpty()) initialOutputSlots.add(slot);
         }
-        Set<BlockPos> fuelCharged = new HashSet<>();
         int processed = 0;
         boolean madeProgress;
         do {
@@ -492,21 +490,17 @@ public class LargeCauldronBlockEntity extends BlockEntity
                 List<BlockPos> candidates = helpers.isEmpty()
                     ? List.of(slotPos.below())
                     : orderedHelpers(slotPos, helpers, base);
-                RecipeAttempt attempt = main.tryProcessItemGroup(
+                RecipeExecution execution = main.tryProcessItemGroup(
                     serverLevel,
                     base,
                     candidates,
                     event.getEntity(),
                     slot,
                     false,
-                    fuelCharged,
                     allowItemCompression
                 );
-                if (!attempt.execution().executed()) continue;
-                if (level.getBlockState(attempt.helper()).is(ModBlocks.BURNING_HEATER)) {
-                    fuelCharged.add(attempt.helper());
-                }
-                if (attempt.execution().damageAnvil()) event.setAnvilDamage(true);
+                if (!execution.executed()) continue;
+                if (execution.damageAnvil()) event.setAnvilDamage(true);
                 processed++;
                 madeProgress = true;
             }
@@ -518,21 +512,17 @@ public class LargeCauldronBlockEntity extends BlockEntity
         for (int slot : initialOutputSlots) {
             if (processed >= MAX_PROCESS_EFFICIENCY) break;
             if (main.output.getStackInSlot(slot).isEmpty()) continue;
-            RecipeAttempt attempt = main.tryProcessItemGroup(
+            RecipeExecution execution = main.tryProcessItemGroup(
                 serverLevel,
                 base,
                 centerCandidates,
                 event.getEntity(),
                 slot,
                 true,
-                fuelCharged,
                 allowItemCompression
             );
-            if (!attempt.execution().executed()) continue;
-            if (level.getBlockState(attempt.helper()).is(ModBlocks.BURNING_HEATER)) {
-                fuelCharged.add(attempt.helper());
-            }
-            if (attempt.execution().damageAnvil()) event.setAnvilDamage(true);
+            if (!execution.executed()) continue;
+            if (execution.damageAnvil()) event.setAnvilDamage(true);
             processed++;
         }
 
@@ -542,19 +532,15 @@ public class LargeCauldronBlockEntity extends BlockEntity
                     processed++;
                     continue;
                 }
-                RecipeAttempt attempt = main.tryProcessFluidRecipe(
+                RecipeExecution execution = main.tryProcessFluidRecipe(
                     serverLevel,
                     base,
                     centerCandidates,
                     event.getEntity(),
-                    fuelCharged,
                     allowItemCompression
                 );
-                if (!attempt.execution().executed()) break;
-                if (level.getBlockState(attempt.helper()).is(ModBlocks.BURNING_HEATER)) {
-                    fuelCharged.add(attempt.helper());
-                }
-                if (attempt.execution().damageAnvil()) event.setAnvilDamage(true);
+                if (!execution.executed()) break;
+                if (execution.damageAnvil()) event.setAnvilDamage(true);
                 processed++;
             }
         }
@@ -603,14 +589,13 @@ public class LargeCauldronBlockEntity extends BlockEntity
         return false;
     }
 
-    private RecipeAttempt tryProcessItemGroup(
+    private RecipeExecution tryProcessItemGroup(
         ServerLevel level,
         BlockPos base,
         List<BlockPos> candidates,
         Entity anvil,
         int slot,
         boolean outputSource,
-        Set<BlockPos> fuelCharged,
         boolean allowItemCompression
     ) {
         for (BlockPos helper : candidates) {
@@ -633,7 +618,6 @@ public class LargeCauldronBlockEntity extends BlockEntity
                     anvil,
                     slot,
                     outputSource,
-                    fuelCharged.contains(helper),
                     allowItemCompression
                 );
             } finally {
@@ -641,29 +625,25 @@ public class LargeCauldronBlockEntity extends BlockEntity
                 this.processingOutput = false;
                 this.processingOutputInputs.clear();
             }
-            if (execution.executed()) return new RecipeAttempt(execution, helper);
+            if (execution.executed()) return execution;
         }
-        return RecipeAttempt.EMPTY;
+        return RecipeExecution.EMPTY;
     }
 
-    private RecipeAttempt tryProcessFluidRecipe(
+    private RecipeExecution tryProcessFluidRecipe(
         ServerLevel level,
         BlockPos base,
         List<BlockPos> candidates,
         Entity anvil,
-        Set<BlockPos> fuelCharged,
         boolean allowItemCompression
     ) {
         for (BlockPos helper : candidates) {
             Vec3 contextPos = new Vec3(helper.getX() + 0.5, base.getY() + 1.0, helper.getZ() + 0.5);
             InWorldRecipeContext context = new InWorldRecipeContext(level, contextPos, anvil);
-            if (fuelCharged.contains(helper)) {
-                context.put(SuperHeatingRecipe.ConsumeFuel.FUEL_CONSUMED, true);
-            }
             RecipeExecution execution = triggerOneRecipe(level, context, ItemStack.EMPTY, allowItemCompression);
-            if (execution.executed()) return new RecipeAttempt(execution, helper);
+            if (execution.executed()) return execution;
         }
-        return RecipeAttempt.EMPTY;
+        return RecipeExecution.EMPTY;
     }
 
     private RecipeExecution triggerRecipeGroup(
@@ -672,7 +652,6 @@ public class LargeCauldronBlockEntity extends BlockEntity
         Entity anvil,
         int slot,
         boolean outputSource,
-        boolean fuelConsumed,
         boolean allowItemCompression
     ) {
         IItemHandler source = outputSource ? this.output : this.input;
@@ -686,9 +665,6 @@ public class LargeCauldronBlockEntity extends BlockEntity
             ItemStack processingInput = source.getStackInSlot(slot);
             if (processingInput.isEmpty()) break;
             InWorldRecipeContext context = new InWorldRecipeContext(level, contextPos, anvil);
-            if (fuelConsumed || executed) {
-                context.put(SuperHeatingRecipe.ConsumeFuel.FUEL_CONSUMED, true);
-            }
             RecipeExecution current = triggerOneRecipe(
                 level,
                 context,
@@ -1219,39 +1195,26 @@ public class LargeCauldronBlockEntity extends BlockEntity
     }
 
     private AABB contentArea() {
-        return new AABB(
-            this.worldPosition.getX() - 0.75,
-            this.worldPosition.getY() - 0.5,
-            this.worldPosition.getZ() - 0.75,
-            this.worldPosition.getX() + 1.75,
-            this.worldPosition.getY() + 1.75,
-            this.worldPosition.getZ() + 1.75
-        );
+        return CauldronUtil.getInnerArea(this.worldPosition, this.getBlockState());
     }
 
-    private void hurtEntitiesInside(ServerLevel level) {
+    private void hurtEntitiesInsideFromCampfire(ServerLevel level) {
         BlockPos base = this.worldPosition.below();
         boolean normalCampfire = false;
         boolean soulCampfire = false;
-        boolean heater = false;
         for (int slot = 0; slot < FOOTPRINT_OFFSETS.length; slot++) {
             BlockState state = level.getBlockState(positionForFootprint(base, slot).below());
             if (CampfireBlock.isLitCampfire(state)) {
                 soulCampfire |= state.is(Blocks.SOUL_CAMPFIRE);
                 normalCampfire |= state.is(Blocks.CAMPFIRE);
             }
-            heater |= state.is(ModBlocks.HEATER) && !state.getValue(HeaterBlock.OVERLOAD);
         }
-        if (!normalCampfire && !soulCampfire && !heater) return;
+        if (!normalCampfire && !soulCampfire) return;
 
         AABB inside = this.contentArea();
         for (LivingEntity living : level.getEntitiesOfClass(LivingEntity.class, inside)) {
             if (living.fireImmune() || living.isSteppingCarefully()) continue;
-            if (heater) {
-                living.hurt(ModDamageTypes.heaterBurn(level), 4.0F);
-            } else {
-                living.hurt(level.damageSources().inFire(), soulCampfire ? 2.0F : 1.0F);
-            }
+            living.hurt(level.damageSources().inFire(), soulCampfire ? 2.0F : 1.0F);
         }
     }
 
@@ -1393,10 +1356,7 @@ public class LargeCauldronBlockEntity extends BlockEntity
     }
 
     private record RecipeExecution(boolean executed, boolean damageAnvil) {
-    }
-
-    private record RecipeAttempt(RecipeExecution execution, @Nullable BlockPos helper) {
-        private static final RecipeAttempt EMPTY = new RecipeAttempt(new RecipeExecution(false, false), null);
+        private static final RecipeExecution EMPTY = new RecipeExecution(false, false);
     }
 
     public record RecipePreview(

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/LensBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/LensBlockEntity.java
@@ -71,6 +71,7 @@ public class LensBlockEntity extends BaseLaserBlockEntity {
 
     @Override
     public void onCancelingIrradiation(BaseLaserBlockEntity source) {
+        if (!this.irradiateSelfLaserBlockSet.contains(source)) return;
         super.onCancelingIrradiation(source);
         this.enabled = !this.irradiateSelfLaserBlockSet.isEmpty();
     }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/RubyPrismBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/RubyPrismBlockEntity.java
@@ -40,6 +40,7 @@ public class RubyPrismBlockEntity extends BaseLaserBlockEntity {
 
     @Override
     public void onCancelingIrradiation(BaseLaserBlockEntity baseLaserBlockEntity) {
+        if (!irradiateSelfLaserBlockSet.contains(baseLaserBlockEntity)) return;
         super.onCancelingIrradiation(baseLaserBlockEntity);
         enabled = !irradiateSelfLaserBlockSet.isEmpty();
     }

--- a/src/main/java/dev/dubhe/anvilcraft/data/generator/RedstoneWireBlockStateGenerator.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/generator/RedstoneWireBlockStateGenerator.java
@@ -50,6 +50,13 @@ public class RedstoneWireBlockStateGenerator {
                         .condition(RedstoneWireBlock.ATTACHMENT, attachment)
                         .condition(property, ConnectionType.CORNER)
                         .end();
+                    if (RedstoneWireBlock.getLocalDirection(attachment, index) == Direction.UP) {
+                        ModelFile sideCornerSp = sideCornerSpModel(provider, attachment, index);
+                        multipart.part().modelFile(sideCornerSp).addModel()
+                            .condition(RedstoneWireBlock.ATTACHMENT, attachment)
+                            .condition(property, ConnectionType.CORNER_SP)
+                            .end();
+                    }
                 }
                 multipart.part().modelFile(up).addModel()
                     .condition(RedstoneWireBlock.ATTACHMENT, attachment)
@@ -137,6 +144,32 @@ public class RedstoneWireBlockStateGenerator {
             face(Direction.EAST, "#1", 6, 0, 7, 10, 90, true, null),
             face(Direction.WEST, "#1", 6, 0, 7, 10, 90, true, null),
             face(Direction.UP, "#1", 6, 0, 10, 10, 0, true, null)
+        ));
+        return model;
+    }
+
+    /** 生成墙面向上断口连接支撑方块顶面红石粉时使用的专用短拐角。 */
+    private static BlockModelBuilder sideCornerSpModel(
+        RegistrumBlockstateProvider provider, Direction attachment, int index
+    ) {
+        Direction tangent = RedstoneWireBlock.getLocalDirection(attachment, index);
+        BlockModelBuilder model = model(provider, attachment, "side_corner_sp_" + index)
+            .texture("0", AnvilCraft.of("block/redstone_wire_line"))
+            .texture("1", AnvilCraft.of("block/redstone_wire_line_overlay"))
+            .texture("particle", AnvilCraft.of("block/redstone_wire_line"));
+        addBoxWithRotatedUvs(model, attachment, tangent, 5.0, 0.0, 0.0, 11.0, 1.0, 8.0, List.of(
+            face(Direction.NORTH, "#0", 5, 0, 11, 1, 0, false, Direction.NORTH),
+            face(Direction.EAST, "#0", 10, 0, 11, 8, 90, false, null),
+            face(Direction.WEST, "#0", 5, 8, 6, 0, 90, false, null),
+            face(Direction.UP, "#0", 5, 0, 11, 8),
+            face(Direction.DOWN, "#0", 11, 0, 5, 8, 0, false, Direction.DOWN)
+        ));
+        addBoxWithRotatedUvs(model, attachment, tangent, 6.0, 0.01, -1.0, 10.0, 2.0, 8.0, List.of(
+            face(Direction.NORTH, "#1", 6, 0, 10, 1, 0, true, Direction.NORTH),
+            face(Direction.EAST, "#1", 6, 0, 7, 9, 90, true, null),
+            face(Direction.WEST, "#1", 6, 0, 7, 9, 90, true, null),
+            face(Direction.UP, "#1", 6, 0, 10, 9, 0, true, null),
+            face(Direction.DOWN, "#1", 6, 0, 10, 9, 0, true, null)
         ));
         return model;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/event/FallingBlockCollisionEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/FallingBlockCollisionEventListener.java
@@ -42,6 +42,7 @@ public class FallingBlockCollisionEventListener {
 
     @SubscribeEvent
     public static void anvilCollisionCraft(AnvilEvent.CollisionBlock event) {
+        if (event.isCanceled()) return;
         Vec3 entityPos = event.getEntity().position();
         Level level = event.getLevel();
         BlockPos pos = event.getPos();

--- a/src/main/java/dev/dubhe/anvilcraft/event/LivingEntityEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/LivingEntityEventListener.java
@@ -7,6 +7,7 @@ import dev.dubhe.anvilcraft.entity.ai.goal.GenericZombieAttackGoal;
 import dev.dubhe.anvilcraft.init.item.ModAmulets;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.recipe.transform.MobTransformWithItemRecipe;
+import dev.dubhe.anvilcraft.util.CauldronUtil;
 import net.minecraft.tags.EntityTypeTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageTypes;
@@ -64,6 +65,7 @@ public class LivingEntityEventListener {
 
     @SubscribeEvent
     public static void onTick(EntityTickEvent.Post event) {
+        CauldronUtil.hurtFromHeaterBelow(event.getEntity());
         Mob entity = Util.castSafely(event.getEntity(), Mob.class).orElse(null);
         if (entity == null) return;
         if (!(entity.getTarget() instanceof Player player)) return;

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
@@ -13,6 +13,7 @@ import dev.dubhe.anvilcraft.block.GiantAnvilBlock;
 import dev.dubhe.anvilcraft.block.NeoforgeBlock;
 import dev.dubhe.anvilcraft.block.TranscendenceAnvilBlock;
 import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
+import dev.dubhe.anvilcraft.block.multipart.AbstractMultiPartBlock;
 import dev.dubhe.anvilcraft.entity.FallingGiantAnvilEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTriggers;
@@ -74,22 +75,25 @@ public class AnvilEventListener {
         if (event.getEntity() instanceof FallingGiantAnvilEntity
             && hitBlockState.is(ModBlocks.LARGE_CAULDRON)) {
             LargeCauldronBlockEntity cauldron = LargeCauldronBlockEntity.getMain(level, hitBlockPos, hitBlockState);
-            if (cauldron != null && cauldron.handleGiantAnvilImpact(event)) return;
+            if (cauldron != null && cauldron.handleGiantAnvilImpact(event)) {
+                handleBehaviors(level, hitBlockPos, hitBlockState, event);
+                return;
+            }
         }
-        BlockPos belowPos = hitBlockPos.below();
-        BlockState hitBelowState = level.getBlockState(belowPos);
-        if (hitBelowState.is(Blocks.STONECUTTER)) {
-            brokeBlock(level, hitBlockPos, event);
+        BlockPos breakBlockPos = hitBlockPos;
+        if (hitBlockState.getBlock() instanceof AbstractMultiPartBlock<?> multiPartBlock) {
+            BlockPos mainPartPos = multiPartBlock.getMainPartPos(hitBlockPos, hitBlockState);
+            if (level.getBlockState(mainPartPos).is(multiPartBlock)) breakBlockPos = mainPartPos;
+        }
+        BlockState breakBlockState = level.getBlockState(breakBlockPos);
+        if (hasStonecutterBelow(level, breakBlockPos, breakBlockState)) {
+            brokeBlock(level, breakBlockPos, event);
             return;
         }
         if (!ProceduralProcessStepManager.checkAnyMatches(event)) {
             handleNeoAnvilRecipe(event);
         }
-        for (IAnvilBehavior behavior : IAnvilBehavior.findMatching(hitBlockState)) {
-            if (behavior.handle(level, hitBlockPos, hitBlockState, event.getFallDistance(), event)) {
-                return;
-            }
-        }
+        if (handleBehaviors(level, hitBlockPos, hitBlockState, event)) return;
         if (blockState.is(ModBlocks.NEOFORGE)) {
             if (event.getFallDistance() > 1) {
                 if (level.random.nextDouble() < 0.01) {
@@ -97,6 +101,18 @@ public class AnvilEventListener {
                 }
             }
         }
+    }
+
+    private static boolean handleBehaviors(
+        Level level,
+        BlockPos hitBlockPos,
+        BlockState hitBlockState,
+        AnvilEvent.OnLand event
+    ) {
+        for (IAnvilBehavior behavior : IAnvilBehavior.findMatching(hitBlockState)) {
+            if (behavior.handle(level, hitBlockPos, hitBlockState, event.getFallDistance(), event)) return true;
+        }
+        return false;
     }
 
     public static void handleNeoAnvilRecipe(AnvilEvent.OnLand event) {
@@ -115,6 +131,29 @@ public class AnvilEventListener {
         } finally {
             GiantAnvilBlock.SUPPRESS_DROPS.set(false);
         }
+    }
+
+    private static boolean hasStonecutterBelow(Level level, BlockPos pos, BlockState state) {
+        if (state.getBlock() instanceof AbstractMultiPartBlock<?> multiPartBlock) {
+            return hasStonecutterBelowAnyPart(level, pos, state, multiPartBlock);
+        }
+        return level.getBlockState(pos.below()).is(Blocks.STONECUTTER);
+    }
+
+    private static <P extends Enum<P>> boolean hasStonecutterBelowAnyPart(
+        Level level,
+        BlockPos mainPartPos,
+        BlockState mainPartState,
+        AbstractMultiPartBlock<P> multiPartBlock
+    ) {
+        for (P part : multiPartBlock.getParts()) {
+            BlockPos partPos = mainPartPos.offset(multiPartBlock.offsetFrom(mainPartState, part));
+            if (level.getBlockState(partPos).is(multiPartBlock)
+                && level.getBlockState(partPos.below()).is(Blocks.STONECUTTER)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void brokeBlock(Level level, BlockPos pos, AnvilEvent.OnLand event) {

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModAnvilBehaviors.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModAnvilBehaviors.java
@@ -24,7 +24,7 @@ import dev.dubhe.anvilcraft.block.GunpowderBlock;
 import dev.dubhe.anvilcraft.block.SugarBlock;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
-import net.minecraft.world.level.block.AbstractCauldronBlock;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -51,7 +51,7 @@ public class ModAnvilBehaviors {
         event.registerBehavior(state -> state.getBlock() instanceof GunpowderBlock, new GunpowderBlockBehavior());
         event.registerBehavior(state -> state.is(ModBlocks.IMPACT_PILE), new ImpactPileBehavior());
         event.registerBehavior(state -> state.getBlock() instanceof SugarBlock, new SugarBlockBehavior());
-        event.registerBehavior(state -> state.getBlock() instanceof AbstractCauldronBlock, new TimeWarpPlayerBehavior());
+        event.registerBehavior(state -> state.is(BlockTags.CAULDRONS), new TimeWarpPlayerBehavior());
         event.registerBehavior(Blocks.BEACON, new BeaconConversionBehavior());
         event.registerBehavior(ModBlocks.OVERHEATED_EMBER_METAL_BLOCK.get(), new TranscendiumBehavior());
         event.registerBehavior(

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/EntityMixin.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.mixin;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.anvilcraft.lib.v2.util.Util;
+import dev.dubhe.anvilcraft.api.entity.IAnvilCraftEntityExtension;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.event.EntityThroughPortalEvent;
 import dev.dubhe.anvilcraft.api.injection.entity.IEntityExtension;
@@ -244,6 +245,10 @@ public abstract class EntityMixin implements IEntityExtension {
         Optional<FallingBlockEntity> entityOp = Util.castSafely(this, FallingBlockEntity.class);
         if (entityOp.isEmpty() || !this.horizontalCollision) return;
         FallingBlockEntity self = entityOp.get();
+        if (self instanceof IAnvilCraftEntityExtension extension
+            && !extension.anvilcraft$canCollisionCraft()) {
+            return;
+        }
         BlockPos blockPos = BlockPos.containing(this.position.add(anvil$beforeBoundingMovement
             .scale(0.55 / anvil$beforeBoundingMovement.length())
             .multiply(1, 0, 1)));

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/ExplosionMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/ExplosionMixin.java
@@ -13,6 +13,7 @@ import dev.dubhe.anvilcraft.api.injection.IExplosionExtension;
 import dev.dubhe.anvilcraft.recipe.anvil.collision.BlockTransform;
 import it.unimi.dsi.fastutil.objects.ObjectListIterator;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
@@ -34,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Mixin(Explosion.class)
 abstract class ExplosionMixin implements IExplosionExtension {
@@ -93,6 +95,8 @@ abstract class ExplosionMixin implements IExplosionExtension {
         @Share("isExplosionBlockTransformed") LocalBooleanRef isExplosionBlockTransformed,
         @Local(ordinal = 0) BlockPos pos
     ) {
+        // The shared local is reused for every ray iteration in explode().
+        isExplosionBlockTransformed.set(false);
         Block block = level.getBlockState(pos).getBlock();
         ArrayList<BlockTransform> blockTransforms = new ArrayList<>(this.anvilcraft$blockTransformMap.get(block));
         if (blockTransforms.isEmpty()) return;
@@ -138,8 +142,14 @@ abstract class ExplosionMixin implements IExplosionExtension {
     @Override
     public void anvilcraft$setBlockTransformExplosion(Collection<BlockTransform> blockTransformExplosions) {
         for (BlockTransform blockTransform : blockTransformExplosions) {
-            for (BlockState state : blockTransform.inputBlock().getStatesCache()) {
-                Block block = state.getBlock();
+            Set<Block> inputBlocks = new HashSet<>();
+            blockTransform.inputBlock().getBlocks().unwrap().ifLeft(tag ->
+                BuiltInRegistries.BLOCK.getTagOrEmpty(tag).forEach(holder -> inputBlocks.add(holder.value()))
+            );
+            blockTransform.inputBlock().getBlocks().unwrap().ifRight(holders ->
+                holders.forEach(holder -> inputBlocks.add(holder.value()))
+            );
+            for (Block block : inputBlocks) {
                 this.anvilcraft$blockTransformMap.put(block, blockTransform);
             }
         }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/RedstoneWireBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/RedstoneWireBlockMixin.java
@@ -1,14 +1,20 @@
 package dev.dubhe.anvilcraft.mixin;
 
 import dev.dubhe.anvilcraft.api.injection.tooltip.ITooltipProviderExtension;
+import dev.dubhe.anvilcraft.block.RedstoneWireBlock;
 import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.RedStoneWireBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,5 +31,12 @@ public abstract class RedstoneWireBlockMixin implements ITooltipProviderExtensio
         lines.add(Component.translatable("tooltip.anvilcraft.redstone.title").withStyle(ChatFormatting.BLUE));
         lines.add(Component.translatable("tooltip.anvilcraft.redstone.power", state.getValue(POWER)).withStyle(ChatFormatting.GRAY));
         return lines;
+    }
+
+    @Inject(method = "calculateTargetStrength", at = @At("RETURN"), cancellable = true)
+    private void anvilcraft$includeUpwardWireSignal(
+        Level level, BlockPos pos, CallbackInfoReturnable<Integer> callback
+    ) {
+        callback.setReturnValue(Math.max(callback.getReturnValue(), RedstoneWireBlock.getUpwardDustSignal(level, pos)));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
@@ -9,6 +9,7 @@ import dev.anvilcraft.lib.v2.recipe.predicate.IRecipePredicate;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeContext;
 import dev.anvilcraft.lib.v2.util.MathUtil;
 import dev.dubhe.anvilcraft.api.block.IIgnitableCauldron;
+import dev.dubhe.anvilcraft.api.entity.IEntityCauldron;
 import dev.dubhe.anvilcraft.api.fluid.IFluidHandlerHolder;
 import dev.dubhe.anvilcraft.api.fluid.LargeCauldronFluidHandler;
 import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
@@ -26,11 +27,13 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
@@ -120,7 +123,8 @@ public record HasCauldron(
         // 不是锅 否决
         BlockPos pos = BlockPos.containing(context.getPos().add(this.offset()));
         BlockCache cache = context.computeIfAbsent(BlockCache.BLOCK_CACHE);
-        if (!cache.getBlockState(pos).is(BlockTags.CAULDRONS)) return false;
+        IEntityCauldron entityCauldron = findEntityCauldron(context, pos);
+        if (!cache.getBlockState(pos).is(BlockTags.CAULDRONS) && entityCauldron == null) return false;
 
         if (cache.getBlockEntity(pos) instanceof LargeCauldronBlockEntity cauldron) {
             if (this.consume() > LargeCauldronFluidHandler.TANK_CAPACITY
@@ -129,26 +133,28 @@ public record HasCauldron(
         }
 
         // 消耗/产生比锅容量大 否决
-        double capacity = HasCauldron.getCapacity(cache, pos);
+        double capacity = HasCauldron.getCapacity(cache, pos, entityCauldron);
         if (this.consume() > capacity || this.produce() > capacity) return false;
 
         // 锅中流体检查不通过 否决
-        ResourceLocation curFluid = HasCauldron.getCurFluid(cache, pos);
+        ResourceLocation curFluid = HasCauldron.getCurFluid(cache, pos, entityCauldron);
         if (this.hasCheck() && !this.matchesFluid(curFluid)) return false;
 
         // 如果锅必须为可点燃锅
         if (this.ignited) {
-            // 锅不为可点燃锅 否决
-            if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
-            // 锅未点燃 否决
-            if (!cauldron.isIgnited(cache, pos)) return false;
+            if (entityCauldron != null) {
+                if (!entityCauldron.anvilcraft$isIgnited()) return false;
+            } else {
+                if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
+                if (!cauldron.isIgnited(cache, pos)) return false;
+            }
         }
 
         // 不消耗且不产生 通过
         if (this.consume() == 0 && this.produce() == 0) return true;
 
         // 消耗量大于存量 否决
-        double cur = HasCauldron.getCur(cache, pos);
+        double cur = HasCauldron.getCur(cache, pos, entityCauldron);
         if (this.consume() > cur) return false;
 
         // 最终总量超出容量 否决
@@ -176,7 +182,8 @@ public record HasCauldron(
         if (context.getLevel().getRandom().nextFloat() > this.chance()) return;
         if (this.fluid().equals(EMPTY) && !HasCauldron.isNotEmpty(this.transform())) return;
 
-        double cur = HasCauldron.getCur(cache, pos);
+        IEntityCauldron entityCauldron = findEntityCauldron(context, pos);
+        double cur = HasCauldron.getCur(cache, pos, entityCauldron);
         double afterConsume = cur - this.consume();
         double amount = afterConsume + this.produce();
 
@@ -184,9 +191,9 @@ public record HasCauldron(
         if (!HasCauldron.isNotEmpty(newFluid)) newFluid = this.fluid();
         if (!HasCauldron.isNotEmpty(newFluid)) return;
         if (amount > 0 && HasCauldron.isNotEmpty(newFluid)) {
-            HasCauldron.applyFluid(cache, pos, newFluid, amount, this.ignited);
+            HasCauldron.applyFluid(cache, pos, newFluid, amount, this.ignited, entityCauldron);
         } else {
-            HasCauldron.applyEmpty(cache, pos);
+            HasCauldron.applyEmpty(cache, pos, entityCauldron);
         }
 
         context.putAcceptor(BlockCache.BLOCK_CACHE.location(), BlockCache.DEFAULT_ACCEPTOR);
@@ -250,9 +257,12 @@ public record HasCauldron(
     }
 
     public static double getCapacity(BlockCache cache, BlockPos pos) {
-        return cache.getBlockEntity(pos) instanceof IFluidHandlerHolder holder
-               ? holder.getFluidHandler().getTankCapacity(0)
-               : 1000;
+        return getCapacity(cache, pos, null);
+    }
+
+    private static double getCapacity(BlockCache cache, BlockPos pos, @Nullable IEntityCauldron entityCauldron) {
+        IFluidHandler handler = getFluidHandler(cache, pos, entityCauldron);
+        return handler == null ? 1000 : handler.getTankCapacity(0);
     }
 
     /**
@@ -262,11 +272,22 @@ public record HasCauldron(
      */
     @SuppressWarnings("deprecation")
     public static ResourceLocation getCurFluid(BlockCache cache, BlockPos pos) {
-        return cache.getBlockEntity(pos) instanceof IFluidHandlerHolder holder
-               ? holder.getFluidHandler().getFluidInTank(0).getFluidHolder().getKey().location()
-               : cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron
-                 ? cauldron.getFluid(cache, pos).builtInRegistryHolder().key().location()
-                 : WrapUtils.cauldron2Fluid(cache.getBlockState(pos).getBlock());
+        return getCurFluid(cache, pos, null);
+    }
+
+    private static ResourceLocation getCurFluid(
+        BlockCache cache,
+        BlockPos pos,
+        @Nullable IEntityCauldron entityCauldron
+    ) {
+        IFluidHandler handler = getFluidHandler(cache, pos, entityCauldron);
+        if (handler != null) {
+            FluidStack stack = handler.getFluidInTank(0);
+            return stack.isEmpty() ? EMPTY : stack.getFluidHolder().getKey().location();
+        }
+        return cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron
+               ? cauldron.getFluid(cache, pos).builtInRegistryHolder().key().location()
+               : WrapUtils.cauldron2Fluid(cache.getBlockState(pos).getBlock());
     }
 
     /**
@@ -275,7 +296,12 @@ public record HasCauldron(
      * @return 炼药锅方块
      */
     public static double getCur(BlockCache cache, BlockPos pos) {
-        if (cache.getBlockEntity(pos) instanceof IFluidHandlerHolder holder) return holder.getFluidHandler().getFluidInTank(0).getAmount();
+        return getCur(cache, pos, null);
+    }
+
+    private static double getCur(BlockCache cache, BlockPos pos, @Nullable IEntityCauldron entityCauldron) {
+        IFluidHandler handler = getFluidHandler(cache, pos, entityCauldron);
+        if (handler != null) return handler.getFluidInTank(0).getAmount();
         BlockState state = cache.getBlockState(pos);
         if (state.is(Blocks.CAULDRON)) return 0.0;
         IntegerProperty property = CauldronUtil.LEVEL_4;
@@ -289,8 +315,12 @@ public record HasCauldron(
     }
 
     public static void applyEmpty(BlockCache cache, BlockPos pos) {
-        if (cache.getBlockEntity(pos) instanceof IFluidHandlerHolder holder) {
-            IFluidHandler handler = holder.getFluidHandler();
+        applyEmpty(cache, pos, null);
+    }
+
+    private static void applyEmpty(BlockCache cache, BlockPos pos, @Nullable IEntityCauldron entityCauldron) {
+        IFluidHandler handler = getFluidHandler(cache, pos, entityCauldron);
+        if (handler != null) {
             handler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.EXECUTE);
         } else {
             cache.setBlock(pos, Blocks.CAULDRON);
@@ -298,11 +328,23 @@ public record HasCauldron(
     }
 
     public static void applyFluid(BlockCache cache, BlockPos pos, ResourceLocation fluid, double mb, boolean ignited) {
+        applyFluid(cache, pos, fluid, mb, ignited, null);
+    }
+
+    private static void applyFluid(
+        BlockCache cache,
+        BlockPos pos,
+        ResourceLocation fluid,
+        double mb,
+        boolean ignited,
+        @Nullable IEntityCauldron entityCauldron
+    ) {
         if (cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron) {
             if (cauldron.isIgnited(cache, pos)) ignited = true;
         }
-        if (cache.getBlockEntity(pos) instanceof IFluidHandlerHolder holder) {
-            IFluidHandler handler = holder.getFluidHandler();
+        if (entityCauldron != null && entityCauldron.anvilcraft$isIgnited()) ignited = true;
+        IFluidHandler handler = getFluidHandler(cache, pos, entityCauldron);
+        if (handler != null) {
             FluidStack fluidInTank = handler.getFluidInTank(0);
             Fluid target = BuiltInRegistries.FLUID.get(fluid);
             if (fluidInTank.is(target)) {
@@ -334,6 +376,35 @@ public record HasCauldron(
         if (cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron) {
             if (cauldron.isIgnited(cache, pos) != ignited) cauldron.setIgnited(cache, pos, ignited);
         }
+        if (entityCauldron != null && entityCauldron.anvilcraft$isIgnited() != ignited) {
+            entityCauldron.anvilcraft$setIgnited(ignited);
+        }
+    }
+
+    private static @Nullable IFluidHandler getFluidHandler(
+        BlockCache cache,
+        BlockPos pos,
+        @Nullable IEntityCauldron entityCauldron
+    ) {
+        if (entityCauldron != null) return entityCauldron.getFluidHandler();
+        return cache.getBlockEntity(pos) instanceof IFluidHandlerHolder holder ? holder.getFluidHandler() : null;
+    }
+
+    private static @Nullable IEntityCauldron findEntityCauldron(InWorldRecipeContext context, BlockPos pos) {
+        Vec3 center = pos.getCenter();
+        IEntityCauldron closest = null;
+        double closestDistance = Double.POSITIVE_INFINITY;
+        for (Entity entity : context.getLevel().getEntitiesOfClass(
+            Entity.class,
+            new AABB(pos).inflate(0.0625),
+            entity -> entity.isAlive() && entity instanceof IEntityCauldron
+        )) {
+            double distance = entity.getBoundingBox().getCenter().distanceToSqr(center);
+            if (distance >= closestDistance) continue;
+            closest = (IEntityCauldron) entity;
+            closestDistance = distance;
+        }
+        return closest;
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/SuperHeatingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/SuperHeatingRecipe.java
@@ -291,7 +291,7 @@ public class SuperHeatingRecipe extends AbstractProcessRecipe<SuperHeatingRecipe
         public static final int FUEL_COST_TICKS = 240 * 20;
 
         /**
-         * 标记一次铁砧落地事件中是否已消耗过燃料，防止多个物品匹配时重复消耗
+         * 标记当前配方上下文是否已消耗过燃料，避免同一结果被重复接受
          */
         public static final InWorldRecipeData<Boolean> FUEL_CONSUMED =
             InWorldRecipeData.of(AnvilCraft.of("super_heating_fuel_consumed"), false);

--- a/src/main/java/dev/dubhe/anvilcraft/util/AccelerateManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/AccelerateManager.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.util;
 
+import dev.dubhe.anvilcraft.api.entity.IAnvilCraftEntityExtension;
 import dev.dubhe.anvilcraft.api.power.IPowerComponent;
 import dev.dubhe.anvilcraft.block.AccelerationRingBlock;
 import dev.dubhe.anvilcraft.block.entity.AccelerationRingBlockEntity;
@@ -67,8 +68,12 @@ public class AccelerateManager {
 
     public static boolean canBeAccelerated(Entity entity) {
         return entity instanceof FallingBlockEntity fallingBlockEntity
-               && fallingBlockEntity.getBlockState().is(BlockTags.ANVIL)
-               && !fallingBlockEntity.getBlockState().is(ModBlockTags.NON_MAGNETIC)
+               && (fallingBlockEntity.getBlockState().is(BlockTags.ANVIL)
+                   || entity instanceof IAnvilCraftEntityExtension extension
+                   && extension.anvilcraft$isMagnetized())
+               && (!(entity instanceof IAnvilCraftEntityExtension extension)
+                   ? !fallingBlockEntity.getBlockState().is(ModBlockTags.NON_MAGNETIC)
+                   : extension.anvilcraft$isMagnetized())
                || entity instanceof Projectile
                || (entity instanceof Player player && isPlayerCanBeAccelerated(player));
     }
@@ -170,7 +175,10 @@ public class AccelerateManager {
     }
 
     private static boolean isAnvil(Entity entity) {
-        if (entity instanceof FallingBlockEntity falling) return falling.getBlockState().is(BlockTags.ANVIL);
+        if (entity instanceof FallingBlockEntity falling) {
+            return falling.getBlockState().is(BlockTags.ANVIL)
+                || entity instanceof IAnvilCraftEntityExtension extension && extension.anvilcraft$isMagnetized();
+        }
         return entity instanceof RailgunAnvilEntity railgun && railgun.getBlockState().is(BlockTags.ANVIL);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/util/CauldronUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/CauldronUtil.java
@@ -1,7 +1,11 @@
 package dev.dubhe.anvilcraft.util;
 
+import dev.dubhe.anvilcraft.api.block.ICauldronGeometry;
 import dev.dubhe.anvilcraft.block.Layered4LevelCauldronBlock;
 import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.AbstractCauldronBlock;
 import net.minecraft.world.level.block.Block;
@@ -9,10 +13,12 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LayeredCauldronBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -234,5 +240,33 @@ public class CauldronUtil {
     public static boolean compatibleForFill(BlockState state, Block cauldronContent, int fillLevel) {
         if (fillLevel <= 0) return true;
         return remainSpaceFor(state, cauldronContent) >= fillLevel;
+    }
+
+    public static AABB getInnerArea(BlockPos pos, BlockState state) {
+        if (state.getBlock() instanceof ICauldronGeometry geometry) {
+            return geometry.getCauldronInnerArea(pos, state);
+        }
+        return new AABB(pos);
+    }
+
+    public static List<BlockPos> getBottomPositions(BlockPos pos, BlockState state) {
+        if (state.getBlock() instanceof ICauldronGeometry geometry) {
+            return geometry.getCauldronBottomPositions(pos, state);
+        }
+        return List.of(pos.below());
+    }
+
+    public static boolean isEntityInside(BlockPos pos, BlockState state, Entity entity) {
+        return getInnerArea(pos, state).contains(entity.position());
+    }
+
+    public static void hurtFromHeaterBelow(Entity entity) {
+        if (!(entity instanceof LivingEntity) || entity.level().isClientSide()) return;
+        BlockPos pos = entity.blockPosition();
+        BlockState state = entity.level().getBlockState(pos);
+        if (!state.is(BlockTags.CAULDRONS) || !isEntityInside(pos, state, entity)) return;
+        for (BlockPos bottomPos : getBottomPositions(pos, state)) {
+            if (HeaterUtil.hurtEntity(entity.level(), entity.level().getBlockState(bottomPos), entity)) return;
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/GravityManager.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.util;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.entity.IAnvilCraftEntityExtension;
 import dev.dubhe.anvilcraft.block.BlackHoleBlock;
 import dev.dubhe.anvilcraft.block.WhiteHoleBlock;
 import dev.dubhe.anvilcraft.entity.LevitatingBlockEntity;
@@ -107,6 +108,10 @@ public final class GravityManager {
     }
 
     public static GravityType getGravityType(Entity entity) {
+        if (entity instanceof IAnvilCraftEntityExtension extension) {
+            GravityType supplied = extension.anvilcraft$getGravityType();
+            if (supplied != null) return supplied;
+        }
         if (entity instanceof ItemEntity itemEntity) {
             var item = itemEntity.getItem();
             if (item.is(ModItems.NEGATIVE_MATTER_NUGGET.get())
@@ -139,11 +144,16 @@ public final class GravityManager {
     }
 
     public static Vec3 getGravityVector(Entity entity, double baseGravity) {
-        return GravitySourceManager.calculateGravityVector(
+        Vec3 gravity = GravitySourceManager.calculateGravityVector(
             entity.level(),
             entity.getBoundingBox().getCenter(),
             Math.abs(baseGravity)
-        ).scale(getGravityType(entity).getScalar());
+        );
+        if (entity instanceof IAnvilCraftEntityExtension extension) {
+            Vec3 additional = extension.anvilcraft$getAdditionalGravity(Math.abs(baseGravity));
+            if (isFinite(additional)) gravity = gravity.add(additional);
+        }
+        return gravity.scale(getGravityType(entity).getScalar());
     }
 
     /**
@@ -191,11 +201,11 @@ public final class GravityManager {
     }
 
     public static Vec3 getNetGravityVectorForFallingBlock(Entity entity) {
-        return getNetGravityVectorForFallingBlock(
-            entity.level(),
-            entity.getBoundingBox().getCenter(),
-            getGravityType(entity)
-        );
+        GravityType gravityType = getGravityType(entity);
+        double scalar = gravityType.getScalar();
+        double baseGravity = 0.04 * getDimensionGravity(entity.level());
+        Vec3 baseGravityVector = new Vec3(0, -baseGravity * scalar, 0);
+        return baseGravityVector.add(getGravityVector(entity, 0.04));
     }
 
     public static void registerDimensionGravity(ResourceKey<Level> dimension, double gravity) {

--- a/src/main/java/dev/dubhe/anvilcraft/util/HeaterUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/HeaterUtil.java
@@ -1,0 +1,21 @@
+package dev.dubhe.anvilcraft.util;
+
+import dev.dubhe.anvilcraft.api.block.IDamagingHeater;
+import dev.dubhe.anvilcraft.init.entity.ModDamageTypes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class HeaterUtil {
+    public static boolean hurtEntity(Level level, BlockState state, Entity entity) {
+        if (!(state.getBlock() instanceof IDamagingHeater heater)
+            || !heater.isActive(state)
+            || entity.isSteppingCarefully()
+            || !(entity instanceof LivingEntity)) {
+            return false;
+        }
+        entity.hurt(ModDamageTypes.heaterBurn(level), 4.0F);
+        return true;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/util/MagnetUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/MagnetUtil.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.util;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.api.entity.IAnvilCraftEntityExtension;
 import dev.dubhe.anvilcraft.api.event.UseMagnetEvent;
 import dev.dubhe.anvilcraft.block.MagnetBlock;
 import dev.dubhe.anvilcraft.entity.MagnetizedNodeEntity;
@@ -43,6 +44,21 @@ public abstract class MagnetUtil {
         if (player == null) return InteractionResult.PASS;
         if (!player.isShiftKeyDown()) return InteractionResult.PASS;
         BlockPos pos = context.getClickedPos();
+        if (player.isShiftKeyDown()) {
+            AABB entityArea = new AABB(pos).inflate(0.08D);
+            for (Entity entity : level.getEntities(
+                player,
+                entityArea,
+                candidate -> candidate instanceof IAnvilCraftEntityExtension
+                    && candidate.isAlive()
+            )) {
+                IAnvilCraftEntityExtension extension = (IAnvilCraftEntityExtension) entity;
+                if (extension.anvilcraft$acceptMagnetization(player, context.getItemInHand())) {
+                    player.getCooldowns().addCooldown(item, 5);
+                    return InteractionResult.sidedSuccess(level.isClientSide());
+                }
+            }
+        }
         BlockState blockState = level.getBlockState(pos);
         if (blockState.isAir()) return InteractionResult.PASS;
         double maxY = blockState.getCollisionShape(level, pos).max(Direction.Axis.Y, 0.5, 0.5);

--- a/src/main/resources/assets/anvilcraft/models/block/redstone_wire_side_corner_sp.json
+++ b/src/main/resources/assets/anvilcraft/models/block/redstone_wire_side_corner_sp.json
@@ -1,0 +1,36 @@
+{
+	"format_version": "1.9.0",
+	"credit": "Made by XeKr with Blockbench",
+	"ambientocclusion": false,
+	"textures": {
+		"0": "anvilcraft:block/redstone_wire_line",
+		"1": "anvilcraft:block/redstone_wire_line_overlay",
+		"particle": "anvilcraft:block/redstone_wire_line"
+	},
+	"elements": [
+		{
+			"from": [5, 0, 0],
+			"to": [11, 1, 8],
+			"rotation": {"angle": 0, "axis": "y", "origin": [6, 0, 5]},
+			"faces": {
+				"north": {"uv": [5, 0, 11, 1], "texture": "#0", "cullface": "north"},
+				"east": {"uv": [10, 0, 11, 8], "rotation": 90, "texture": "#0"},
+				"west": {"uv": [5, 8, 6, 0], "rotation": 90, "texture": "#0"},
+				"up": {"uv": [5, 0, 11, 8], "texture": "#0"},
+				"down": {"uv": [11, 0, 5, 8], "texture": "#0", "cullface": "down"}
+			}
+		},
+		{
+			"from": [6, 0.01, -1],
+			"to": [10, 2, 8],
+			"rotation": {"angle": 0, "axis": "y", "origin": [6, 1, 5]},
+			"faces": {
+				"north": {"uv": [6, 0, 10, 1], "texture": "#1", "cullface": "north", "tintindex": 0},
+				"east": {"uv": [6, 0, 7, 9], "rotation": 90, "texture": "#1", "tintindex": 0},
+				"west": {"uv": [6, 0, 7, 9], "rotation": 90, "texture": "#1", "tintindex": 0},
+				"up": {"uv": [6, 0, 10, 9], "texture": "#1", "tintindex": 0},
+				"down": {"uv": [6, 0, 10, 9], "texture": "#1", "tintindex": 0}
+			}
+		}
+	]
+}

--- a/src/main/resources/assets/anvilcraft/models/block/redstone_wire_up.json
+++ b/src/main/resources/assets/anvilcraft/models/block/redstone_wire_up.json
@@ -9,7 +9,7 @@
 	},
 	"elements": [
 		{
-			"from": [5, 1, -0.1],
+			"from": [5, 1, 0],
 			"to": [11, 17, 1],
 			"rotation": {"angle": 0, "axis": "x", "origin": [8, 9, 8]},
 			"faces": {


### PR DESCRIPTION
- 让手持巨型铁砧时大锅顶部视为完整碰撞
- 修复各种锅和缸的伤害问题 fixed #4186 
- 让多方块下面有切石机任意part被砸正确触发破坏
- 修复大锅燃烧加热器扣除时间不对问题 fixed #4187 
- 修复环形光路bug fixed #4152 
- 红石导线修改
- 开放引力api