### PR TITLE
perf(rendering): skip lighting for wrapped block models

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/BlockStateModelRenderer.java
@@ -24,6 +24,17 @@ public class BlockStateModelRenderer {
         Minecraft.getInstance().getBlockColors()
     );
 
+    @Getter
+    private final ModelBlockRenderer tessellatorNoLighting = new ModelBlockRenderer(
+        false,
+        true,
+        Minecraft.getInstance().getBlockColors()
+    );
+
+    BlockStateModelRenderer() {
+        this.tessellatorNoLighting.lighter = new FullBrightNoOpLighter();
+    }
+
     @Nullable
     public WrappedBlockStateModel getModel(BlockStateModelTessellateState state) {
         return this.cache.get(state);

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/FullBrightNoOpLighter.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/FullBrightNoOpLighter.java
@@ -1,0 +1,48 @@
+package dev.dubhe.anvilcraft.api.rendering;
+
+import com.mojang.blaze3d.vertex.QuadInstance;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.BlockModelLighter;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class FullBrightNoOpLighter extends BlockModelLighter {
+
+    @Override
+    public void prepareQuadAmbientOcclusion(
+        BlockAndTintGetter level,
+        BlockState state,
+        BlockPos centerPosition,
+        BakedQuad quad,
+        QuadInstance outputInstance
+    ) {
+        outputInstance.setColor(-1);
+    }
+
+    @Override
+    protected void prepareQuadShape(
+        BlockAndTintGetter level,
+        BlockState state,
+        BlockPos pos,
+        BakedQuad quad,
+        boolean ambientOcclusion
+    ) {
+    }
+
+    @Override
+    public void prepareQuadFlat(
+        BlockAndTintGetter level,
+        BlockState state,
+        BlockPos pos,
+        int lightCoords,
+        BakedQuad quad,
+        QuadInstance outputInstance
+    ) {
+    }
+
+    @Override
+    public int getLightCoords(BlockState state, BlockAndTintGetter level, BlockPos relativePos) {
+        return 15728880;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/rendering/WrappedBlockStateModel.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/rendering/WrappedBlockStateModel.java
@@ -42,7 +42,7 @@ public class WrappedBlockStateModel extends Model<BlockStateModelTessellateState
     ) {
         Minecraft mc = Minecraft.getInstance();
         StandaloneModelKey<BlockStateModel> key = this.state.key();
-        ModelBlockRenderer tessellator = this.renderer.getTessellator();
+        ModelBlockRenderer tessellator = this.renderer.getTessellatorNoLighting();
         BlockStateModel model = mc.getModelManager().getStandaloneModel(key);
 
         tessellator.tesselateBlock(

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -166,3 +166,5 @@ public net.minecraft.client.renderer.block.BlockModelRenderState submitModel(Lne
 public-f net.minecraft.world.level.block.entity.BlockEntity worldPosition
 
 public-f net.minecraft.client.model.Model renderToBuffer(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;III)V
+
+public-f net.minecraft.client.renderer.block.ModelBlockRenderer lighter


### PR DESCRIPTION
## Summary

- add a dedicated no-lighting model tessellator backed by a full-bright no-op lighter
- render wrapped block-state models without per-quad lighting work
- expose the model renderer lighter field through the access transformer

## Testing

- `.\gradlew.bat compileJava --console=plain`
- `git diff upstream/dev/26.1/1.6...HEAD --check`