### PR TITLE
Add a capacitor-based active charging mechanism, and update the tooltip accordingly. 添加电容器主动充能机制，补充tooltip

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -1674,6 +1674,7 @@
   "tooltip.anvilcraft.item.energy_weapon_platform": "ᵷuᴉʞɐW uodɐǝM ʎᵷɹǝuƎ ɟo ʇꞁnsǝɹ ǝɥʇ ʇᴉɹǝɥuᴉ ʎꞁuo ꞁꞁᴉʍ ʇnq 'pǝɹoʇs ƎℲW 0߈9",
   "tooltip.anvilcraft.item.energy_weapon_platform.shift": "ɹǝʍod ǝɹoʇsǝɹ oʇ sɹoʇᴉɔɐdɐɔ sǝɯnsuoƆ\nsuodɐǝʍ ʎᵷɹǝuǝ snoᴉɹɐʌ ǝʇɐǝɹɔ oʇ sꞁɐᴉɹǝʇɐɯ ʇuǝɹǝɟɟᴉp ɥʇᴉʍ pǝʇɟɐɹɔ ǝq uɐƆ\nᵷuᴉʞɐW uodɐǝM ʎᵷɹǝuƎ ɟo ʇꞁnsǝɹ ǝɥʇ ʇᴉɹǝɥuᴉ ʎꞁuo ꞁꞁᴉʍ ʇnq 'pǝɹoʇs ƎℲW 0߈9",
   "tooltip.anvilcraft.item.excited_state_void_matter": "ɹǝʇʇɐɯ pᴉoʌ ʎɹɐuᴉpɹo uɐɥʇ ǝꞁqɐʇsun ǝɹoɯ 'sǝᴉʇᴉɹɐꞁnᵷuᴉs ǝꞁoɥ ʞɔɐꞁq ɟo ǝɔuɐʇsqns ǝɥ⟘",
+  "tooltip.anvilcraft.item.excited_state_void_matter_block": "ǝꞁoH ʞɔɐꞁᗺ ɐ ɯoɹɟ sǝɯoɔ ˙˙˙pᴉoʌ ᵷuᴉʇᴉɔxǝ ˙˙˙pᴉoʌ ɟo ʞunɥɔ Ɐ",
   "tooltip.anvilcraft.item.exp_collector": "pᴉnꞁℲ ԀXƎ oʇuᴉ ɯǝɥʇ ʇɹǝʌuoɔ puɐ sqɹo ԀXƎ ʎqɹɐǝu ʇɔǝꞁꞁoƆ",
   "tooltip.anvilcraft.item.exp_gem": "ǝpᴉsuᴉ pǝuᴉɐʇuoɔ ԀXƎ ǝɥʇ ʇɔɐɹʇxǝ oʇ ʞɔᴉꞁɔ-ʇɥᵷᴉᴚ",
   "tooltip.anvilcraft.item.exposed_copper_pressure_plate": "ǝʇɐꞁd ɹǝddoɔ ɐ osꞁɐ 'ǝɯᴉʇ ᵷuᴉssǝɹd ɥʇᴉʍ sǝsɐǝɹɔuᴉ ꞁɐuᵷᴉs ǝuoʇspǝᴚ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -1674,6 +1674,7 @@
   "tooltip.anvilcraft.item.energy_weapon_platform": "640 MFE stored, but will only inherit the result of Energy Weapon Making",
   "tooltip.anvilcraft.item.energy_weapon_platform.shift": "640 MFE stored, but will only inherit the result of Energy Weapon Making\nCan be crafted with different materials to create various energy weapons\nConsumes capacitors to restore power",
   "tooltip.anvilcraft.item.excited_state_void_matter": "The substance of black hole singularities, more unstable than ordinary void matter",
+  "tooltip.anvilcraft.item.excited_state_void_matter_block": "A chunk of void... exciting void... comes from a Black Hole",
   "tooltip.anvilcraft.item.exp_collector": "Collect nearby EXP orbs and convert them into EXP Fluid",
   "tooltip.anvilcraft.item.exp_gem": "Right-click to extract the EXP contained inside",
   "tooltip.anvilcraft.item.exposed_copper_pressure_plate": "Redstone signal increases with pressing time, also a copper plate",

--- a/src/generated/resources/data/anvilcraft/recipe/procedural_process/netherite_block.json
+++ b/src/generated/resources/data/anvilcraft/recipe/procedural_process/netherite_block.json
@@ -75,7 +75,10 @@
             "blocks": "anvilcraft:wip_block"
           },
           {
-            "blocks": "anvilcraft:heater",
+            "blocks": [
+              "anvilcraft:heater",
+              "anvilcraft:burning_heater"
+            ],
             "properties": [
               {
                 "overload": "false"

--- a/src/main/java/dev/dubhe/anvilcraft/api/tooltip/ItemTooltipManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/tooltip/ItemTooltipManager.java
@@ -474,6 +474,7 @@ public class ItemTooltipManager {
         NORMAL.put(ModBlocks.PLYWOOD_SLAB.asItem(), "Solid wood? Not a chance");
         NORMAL.put(ModBlocks.ANCIENT_SEA_REEF.asItem(), "A chunk of sea reef – looks like it's hiding some treasure");
         NORMAL.put(ModBlocks.VOID_MATTER_BLOCK.asItem(), "A chunk of void...");
+        NORMAL.put(ModBlocks.EXCITED_STATE_VOID_MATTER_BLOCK.asItem(), "A chunk of void... exciting void... comes from a Black Hole");
         NORMAL.put(ModBlocks.CREATIVE_GENERATOR.asItem(), "Provide up to 8192 kW of power, can also be used as a load");
         NORMAL.put(ModFoodItems.COCOA_BUTTER.asItem(), "One hundred percent natural pure cocoa butter!");
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/AnvilCraftClient.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/AnvilCraftClient.java
@@ -18,6 +18,7 @@ import dev.dubhe.anvilcraft.init.ModParticles;
 import dev.dubhe.anvilcraft.init.block.ModFluids;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.item.weapon.AnvilRailgunItem;
+import dev.dubhe.anvilcraft.item.weapon.LaserGunItem;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.particle.FlyTowardsPositionParticle;
 import net.minecraft.world.InteractionHand;
@@ -118,6 +119,9 @@ public class AnvilCraftClient {
             if (stack.getItem() instanceof AnvilRailgunItem && entity instanceof Player player
                 && AnvilRailgunItem.isLoading(player, stack, hand)) {
                 return HumanoidModel.ArmPose.CROSSBOW_CHARGE;
+            }
+            if (stack.getItem() instanceof LaserGunItem) {
+                return HumanoidModel.ArmPose.BOW_AND_ARROW;
             }
             return HumanoidModel.ArmPose.CROSSBOW_HOLD;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/item/CapacitorInventoryCharge.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/CapacitorInventoryCharge.java
@@ -1,0 +1,54 @@
+package dev.dubhe.anvilcraft.item;
+
+import dev.dubhe.anvilcraft.item.weapon.EnergyWeaponItem;
+import dev.dubhe.anvilcraft.item.weapon.SpectralWeaponLauncherItem;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomModelData;
+import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.energy.IEnergyStorage;
+
+final class CapacitorInventoryCharge {
+    private CapacitorInventoryCharge() {
+    }
+
+    static boolean tryChargeTarget(
+        ItemStack capacitor,
+        Slot slot,
+        ClickAction clickAction,
+        Player player,
+        int energy,
+        ItemStack emptyCapacitor
+    ) {
+        if (clickAction != ClickAction.SECONDARY || !slot.allowModification(player)) return false;
+        ItemStack target = slot.getItem();
+        if (!isChargeTarget(target)) return false;
+
+        IEnergyStorage storage = target.getCapability(Capabilities.EnergyStorage.ITEM);
+        if (storage == null || !storage.canReceive()) return false;
+
+        int accepted = storage.receiveEnergy(energy, false);
+        if (accepted <= 0) return false;
+
+        capacitor.shrink(1);
+        player.getInventory().placeItemBackInInventory(emptyCapacitor.copy());
+        updateChargedModel(target);
+        slot.setChanged();
+        return true;
+    }
+
+    private static boolean isChargeTarget(ItemStack stack) {
+        return stack.getItem() instanceof IonoCraftBackpackItem
+            || stack.getItem() instanceof EnergyWeaponItem
+            || stack.getItem() instanceof SpectralWeaponLauncherItem;
+    }
+
+    private static void updateChargedModel(ItemStack stack) {
+        if (stack.getItem() instanceof EnergyWeaponItem) {
+            stack.set(DataComponents.CUSTOM_MODEL_DATA, CustomModelData.DEFAULT);
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/item/CapacitorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/CapacitorItem.java
@@ -2,13 +2,29 @@ package dev.dubhe.anvilcraft.item;
 
 import dev.dubhe.anvilcraft.api.item.IChargerDischargeable;
 import dev.dubhe.anvilcraft.init.item.ModItems;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 public class CapacitorItem extends Item implements IChargerDischargeable {
+    public static final int ENERGY = 8_000_000;
 
     public CapacitorItem(Properties properties) {
         super(properties);
+    }
+
+    @Override
+    public boolean overrideStackedOnOther(ItemStack stack, Slot slot, ClickAction clickAction, Player player) {
+        return CapacitorInventoryCharge.tryChargeTarget(
+            stack,
+            slot,
+            clickAction,
+            player,
+            ENERGY,
+            ModItems.CAPACITOR_EMPTY.asStack(1)
+        );
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/SuperCapacitorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/SuperCapacitorItem.java
@@ -2,16 +2,33 @@ package dev.dubhe.anvilcraft.item;
 
 import dev.dubhe.anvilcraft.api.item.IChargerDischargeable;
 import dev.dubhe.anvilcraft.init.item.ModItems;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 public class SuperCapacitorItem extends Item implements IChargerDischargeable {
+    public static final int ENERGY = 160_000_000;
+
     public SuperCapacitorItem(Properties properties) {
         super(properties);
     }
 
     @Override
+    public boolean overrideStackedOnOther(ItemStack stack, Slot slot, ClickAction clickAction, Player player) {
+        return CapacitorInventoryCharge.tryChargeTarget(
+            stack,
+            slot,
+            clickAction,
+            player,
+            ENERGY,
+            ModItems.SUPER_CAPACITOR_EMPTY.asStack(1)
+        );
+    }
+
+    @Override
     public ItemStack discharge(ItemStack input) {
-        return ModItems.CAPACITOR_EMPTY.asStack(1);
+        return ModItems.SUPER_CAPACITOR_EMPTY.asStack(1);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/item/weapon/LaserGunItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/weapon/LaserGunItem.java
@@ -195,7 +195,7 @@ public class LaserGunItem extends EnergyWeaponItem {
 
     @Override
     public UseAnim getUseAnimation(ItemStack stack) {
-        return UseAnim.NONE;
+        return UseAnim.BOW;
     }
 
     private static final class LaserState {

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/BlockProcessingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/BlockProcessingRecipe.java
@@ -160,7 +160,7 @@ public class BlockProcessingRecipe extends AbstractProcessRecipe<BlockProcessing
         public BlockProcessingRecipe.Builder fakeSuperHeating(Block input) {
             this.inputs.add(BlockStatePredicate.builder().of(input).build());
             this.inputs.add(BlockStatePredicate.builder()
-                .of(ModBlocks.HEATER.get())
+                .of(ModBlocks.HEATER.get(), ModBlocks.BURNING_HEATER.get())
                 .with(HeaterBlock.OVERLOAD, false)
                 .or()
                 .with(BurningHeaterBlock.LEVEL, 2)


### PR DESCRIPTION
- 在 CapacitorItem 和 SuperCapacitorItem 中实现充能快捷方式，支持右键点击直接充能目标物品
- 新增 CapacitorInventoryCharge 辅助类，统一处理充能逻辑及动画更新
- 修改 LaserGunItem 的使用动画为弓箭状态，提高动作表现一致性
- 在 AnvilCraftClient 中为激光枪手部姿势添加支持，匹配客户端渲染需求
- 调整 BlockProcessingRecipe 及相关配置，支持燃烧加热器多状态处理
- 更新语言包和物品提示，新增激发态虚空物质块的描述信息