### PR TITLE
Optimization of CFA and Outlet 针对锻星砧特殊天体数据包加载模型的优化，以及输出口特性补齐

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.api.itemhandler;
 
 import com.google.common.collect.ImmutableList;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.item.property.component.OverLimitItemContainerContents;
 import dev.dubhe.anvilcraft.util.AnvilUtil;
@@ -189,16 +190,36 @@ public class ItemHandlerUtil {
             list.add(input);
             return list;
         }
-        AABB aabb = new AABB(inputBlockPos);
+        AABB aabb = new AABB(inputBlockPos).inflate(0.01D);
         list = level.getEntitiesOfClass(
-                Entity.class, aabb, e -> e instanceof ContainerEntity)
+                Entity.class,
+                aabb,
+                entity -> entity.isAlive()
+                    && BlockPos.containing(entity.getBoundingBox().getCenter()).equals(inputBlockPos))
             .stream()
-            .map(e -> e.getCapability(
-                Capabilities.ItemHandler.ENTITY,
-                null
-            ))
+            .map(e -> e instanceof IItemHandlerHolder holder
+                ? holder.getItemHandler()
+                : e.getCapability(Capabilities.ItemHandler.ENTITY, null))
+            .filter(handler -> handler != null)
             .toList();
         return list;
+    }
+
+    public static @Nullable List<IItemHandler> getOutletTargetItemHandlerList(
+        BlockPos inputBlockPos,
+        @Nullable Direction context,
+        @Nullable Level level
+    ) {
+        if (level == null) return null;
+        LargeCauldronBlockEntity cauldron = LargeCauldronBlockEntity.getMain(
+            level,
+            inputBlockPos,
+            level.getBlockState(inputBlockPos)
+        );
+        if (cauldron != null) {
+            return List.of(cauldron.getInputHandler());
+        }
+        return getTargetItemHandlerList(inputBlockPos, context, level);
     }
 
     public static int countItemsInHandler(IItemHandler handler) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -304,7 +304,11 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
             if (!state.getValue(FishTankBlock.OUTLET)) return;
             Direction outletDir = state.getValue(FishTankBlock.FACING);
             BlockPos pos = FishTankBlockEntity.this.getBlockPos();
-            List<IItemHandler> targets = ItemHandlerUtil.getTargetItemHandlerList(pos.relative(outletDir), null, level);
+            List<IItemHandler> targets = ItemHandlerUtil.getOutletTargetItemHandlerList(
+                pos.relative(outletDir),
+                null,
+                level
+            );
 
             this.autoOutputting = true;
             try {
@@ -708,7 +712,11 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
         if (level == null || level.isClientSide()) return;
         BlockPos pos = this.getBlockPos();
         Direction outletDir = this.getBlockState().getValue(FishTankBlock.FACING);
-        List<IItemHandler> targets = ItemHandlerUtil.getTargetItemHandlerList(pos.relative(outletDir), null, level);
+        List<IItemHandler> targets = ItemHandlerUtil.getOutletTargetItemHandlerList(
+            pos.relative(outletDir),
+            null,
+            level
+        );
         if (targets == null || targets.isEmpty()) {
             // 开口被有碰撞的方块堵住时不输出，物品留在输出槽等待下次重试
             if (FishTankBlockEntity.isOutletBlocked(level, pos, outletDir)) return;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/SpecialCelestialBodyData.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/SpecialCelestialBodyData.java
@@ -84,8 +84,12 @@ public record SpecialCelestialBodyData(
         return RingType.NONE;
     }
 
-    /// 获取此特殊天体的独立模型/贴图资源路径
+    /// 获取此特殊天体的独立模型/贴图资源路径。
+    /// 无命名空间的旧格式仍指向 AnvilCraft 的天体模型目录；完整资源 ID 则直接使用。
     public ResourceLocation getModelLocation() {
+        if (model.indexOf(':') >= 0) {
+            return ResourceLocation.parse(model);
+        }
         return AnvilCraft.of("block/celestial_body/" + model);
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/SpecialCelestialBodyRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/SpecialCelestialBodyRecipe.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 ///
 /// {@code model} 字段在两种渲染模式下含义不同：
 /// - needs_custom_model=false → 贴图名，用于 {@code CelestialBodyTextureBakery} 程序化生成贴图
-/// - needs_custom_model=true  → 模型名，加载 {@code block/celestial_body/<model>} BakedModel
+/// - needs_custom_model=true  → 模型资源 ID；旧格式模型名仍加载 AnvilCraft 天体模型目录中的模型
 @SuppressWarnings("checkstyle:LineLength")
 public record SpecialCelestialBodyRecipe(
     String name,

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/RegisterAdditionalEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/RegisterAdditionalEventListener.java
@@ -2,7 +2,9 @@ package dev.dubhe.anvilcraft.client.event;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.CelestialForgingAnvilBlockEntityRenderer;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -89,6 +91,7 @@ public class RegisterAdditionalEventListener {
         event.register(standaloneBlock("celestial_body/neutron_star"));
         event.register(standaloneBlock("celestial_body/neutron_star_jet"));
         event.register(standaloneBlock("celestial_body/black_hole"));
+        registerCelestialBodyModels(event);
 
         // WIP models
         event.register(standaloneBlock("ancient_sea_reef_wip"));
@@ -114,5 +117,27 @@ public class RegisterAdditionalEventListener {
 
     private static ModelResourceLocation standaloneItem(String path) {
         return ModelResourceLocation.standalone(AnvilCraft.of("item/" + path));
+    }
+
+    /**
+     * 自动注册资源包中提供的天体模型。
+     */
+    private static void registerCelestialBodyModels(ModelEvent.RegisterAdditional event) {
+        Minecraft.getInstance()
+            .getResourceManager()
+            .listResources("models/block/celestial_body", location -> location.getPath().endsWith(".json"))
+            .keySet()
+            .stream()
+            .map(RegisterAdditionalEventListener::toStandaloneModel)
+            .forEach(event::register);
+    }
+
+    private static ModelResourceLocation toStandaloneModel(ResourceLocation resourceLocation) {
+        String resourcePath = resourceLocation.getPath();
+        String modelPath = resourcePath.substring("models/".length(), resourcePath.length() - ".json".length());
+        ResourceLocation modelLocation = ResourceLocation.fromNamespaceAndPath(
+            resourceLocation.getNamespace(), modelPath
+        );
+        return ModelResourceLocation.standalone(modelLocation);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CelestialForgingAnvilScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CelestialForgingAnvilScreen.java
@@ -954,19 +954,8 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
         guiGraphics.pose().mulPose(Axis.YP.rotation(rotY));
         guiGraphics.pose().translate(-0.5, -0.5, -0.5);
 
-        var modelRenderer = minecraft.getBlockRenderer().getModelRenderer();
         var buf = guiGraphics.bufferSource();
-        modelRenderer.renderModel(
-            guiGraphics.pose().last(),
-            buf.getBuffer(RenderType.cutout()),
-            null,
-            model,
-            1.0f,
-            1.0f,
-            1.0f,
-            LightTexture.FULL_BRIGHT,
-            0
-        );
+        CelestialBodyRenderer.renderCustomModel(guiGraphics.pose().last(), buf, model, 0);
 
         /// 为拥有大气的复杂模型天体渲染大气层
         if (special.hasAtmosphere() && special.temperature() != null) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CelestialForgingAnvilBlockEntityRenderer.java
@@ -970,11 +970,7 @@ public class CelestialForgingAnvilBlockEntityRenderer implements BlockEntityRend
             .getModel(ModelResourceLocation.standalone(special.getModelLocation()));
         if (model == Minecraft.getInstance().getModelManager().getMissingModel()) return;
 
-        VertexConsumer consumer = bufferSource.getBuffer(RenderType.cutout());
-        Minecraft.getInstance()
-            .getBlockRenderer()
-            .getModelRenderer()
-            .renderModel(poseStack.last(), consumer, null, model, 1.0f, 1.0f, 1.0f, LightTexture.FULL_BRIGHT, packedOverlay);
+        CelestialBodyRenderer.renderCustomModel(poseStack.last(), bufferSource, model, packedOverlay);
     }
 
     /// 使用玩家皮肤纹理渲染玩家头颅天体。

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/celestial/CelestialBodyRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/celestial/CelestialBodyRenderer.java
@@ -6,7 +6,9 @@ import dev.dubhe.anvilcraft.block.entity.celestial.StarData;
 import dev.dubhe.anvilcraft.block.entity.celestial.Temperature;
 import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
@@ -54,6 +56,35 @@ public class CelestialBodyRenderer {
     }
 
     /// === 公共渲染方法 ===
+
+    /// 按模型 JSON 声明的 render_type 渲染独立天体模型。
+    public static void renderCustomModel(
+        PoseStack.Pose pose,
+        MultiBufferSource bufferSource,
+        BakedModel model,
+        int packedOverlay
+    ) {
+        ModelData modelData = ModelData.EMPTY;
+        for (RenderType renderType : model.getRenderTypes(
+            Blocks.IRON_BARS.defaultBlockState(),
+            RandomSource.create(42L),
+            modelData
+        )) {
+            Minecraft.getInstance().getBlockRenderer().getModelRenderer().renderModel(
+                pose,
+                bufferSource.getBuffer(renderType),
+                null,
+                model,
+                1.0f,
+                1.0f,
+                1.0f,
+                LightTexture.FULL_BRIGHT,
+                packedOverlay,
+                modelData,
+                renderType
+            );
+        }
+    }
 
     public static void renderPlanetBody(PoseStack ps, VertexConsumer vc, int light, int overlay) {
         renderPlanetCube(ps, vc, light, overlay, LIGHT_DIR);

--- a/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/CauldronOutletEntity.java
@@ -193,7 +193,7 @@ public class CauldronOutletEntity extends Entity {
         // 输出口前方的方块，如果是容器则优先输入进容器，输入不进的部分再作为掉落物输出
         IItemHandler target = null;
         if (!this.level().isClientSide) {
-            List<IItemHandler> targets = ItemHandlerUtil.getTargetItemHandlerList(
+            List<IItemHandler> targets = ItemHandlerUtil.getOutletTargetItemHandlerList(
                 cauldronPos.relative(attachedDirection),
                 attachedDirection.getOpposite(),
                 this.level()

--- a/src/main/java/dev/dubhe/anvilcraft/event/CauldronOutletEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/CauldronOutletEventListener.java
@@ -55,6 +55,7 @@ public class CauldronOutletEventListener {
         }
 
         removeExistingOutlets(level, cauldronPos);
+        removeOpposingOutlet(level, cauldronPos, direction);
         level.addFreshEntity(new CauldronOutletEntity(level, position, cauldronPos, direction));
         playOutletSound(level, cauldronPos);
     }
@@ -79,7 +80,7 @@ public class CauldronOutletEventListener {
         return level.getEntitiesOfClass(
             CauldronOutletEntity.class,
             searchBox,
-            entity -> entity.getCauldronPos().equals(cauldronPos)
+            entity -> !entity.isRemoved() && entity.getCauldronPos().equals(cauldronPos)
         );
     }
 
@@ -97,6 +98,13 @@ public class CauldronOutletEventListener {
     private static void removeExistingOutlets(Level level, BlockPos cauldronPos) {
         for (CauldronOutletEntity outlet : getOutlets(level, cauldronPos)) {
             outlet.kill();
+        }
+    }
+
+    private static void removeOpposingOutlet(Level level, BlockPos cauldronPos, Direction direction) {
+        BlockPos targetPos = cauldronPos.relative(direction);
+        for (CauldronOutletEntity outlet : getOutlets(level, targetPos)) {
+            if (outlet.getAttachedDirection() == direction.getOpposite()) outlet.kill();
         }
     }
 


### PR DESCRIPTION
- 让数据包能定义并支持加载资源包中自定义锻星砧特殊天体的模型
- 让炼药锅输出口不再能原地重合（原本是两个锅贴着能两个输出口一正一反贴在一起，视觉上看起来完全是依托答辩）
- 修复了输出口不能输出到大锅容器的问题（原本炼药锅输出口往大锅输出会原地输出卡飞掉落物，鱼缸输出口则是完全不输出，两者都没把大锅当容器）