### PR TITLE
Fix in 26.1

### DIFF
--- a/src/generated/resources/assets/anvilcraft/items/spectral_slingshot.json
+++ b/src/generated/resources/assets/anvilcraft/items/spectral_slingshot.json
@@ -1,9 +1,18 @@
 {
   "model": {
-    "type": "minecraft:special",
-    "base": "anvilcraft:item/spectral_slingshot",
-    "model": {
-      "type": "anvilcraft:spectral_slingshot"
-    }
+    "type": "minecraft:composite",
+    "models": [
+      {
+        "type": "minecraft:model",
+        "model": "anvilcraft:item/spectral_slingshot"
+      },
+      {
+        "type": "minecraft:special",
+        "base": "anvilcraft:item/spectral_slingshot",
+        "model": {
+          "type": "anvilcraft:spectral_slingshot"
+        }
+      }
+    ]
   }
 }

--- a/src/generated/resources/assets/anvilcraft/items/spectral_weapon_launcher.json
+++ b/src/generated/resources/assets/anvilcraft/items/spectral_weapon_launcher.json
@@ -2,18 +2,36 @@
   "model": {
     "type": "minecraft:condition",
     "on_false": {
-      "type": "minecraft:special",
-      "base": "anvilcraft:item/spectral_weapon_launcher",
-      "model": {
-        "type": "anvilcraft:spectral_weapon_launcher"
-      }
+      "type": "minecraft:composite",
+      "models": [
+        {
+          "type": "minecraft:model",
+          "model": "anvilcraft:item/spectral_weapon_launcher"
+        },
+        {
+          "type": "minecraft:special",
+          "base": "anvilcraft:item/spectral_weapon_launcher",
+          "model": {
+            "type": "anvilcraft:spectral_weapon_launcher"
+          }
+        }
+      ]
     },
     "on_true": {
-      "type": "minecraft:special",
-      "base": "anvilcraft:item/spectral_weapon_launcher_exhausted",
-      "model": {
-        "type": "anvilcraft:spectral_weapon_launcher"
-      }
+      "type": "minecraft:composite",
+      "models": [
+        {
+          "type": "minecraft:model",
+          "model": "anvilcraft:item/spectral_weapon_launcher_exhausted"
+        },
+        {
+          "type": "minecraft:special",
+          "base": "anvilcraft:item/spectral_weapon_launcher_exhausted",
+          "model": {
+            "type": "anvilcraft:spectral_weapon_launcher"
+          }
+        }
+      ]
     },
     "predicate": "anvilcraft:integer_component",
     "property": "minecraft:component",

--- a/src/generated/resources/data/anvilcraft/recipe/planet_resource/offering.json
+++ b/src/generated/resources/data/anvilcraft/recipe/planet_resource/offering.json
@@ -4,7 +4,24 @@
   "offering": {
     "entries": [
       {
-        "id": "anvilcraft:gem_block_random",
+        "choices": [
+          {
+            "id": "minecraft:emerald_block",
+            "weight": 1
+          },
+          {
+            "id": "anvilcraft:topaz_block",
+            "weight": 1
+          },
+          {
+            "id": "anvilcraft:ruby_block",
+            "weight": 1
+          },
+          {
+            "id": "anvilcraft:sapphire_block",
+            "weight": 1
+          }
+        ],
         "weight": 50
       },
       {
@@ -20,7 +37,24 @@
         "weight": 2
       },
       {
-        "id": "anvilcraft:gem_amulet_random",
+        "choices": [
+          {
+            "id": "anvilcraft:emerald_amulet",
+            "weight": 1
+          },
+          {
+            "id": "anvilcraft:topaz_amulet",
+            "weight": 1
+          },
+          {
+            "id": "anvilcraft:ruby_amulet",
+            "weight": 1
+          },
+          {
+            "id": "anvilcraft:sapphire_amulet",
+            "weight": 1
+          }
+        ],
         "weight": 2
       },
       {

--- a/src/generated/resources/data/anvilcraft/recipe/planet_resource/wasteland.json
+++ b/src/generated/resources/data/anvilcraft/recipe/planet_resource/wasteland.json
@@ -4,7 +4,7 @@
   "wasteland": {
     "entries": [
       {
-        "id": "anvilcraft:reinforced_concrete_gray",
+        "id": "anvilcraft:gray_reinforced_concrete",
         "weight": 60
       },
       {

--- a/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
+++ b/src/main/java/dev/dubhe/anvilcraft/AnvilCraft.java
@@ -18,6 +18,7 @@ import dev.dubhe.anvilcraft.init.ModCriterionTriggers;
 import dev.dubhe.anvilcraft.init.ModDataAttachments;
 import dev.dubhe.anvilcraft.init.ModDispenserBehavior;
 import dev.dubhe.anvilcraft.init.ModInspections;
+import dev.dubhe.anvilcraft.init.ModMegastructures;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.init.ModMobEffects;
 import dev.dubhe.anvilcraft.init.ModParticles;
@@ -97,6 +98,7 @@ public class AnvilCraft {
         ModFoodItems.register();
         ModBlockEntities.register();
         ModMenuTypes.register();
+        ModMegastructures.register(modEventBus);
         ModComponents.register(modEventBus);
         ModVillagers.register(modEventBus);
         ModRecipeSerializers.register(modEventBus);

--- a/src/main/java/dev/dubhe/anvilcraft/api/tooltip/impl/CfaLogisticsInterfaceTooltipProvider.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/tooltip/impl/CfaLogisticsInterfaceTooltipProvider.java
@@ -1,55 +1,74 @@
 package dev.dubhe.anvilcraft.api.tooltip.impl;
 
+import dev.anvilcraft.lib.v2.rpc.RPC;
+import dev.anvilcraft.lib.v2.rpc.RpcTarget;
 import dev.dubhe.anvilcraft.block.entity.CelestialForgingAnvilLogisticsInterfaceBlockEntity;
+import dev.dubhe.anvilcraft.block.entity.CelestialForgingAnvilLogisticsInterfaceBlockEntity.TooltipData;
+import dev.dubhe.anvilcraft.block.entity.CelestialForgingAnvilLogisticsInterfaceBlockEntity.TooltipSyncResult;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.neoforged.neoforge.transfer.ResourceHandler;
-import net.neoforged.neoforge.transfer.item.ItemResource;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 public class CfaLogisticsInterfaceTooltipProvider
     extends CfaInterfaceTooltipProvider<CelestialForgingAnvilLogisticsInterfaceBlockEntity> {
+    private static final int DATA_REFRESH_INTERVAL = 10;
+    private @Nullable CelestialForgingAnvilLogisticsInterfaceBlockEntity target;
+    private @Nullable CompletableFuture<Optional<TooltipSyncResult>> pendingData;
+    private long nextDataRefresh;
+    private long dataVersion = 0;
+    private @Nullable TooltipData data;
+
     public CfaLogisticsInterfaceTooltipProvider() {
         super(CelestialForgingAnvilLogisticsInterfaceBlockEntity.class);
     }
 
     @Override
     protected List<Component> buildTooltip(CelestialForgingAnvilLogisticsInterfaceBlockEntity logistics) {
+        this.refreshData(logistics);
         List<Component> lines = new ArrayList<>();
+        TooltipData data = this.data;
+        if (data == null) {
+            lines.add(Component.translatable("tooltip.anvilcraft.waiting").withStyle(ChatFormatting.DARK_GRAY));
+            return lines;
+        }
 
         // 显示尚未完成的神庙供奉需求。
-        ItemStack demandItem = logistics.getTempleDemandItem();
-        if (!demandItem.isEmpty() && !logistics.isTempleDemandSatisfied()) {
+        ItemStack demandItem = data.templeDemandItem();
+        if (!demandItem.isEmpty()) {
             lines.add(Component.translatable("screen.anvilcraft.cfa.temple_demand")
                 .withStyle(ChatFormatting.GOLD));
-            int progress = logistics.getTempleDemandProgress();
+            int progress = data.templeDemandProgress();
             if (progress > 0) {
                 lines.add(Component.literal(" · ")
                     .append(demandItem.getHoverName())
-                    .append(Component.literal(" " + progress + "/" + logistics.getTempleDemandCount()))
+                    .append(Component.literal(" " + progress + "/" + data.templeDemandCount()))
                     .withStyle(ChatFormatting.YELLOW));
             } else {
                 lines.add(Component.literal(" · ")
                     .append(demandItem.getHoverName())
-                    .append(Component.literal(" ×" + logistics.getTempleDemandCount()))
+                    .append(Component.literal(" ×" + data.templeDemandCount()))
                     .withStyle(ChatFormatting.YELLOW));
             }
             lines.add(Component.literal(""));
         }
 
-        // 显示锻星砧控制器推送的对撞机状态。
-        List<ItemStack> colliderTargets = logistics.getColliderTargetItems();
-        if (!colliderTargets.isEmpty() || logistics.isColliderProcessing() || logistics.isColliderStarMissing()) {
+        // 显示服务端快照中的对撞机状态。
+        List<ItemStack> colliderTargets = data.colliderTargetItems();
+        if (!colliderTargets.isEmpty() || data.colliderProcessing() || data.colliderStarMissing()) {
             // 缺少恒星时优先显示警告，不显示目标物品。
-            if (logistics.isColliderStarMissing()) {
+            if (data.colliderStarMissing()) {
                 lines.add(Component.translatable("screen.anvilcraft.cfa.collider_star_missing")
                     .withStyle(ChatFormatting.RED));
                 lines.add(Component.literal(""));
-            } else if (logistics.isColliderProcessing()) {
+            } else if (data.colliderProcessing()) {
                 var level = logistics.getLevel();
                 int dots = level != null ? (int) ((level.getGameTime() / 10) % 3) : 0;
                 String base = Component.translatable("screen.anvilcraft.cfa.collider_processing").getString();
@@ -60,7 +79,7 @@ public class CfaLogisticsInterfaceTooltipProvider
                     .withStyle(ChatFormatting.AQUA));
             }
             // 仅在空闲且恒星存在时显示目标物品。
-            if (!logistics.isColliderStarMissing() && !logistics.isColliderProcessing()) {
+            if (!data.colliderStarMissing() && !data.colliderProcessing()) {
                 for (ItemStack target : colliderTargets) {
                     if (!target.isEmpty()) {
                         lines.add(Component.literal(" · ")
@@ -73,24 +92,47 @@ public class CfaLogisticsInterfaceTooltipProvider
         }
 
         // 显示接口内已存储的物品。
-        ResourceHandler<ItemResource> handler = logistics.getItemHandler();
-        boolean hasAny = false;
-        for (int i = 0; i < handler.size(); i++) {
-            ItemResource resource = handler.getResource(i);
-            if (!resource.isEmpty()) {
-                hasAny = true;
-                ItemStack stack = resource.toStack(handler.getAmountAsInt(i));
-                lines.add(Component.literal(" · ")
-                    .append(stack.getHoverName())
-                    .append(Component.literal(" ×" + stack.getCount()))
-                    .withStyle(ChatFormatting.GRAY));
-            }
+        for (ItemStack stack : data.storedItems()) {
+            lines.add(Component.literal(" · ")
+                .append(stack.getHoverName())
+                .append(Component.literal(" ×" + stack.getCount()))
+                .withStyle(ChatFormatting.GRAY));
         }
-        if (!hasAny) {
+        if (data.storedItems().isEmpty()) {
             lines.add(Component.translatable("screen.anvilcraft.cfa.interface.empty")
                 .withStyle(ChatFormatting.DARK_GRAY));
         }
         return lines;
+    }
+
+    private void refreshData(CelestialForgingAnvilLogisticsInterfaceBlockEntity logistics) {
+        Level level = logistics.getLevel();
+        if (level == null) return;
+        if (this.target != logistics) {
+            this.target = logistics;
+            this.pendingData = null;
+            this.nextDataRefresh = level.getGameTime();
+            this.dataVersion = 0;
+            this.data = null;
+        }
+        if (this.pendingData != null && this.pendingData.isDone()) {
+            this.pendingData.join().ifPresent(result -> {
+                this.dataVersion = result.version();
+                TooltipData updatedData = result.data();
+                if (updatedData != null) {
+                    this.data = updatedData;
+                }
+            });
+            this.pendingData = null;
+        }
+        if (this.pendingData != null || level.getGameTime() < this.nextDataRefresh) return;
+        this.nextDataRefresh = level.getGameTime() + CfaLogisticsInterfaceTooltipProvider.DATA_REFRESH_INTERVAL;
+        this.pendingData = RPC.invoke(
+            RpcTarget.server(),
+            CelestialForgingAnvilLogisticsInterfaceBlockEntity::syncTooltipData,
+            logistics.getBlockPos(),
+            this.dataVersion
+        ).thenApply(Optional::of).exceptionally(_ -> Optional.empty());
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/cfa/CelestialForgingAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/cfa/CelestialForgingAnvilBlock.java
@@ -23,7 +23,6 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.ProblemReporter;
-import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -44,12 +43,17 @@ import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.level.redstone.Orientation;
 import net.minecraft.world.level.storage.TagValueOutput;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CelestialForgingAnvilBlock
     extends SimpleMultiPartBlock<Cube323PartHalf>
@@ -225,53 +229,64 @@ public class CelestialForgingAnvilBlock
         return ModMultiblockDefinitions.CELESTIAL_FORGING_ANVIL.identifier();
     }
 
-    // === 结构拆除：26.1 使用 playerWillDestroy 和 setRemoved ===
-
     @Override
-    public BlockState playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
-        BlockPos mainPos = getMainPartPos(pos, state);
-        boolean isMain = state.hasProperty(HALF) && state.getValue(HALF) == Cube323PartHalf.BOTTOM_CENTER;
-        if (isMain && level.getBlockEntity(mainPos) instanceof CelestialForgingAnvilBlockEntity be) {
-            // 将全部内部物品栏内容掉落到世界。
-            for (int i = 0; i < be.getAnvilInventory().getContainerSize(); i++) {
-                ItemStack stack = be.getAnvilInventory().getItem(i);
-                if (!stack.isEmpty()) {
-                    Containers.dropItemStack(level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack);
-                }
-            }
-            ItemStack matStack = be.getMaterialContainer().getItem(0);
-            if (!matStack.isEmpty()) {
-                Containers.dropItemStack(level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, matStack);
-            }
+    protected List<ItemStack> getDrops(BlockState state, LootParams.Builder params) {
+        List<ItemStack> drops = super.getDrops(state, params);
+        BlockEntity blockEntity = params.getOptionalParameter(LootContextParams.BLOCK_ENTITY);
+        if (!(blockEntity instanceof CelestialForgingAnvilBlockEntity be)) {
+            return drops;
+        }
 
-            // 掉落控制器物品并保留天体、巨构和匹配参数，使其重新放置后恢复；
-            // 同时移除与当前位置或运行时绑定的临时字段。
-            if (!level.isClientSide()) {
-                final ItemStack blockStack = new ItemStack(asItem());
-                CompoundTag beTag = be.saveCustomOnly(level.registryAccess());
+        boolean dropsController = false;
+        for (ItemStack stack : drops) {
+            if (!stack.is(this.asItem())) continue;
+            dropsController = true;
+            this.saveBlockEntityDataToDrop(stack, be, params);
+        }
+        if (!dropsController) {
+            return drops;
+        }
 
-                // 清除与原世界位置或瞬时运行状态绑定的数据。
-                beTag.remove("anvils");               // inventory — already dropped above
-                beTag.remove("materialFilter");       // UI state — resets on menu close
-                beTag.remove("materialLimit");        // UI state
-                beTag.remove("searchHistory");        // search history — not preserved
-                beTag.remove("searching");            // runtime
-                beTag.remove("searchTicks");          // runtime
-                beTag.remove("searchFailed");         // runtime
-                beTag.remove("powerInsufficient");    // runtime
-                beTag.remove("amplifierPresent");     // depends on multiblock structure
-                beTag.remove("activeMegastructure");  // depends on multiblock structure
-
-                if (!beTag.isEmpty()) {
-                    TagValueOutput output = TagValueOutput.createWithoutContext(
-                        new ProblemReporter.ScopedCollector(be.problemPath(), LogUtils.getLogger()));
-                    output.store(beTag);
-                    BlockItem.setBlockEntityData(blockStack, be.getType(), output);
-                }
-                Containers.dropItemStack(level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, blockStack);
+        List<ItemStack> result = new ArrayList<>(drops);
+        for (int i = 0; i < be.getAnvilInventory().getContainerSize(); i++) {
+            ItemStack stack = be.getAnvilInventory().getItem(i);
+            if (!stack.isEmpty()) {
+                result.add(stack.copy());
             }
         }
-        return super.playerWillDestroy(level, pos, state, player);
+        ItemStack materialStack = be.getMaterialContainer().getItem(0);
+        if (!materialStack.isEmpty()) {
+            result.add(materialStack.copy());
+        }
+        return result;
+    }
+
+    private void saveBlockEntityDataToDrop(
+        ItemStack stack,
+        CelestialForgingAnvilBlockEntity blockEntity,
+        LootParams.Builder params
+    ) {
+        CompoundTag blockEntityTag = blockEntity.saveForDrop(params.getLevel().registryAccess());
+
+        blockEntityTag.remove("anvils");              // dropped separately
+        blockEntityTag.remove("materialFilter");      // menu state
+        blockEntityTag.remove("materialLimit");       // menu state
+        blockEntityTag.remove("searchHistory");       // search history is not preserved
+        blockEntityTag.remove("searching");           // runtime state
+        blockEntityTag.remove("searchTicks");         // runtime state
+        blockEntityTag.remove("searchFailed");        // runtime state
+        blockEntityTag.remove("powerInsufficient");   // runtime state
+        blockEntityTag.remove("amplifierPresent");       // derived from the multiblock
+        blockEntityTag.remove("activeMegastructureId");  // structure-dependent state
+        blockEntityTag.remove("activeMegastructure");    // legacy structure-dependent state
+        blockEntityTag.remove("activeMegastructureName");
+        blockEntityTag.remove("activeMegastructureRing");
+
+        if (blockEntityTag.isEmpty()) return;
+        TagValueOutput output = TagValueOutput.createWithoutContext(
+            new ProblemReporter.ScopedCollector(blockEntity.problemPath(), LogUtils.getLogger()));
+        output.store(blockEntityTag);
+        BlockItem.setBlockEntityData(stack, blockEntity.getType(), output);
     }
 
     // === 多方块结构生命周期 ===

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/CelestialForgingAnvilBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/CelestialForgingAnvilBlockEntity.java
@@ -17,6 +17,7 @@ import dev.dubhe.anvilcraft.block.entity.megastructure.ExcavatorHandler;
 import dev.dubhe.anvilcraft.block.entity.megastructure.PenroseSphereHandler;
 import dev.dubhe.anvilcraft.block.entity.megastructure.WormholeStabilizerHandler;
 import dev.dubhe.anvilcraft.block.state.Cube323PartHalf;
+import dev.dubhe.anvilcraft.init.ModMegastructures;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.inventory.CelestialForgingAnvilMenu;
@@ -32,6 +33,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.Util;
 import net.minecraft.world.InteractionHand;
@@ -160,11 +162,12 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
     @Nullable
     private PlanetaryResourceSet planetaryResourceSet = null;
 
-    /**
-     * 获取当前已建巨构在重构选项中的索引；未建造时为 -1。
-     */
-    public int getActiveMegastructureIndex() {
-        return this.megastructureManager.getActiveIndex();
+    public boolean hasActiveMegastructure() {
+        return this.megastructureManager.hasActiveMegastructure();
+    }
+
+    public @Nullable Identifier getActiveMegastructureId() {
+        return this.megastructureManager.getActiveId(this);
     }
 
     /**
@@ -586,6 +589,7 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
     }
 
     private final CelestialSearchHistory searchHistory = new CelestialSearchHistory();
+    private @Nullable CompoundTag cachedDropData;
 
     @Getter
     private final SimpleContainer anvilInventory = new SimpleContainer(5) {
@@ -642,13 +646,27 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
 
     @Override
     public void setRemoved() {
+        boolean shouldClear = this.level != null && !this.level.isClientSide() && !PowerGrid.isServerClosing;
+        if (shouldClear && this.cachedDropData == null) {
+            this.cachedDropData = this.saveCustomOnly(this.level.registryAccess());
+        }
         super.setRemoved();
-        if (this.level != null && !this.level.isClientSide() && !PowerGrid.isServerClosing) {
+        if (shouldClear) {
             this.gravityController.remove(this.level, this.worldPosition);
             // 注销虫洞并清理巨构，使连接传送门及时关闭。
             // 服务器关闭期间跳过，避免保存过程中访问持久化数据。
             this.megastructureManager.clearAllMegastructures(this);
         }
+    }
+
+    @Override
+    public void clearRemoved() {
+        super.clearRemoved();
+        this.cachedDropData = null;
+    }
+
+    public CompoundTag saveForDrop(HolderLookup.Provider registries) {
+        return this.cachedDropData == null ? this.saveCustomOnly(registries) : this.cachedDropData.copy();
     }
 
     /**
@@ -744,8 +762,7 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
             PowerGrid.addComponent(this);
             // 若虫洞稳定器仍有效，其处理器会在重新建造回调中恢复网络注册。
             WormholeStabilizerHandler wh = this.megastructureManager.getWormholeHandler();
-            if (this.megastructureManager.getActiveIndex() >= 0 && this.getActiveMegastructureOption() != null
-                && "wormhole_stabilizer".equals(this.getActiveMegastructureOption().megastructure())) {
+            if (ModMegastructures.WORMHOLE_STABILIZER.getId().equals(this.getActiveMegastructureId())) {
                 wh.onBuild(this);
             }
             this.setChanged();
@@ -803,6 +820,11 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
     protected void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
         this.isAmplify = input.getBooleanOr("amplified", false);
+        input.getInt("redstoneSignal").ifPresent(signal -> {
+            int syncedSignal = Math.clamp(signal, 0, 15);
+            this.cachedRedstoneSignal = syncedSignal;
+            this.syncedRedstoneSignal = syncedSignal;
+        });
         this.stellarMass = input.getIntOr("stellarMass", 0);
         this.locked = input.getBooleanOr("locked", false);
         this.amplifierPresent = input.getBooleanOr("amplifierPresent", false);
@@ -857,6 +879,7 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
         });
         // 最后读取巨构数据，使处理器能够覆盖控制器中的派生状态。
         this.megastructureManager.loadAdditional(input);
+        this.megastructureManager.getActiveId(this);
         if (this.level != null && !this.level.isClientSide()) {
             this.syncToClient();
         }
@@ -1055,8 +1078,8 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
             this.isAmplify,
             this.planetaryResourceSet
         );
-        if (this.megastructureManager.getActiveIndex() >= 0) {
-            options = options.stream().filter(opt -> "stellar_evolution_accelerator".equals(opt.megastructure())).toList();
+        if (this.megastructureManager.hasActiveMegastructure()) {
+            options = options.stream().filter(CelestialRefactorOption::auxiliary).toList();
         }
         return options;
     }
@@ -1101,7 +1124,7 @@ public class CelestialForgingAnvilBlockEntity extends BlockEntity
         }
 
         // 实际建造逻辑交由巨构管理器。
-        this.megastructureManager.buildMegastructure(optionIndex, this);
+        this.megastructureManager.buildMegastructure(option, this);
 
         // 重新注册电网，使巨构改变后的组件类型立即生效。
         PowerGrid.addComponent(this);

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/CelestialForgingAnvilLogisticsInterfaceBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/CelestialForgingAnvilLogisticsInterfaceBlockEntity.java
@@ -1,5 +1,8 @@
 package dev.dubhe.anvilcraft.block.entity;
 
+import dev.anvilcraft.lib.v2.rpc.CallableParam;
+import dev.anvilcraft.lib.v2.rpc.IRemoteCallableValidator;
+import dev.anvilcraft.lib.v2.rpc.RemoteCallable;
 import dev.dubhe.anvilcraft.api.itemhandler.FilteredItemStackHandler;
 import dev.dubhe.anvilcraft.api.itemhandler.IItemResourceHandlerHolder;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
@@ -7,33 +10,34 @@ import dev.dubhe.anvilcraft.block.cfa.CelestialForgingAnvilBlock;
 import dev.dubhe.anvilcraft.block.cfa.interfaces.CelestialForgingAnvilInterfaceBlock;
 import dev.dubhe.anvilcraft.block.state.Cube323PartHalf;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.NbtOps;
-import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.game.ClientGamePacketListener;
-import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.util.ProblemReporter;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import org.jspecify.annotations.Nullable;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -45,10 +49,13 @@ import java.util.stream.IntStream;
  */
 public class CelestialForgingAnvilLogisticsInterfaceBlockEntity extends BlockEntity implements IItemResourceHandlerHolder {
     private static final int TYPE_COUNT = 16;
+    private static final StreamCodec<ByteBuf, BlockPos> POS_STREAM_CODEC = ByteBufCodecs.VAR_LONG
+        .map(BlockPos::of, BlockPos::asLong);
     @Setter
     private boolean syncing = false; // 防止虫洞同步重入
-    // 同一游戏刻内的多次库存和提示状态变化合并为一个完整更新包。
-    private boolean clientSyncPending = false;
+    // 同一游戏刻内的多次库存和提示状态变化只增加一次 RPC 数据版本。
+    private boolean tooltipDataDirty = false;
+    private long tooltipDataVersion = 1;
 
     private final FilteredItemStackHandler itemHandler = new FilteredItemStackHandler(TYPE_COUNT) {
         @Override
@@ -91,32 +98,18 @@ public class CelestialForgingAnvilLogisticsInterfaceBlockEntity extends BlockEnt
         return new CelestialForgingAnvilLogisticsInterfaceBlockEntity(type, pos, state);
     }
 
-    // === 网络同步 ===
-
-    /**
-     * 将方块实体数据同步给所有正在追踪此区块的客户端。
-     */
-    public void syncToClients() {
-        CfaBlockEntitySync.sendToTracking(this, this.getUpdatePacket());
-    }
-
     @Override
     public void setChanged() {
         super.setChanged();
         if (level != null && !level.isClientSide()) {
-            this.clientSyncPending = true;
+            this.tooltipDataDirty = true;
         }
     }
 
-    private void flushClientSync() {
-        if (!this.clientSyncPending) return;
-        this.clientSyncPending = false;
-        this.syncToClients();
-    }
-
-    @Override
-    public @Nullable Packet<ClientGamePacketListener> getUpdatePacket() {
-        return ClientboundBlockEntityDataPacket.create(this);
+    private void flushTooltipDataVersion() {
+        if (!this.tooltipDataDirty) return;
+        this.tooltipDataDirty = false;
+        this.tooltipDataVersion++;
     }
 
     @SuppressWarnings("unused")
@@ -246,7 +239,7 @@ public class CelestialForgingAnvilLogisticsInterfaceBlockEntity extends BlockEnt
                 this.setChanged();
             }
         } finally {
-            this.flushClientSync();
+            this.flushTooltipDataVersion();
         }
     }
 
@@ -268,7 +261,7 @@ public class CelestialForgingAnvilLogisticsInterfaceBlockEntity extends BlockEnt
     @Getter
     private boolean colliderStarMissing = false;
 
-    // 下列 setter 会触发客户端同步，以便铁砧锤提示及时刷新。
+    // 下列状态持久化在服务端，并由铁砧锤提示按需通过 RPC 读取。
 
     public void setTempleDemandItem(ItemStack templeDemandItem) {
         if (ItemStack.matches(this.templeDemandItem, templeDemandItem)) return;
@@ -321,8 +314,52 @@ public class CelestialForgingAnvilLogisticsInterfaceBlockEntity extends BlockEnt
     public void setEjectCooldown(int ejectCooldown) {
         if (this.ejectCooldown == ejectCooldown) return;
         this.ejectCooldown = ejectCooldown;
-        // 冷却仅参与服务端逻辑和磁盘持久化，不需要触发客户端完整库存包。
+        // 冷却仅参与服务端逻辑和磁盘持久化。
         super.setChanged();
+    }
+
+    @RemoteCallable(validator = TooltipDataValidator.class)
+    public static TooltipSyncResult syncTooltipData(
+        @CallableParam(clazz = CelestialForgingAnvilLogisticsInterfaceBlockEntity.class, field = "POS_STREAM_CODEC") BlockPos pos,
+        long knownVersion
+    ) {
+        CelestialForgingAnvilLogisticsInterfaceBlockEntity logistics = TooltipDataValidator.TARGET.get();
+        TooltipDataValidator.TARGET.remove();
+        if (logistics == null || !logistics.getBlockPos().equals(pos)) return TooltipSyncResult.EMPTY;
+        logistics.flushTooltipDataVersion();
+        return new TooltipSyncResult(
+            logistics.tooltipDataVersion,
+            knownVersion == logistics.tooltipDataVersion ? null : logistics.createTooltipData()
+        );
+    }
+
+    private TooltipData createTooltipData() {
+        List<ItemStack> storedItems = new ArrayList<>(TYPE_COUNT);
+        for (int slot = 0; slot < this.itemHandler.size(); slot++) {
+            ItemResource resource = this.itemHandler.getResource(slot);
+            if (!resource.isEmpty()) {
+                storedItems.add(resource.toStack(this.itemHandler.getAmountAsInt(slot)));
+            }
+        }
+
+        boolean hasTempleDemand = !this.templeDemandSatisfied && !this.templeDemandItem.isEmpty();
+        List<ItemStack> colliderTargets = new ArrayList<>();
+        if (!this.colliderProcessing && !this.colliderStarMissing) {
+            for (ItemStack target : this.colliderTargetItems) {
+                if (!target.isEmpty()) {
+                    colliderTargets.add(target.copy());
+                }
+            }
+        }
+        return new TooltipData(
+            storedItems,
+            hasTempleDemand ? this.templeDemandItem.copy() : ItemStack.EMPTY,
+            hasTempleDemand ? this.templeDemandCount : 0,
+            hasTempleDemand ? this.templeDemandProgress : 0,
+            colliderTargets,
+            this.colliderProcessing,
+            this.colliderStarMissing
+        );
     }
 
     // === 持久化：26.1 使用 ValueOutput / ValueInput ===
@@ -369,33 +406,117 @@ public class CelestialForgingAnvilLogisticsInterfaceBlockEntity extends BlockEnt
         this.colliderStarMissing = input.getBooleanOr("colliderStarMissing", false);
     }
 
-    // === 网络同步：getUpdateTag 发送 CompoundTag，客户端经 loadAdditional 读取 ===
+    public record TooltipData(
+        List<ItemStack> storedItems,
+        ItemStack templeDemandItem,
+        int templeDemandCount,
+        int templeDemandProgress,
+        List<ItemStack> colliderTargetItems,
+        boolean colliderProcessing,
+        boolean colliderStarMissing
+    ) {
+        private static final int HAS_TEMPLE_DEMAND = 1;
+        private static final int COLLIDER_PROCESSING = 1 << 1;
+        private static final int COLLIDER_STAR_MISSING = 1 << 2;
+        private static final StreamCodec<RegistryFriendlyByteBuf, List<ItemStack>> STORED_ITEMS_STREAM_CODEC =
+            ItemStack.STREAM_CODEC.apply(ByteBufCodecs.list(TYPE_COUNT));
+        private static final StreamCodec<RegistryFriendlyByteBuf, List<ItemStack>> COLLIDER_TARGETS_STREAM_CODEC =
+            ItemStack.STREAM_CODEC.apply(ByteBufCodecs.list());
+        public static final StreamCodec<RegistryFriendlyByteBuf, TooltipData> STREAM_CODEC = StreamCodec.of(
+            TooltipData::encode,
+            TooltipData::decode
+        );
 
-    @Override
-    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
-        CompoundTag tag = super.getUpdateTag(registries);
-        // 同步物品栏，供客户端铁砧锤提示显示。
-        TagValueOutput invOutput = TagValueOutput.createWithContext(
-            new ProblemReporter.Collector(this.problemPath()), registries);
-        this.itemHandler.serialize(invOutput);
-        tag.put("inventory", invOutput.buildResult());
-        if (!this.templeDemandItem.isEmpty()) {
-            tag.put("templeDemandItem", ItemStack.CODEC.encodeStart(NbtOps.INSTANCE, this.templeDemandItem).getOrThrow());
-        }
-        tag.putInt("templeDemandCount", this.templeDemandCount);
-        tag.putInt("templeDemandProgress", this.templeDemandProgress);
-        tag.putBoolean("templeDemandSatisfied", this.templeDemandSatisfied);
-        if (!this.colliderTargetItems.isEmpty()) {
-            ListTag list = new ListTag();
-            for (ItemStack stack : this.colliderTargetItems) {
-                if (!stack.isEmpty()) {
-                    list.add(ItemStack.CODEC.encodeStart(NbtOps.INSTANCE, stack).getOrThrow());
-                }
+        private static void encode(RegistryFriendlyByteBuf buf, TooltipData data) {
+            TooltipData.STORED_ITEMS_STREAM_CODEC.encode(buf, data.storedItems);
+            int flags = 0;
+            if (!data.templeDemandItem.isEmpty()) flags |= TooltipData.HAS_TEMPLE_DEMAND;
+            if (data.colliderProcessing) flags |= TooltipData.COLLIDER_PROCESSING;
+            if (data.colliderStarMissing) flags |= TooltipData.COLLIDER_STAR_MISSING;
+            buf.writeByte(flags);
+            if ((flags & TooltipData.HAS_TEMPLE_DEMAND) != 0) {
+                ItemStack.STREAM_CODEC.encode(buf, data.templeDemandItem);
+                buf.writeVarInt(data.templeDemandCount);
+                buf.writeVarInt(data.templeDemandProgress);
             }
-            tag.put("colliderTargetItems", list);
+            if ((flags & (TooltipData.COLLIDER_PROCESSING | TooltipData.COLLIDER_STAR_MISSING)) == 0) {
+                TooltipData.COLLIDER_TARGETS_STREAM_CODEC.encode(buf, data.colliderTargetItems);
+            }
         }
-        tag.putBoolean("colliderProcessing", this.colliderProcessing);
-        tag.putBoolean("colliderStarMissing", this.colliderStarMissing);
-        return tag;
+
+        private static TooltipData decode(RegistryFriendlyByteBuf buf) {
+            List<ItemStack> storedItems = TooltipData.STORED_ITEMS_STREAM_CODEC.decode(buf);
+            int flags = buf.readUnsignedByte();
+            boolean hasTempleDemand = (flags & TooltipData.HAS_TEMPLE_DEMAND) != 0;
+            ItemStack templeDemandItem = hasTempleDemand ? ItemStack.STREAM_CODEC.decode(buf) : ItemStack.EMPTY;
+            int templeDemandCount = hasTempleDemand ? buf.readVarInt() : 0;
+            int templeDemandProgress = hasTempleDemand ? buf.readVarInt() : 0;
+            boolean colliderProcessing = (flags & TooltipData.COLLIDER_PROCESSING) != 0;
+            boolean colliderStarMissing = (flags & TooltipData.COLLIDER_STAR_MISSING) != 0;
+            List<ItemStack> colliderTargetItems = colliderProcessing || colliderStarMissing
+                                                  ? List.of()
+                                                  : TooltipData.COLLIDER_TARGETS_STREAM_CODEC.decode(buf);
+            return new TooltipData(
+                storedItems,
+                templeDemandItem,
+                templeDemandCount,
+                templeDemandProgress,
+                colliderTargetItems,
+                colliderProcessing,
+                colliderStarMissing
+            );
+        }
+    }
+
+    public record TooltipSyncResult(long version, @Nullable TooltipData data) {
+        public static final TooltipSyncResult EMPTY = new TooltipSyncResult(0, null);
+        public static final StreamCodec<RegistryFriendlyByteBuf, TooltipSyncResult> STREAM_CODEC = StreamCodec.of(
+            TooltipSyncResult::encode,
+            TooltipSyncResult::decode
+        );
+
+        private static void encode(RegistryFriendlyByteBuf buf, TooltipSyncResult result) {
+            buf.writeVarLong(result.version);
+            buf.writeBoolean(result.data != null);
+            if (result.data != null) {
+                TooltipData.STREAM_CODEC.encode(buf, result.data);
+            }
+        }
+
+        private static TooltipSyncResult decode(RegistryFriendlyByteBuf buf) {
+            long version = buf.readVarLong();
+            return new TooltipSyncResult(version, buf.readBoolean() ? TooltipData.STREAM_CODEC.decode(buf) : null);
+        }
+    }
+
+    private static final class TooltipDataValidator implements IRemoteCallableValidator {
+        private static final ThreadLocal<@Nullable CelestialForgingAnvilLogisticsInterfaceBlockEntity> TARGET =
+            new ThreadLocal<>();
+
+        @Override
+        public boolean validate(IPayloadContext ctx, Method method, Object[] args) {
+            if (
+                ctx.flow() != PacketFlow.SERVERBOUND
+                || !(ctx.player() instanceof ServerPlayer player)
+                || args.length != 2
+                || !(args[0] instanceof BlockPos pos)
+                || !(args[1] instanceof Long)
+            ) {
+                return false;
+            }
+            BlockEntity blockEntity = player.level().getBlockEntity(pos);
+            if (!(blockEntity instanceof CelestialForgingAnvilLogisticsInterfaceBlockEntity logistics)) {
+                return false;
+            }
+            boolean accessible = AbstractContainerMenu.stillValid(
+                ContainerLevelAccess.create(player.level(), pos),
+                player,
+                logistics.getBlockState().getBlock()
+            );
+            if (accessible) {
+                TooltipDataValidator.TARGET.set(logistics);
+            }
+            return accessible;
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/CfaMegastructureManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/CfaMegastructureManager.java
@@ -3,22 +3,16 @@ package dev.dubhe.anvilcraft.block.entity;
 import dev.dubhe.anvilcraft.api.power.PowerComponentType;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialRefactorOption;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialRefactorRegistry;
+import dev.dubhe.anvilcraft.block.entity.celestial.Megastructure;
 import dev.dubhe.anvilcraft.block.entity.megastructure.AcceleratorHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.ColliderHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.DysonSphereHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.EcoStationHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.ExcavatorHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.ExtractorHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.GiantExtractorHandler;
 import dev.dubhe.anvilcraft.block.entity.megastructure.IMegastructureHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.MagnetarCoilHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.MatterDecompressorHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.PenroseSphereHandler;
-import dev.dubhe.anvilcraft.block.entity.megastructure.TempleHandler;
 import dev.dubhe.anvilcraft.block.entity.megastructure.WormholeStabilizerHandler;
+import dev.dubhe.anvilcraft.init.ModMegastructures;
+import dev.dubhe.anvilcraft.init.registry.ModRegistries;
 import lombok.Getter;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import org.jspecify.annotations.Nullable;
@@ -28,74 +22,62 @@ import java.util.Map;
 import java.util.Objects;
 
 public class CfaMegastructureManager {
-    private int activeMegastructureIndex = -1;
-    private @Nullable String activeMegastructureName;
-    private int activeMegastructureRing = -1;
+    private @Nullable Identifier activeMegastructureId;
+    private int legacyActiveMegastructureIndex = -1;
+    private @Nullable String legacyActiveMegastructureName;
+    private int legacyActiveMegastructureRing = -1;
 
-    private final Map<String, IMegastructureHandler> handlers = new LinkedHashMap<>();
+    private final Map<Identifier, IMegastructureHandler> handlers = new LinkedHashMap<>();
     @Getter
     private final AcceleratorHandler acceleratorHandler;
 
     public CfaMegastructureManager() {
-        this.registerHandler(new ExcavatorHandler());
-        this.registerHandler(new ExtractorHandler());
-        this.registerHandler(new GiantExtractorHandler());
-        this.registerHandler(new ColliderHandler());
-        this.registerHandler(new DysonSphereHandler("dyson_sphere_small"));
-        this.registerHandler(new DysonSphereHandler("dyson_sphere_large"));
-        this.registerHandler(new MagnetarCoilHandler());
-        this.registerHandler(new PenroseSphereHandler());
-        this.registerHandler(new MatterDecompressorHandler());
-        this.registerHandler(new WormholeStabilizerHandler());
-        this.registerHandler(new EcoStationHandler());
-        this.registerHandler(new TempleHandler());
-        this.acceleratorHandler = new AcceleratorHandler();
+        for (Megastructure megastructure : ModRegistries.MEGASTRUCTURE) {
+            IMegastructureHandler previous = this.handlers.put(megastructure.id(), megastructure.createHandler());
+            if (previous != null) {
+                throw new IllegalStateException("Duplicate megastructure handler: " + megastructure.id());
+            }
+        }
+        IMegastructureHandler accelerator = this.handlers.get(ModMegastructures.STELLAR_EVOLUTION_ACCELERATOR.getId());
+        if (!(accelerator instanceof AcceleratorHandler handler)) {
+            throw new IllegalStateException("Stellar evolution accelerator handler was not registered");
+        }
+        this.acceleratorHandler = handler;
     }
 
-    private void registerHandler(IMegastructureHandler handler) {
-        this.handlers.put(handler.name(), handler);
+    public boolean hasActiveMegastructure() {
+        return this.activeMegastructureId != null
+            || this.legacyActiveMegastructureName != null
+            || this.legacyActiveMegastructureIndex >= 0;
     }
 
-    public int getActiveIndex() {
-        return this.activeMegastructureIndex;
+    public @Nullable Identifier getActiveId(CelestialForgingAnvilBlockEntity be) {
+        this.resolveLegacyIdentity(be);
+        return this.activeMegastructureId;
     }
 
     @Nullable
     public IMegastructureHandler getActiveHandler(CelestialForgingAnvilBlockEntity be) {
-        if (this.activeMegastructureName == null) {
-            this.getActiveOption(be);
-        }
-        return this.activeMegastructureName == null ? null : this.handlers.get(this.activeMegastructureName);
+        Identifier id = this.getActiveId(be);
+        return id == null ? null : this.handlers.get(id);
     }
 
     @Nullable
     public CelestialRefactorOption getActiveOption(CelestialForgingAnvilBlockEntity be) {
-        if (this.activeMegastructureIndex < 0) return null;
-        if (this.activeMegastructureName != null) {
-            for (CelestialRefactorOption option : CelestialRefactorRegistry.getOptionsForRing(0, 6)) {
-                if (option.megastructure().equals(this.activeMegastructureName)
-                    && option.ring() == this.activeMegastructureRing) {
-                    return option;
-                }
-            }
-        }
-        if (be.getCelestialBodyData() == null) return null;
-        var options = CelestialRefactorRegistry.getOptions(
+        Identifier id = this.getActiveId(be);
+        if (id == null) return null;
+        return CelestialRefactorRegistry.getOption(
+            id,
             be.getCelestialBodyData(),
             be.isAmplify(),
             be.getPlanetaryResourceSet()
         );
-        if (this.activeMegastructureIndex >= options.size()) return null;
-        CelestialRefactorOption option = options.get(this.activeMegastructureIndex);
-        this.activeMegastructureName = option.megastructure();
-        this.activeMegastructureRing = option.ring();
-        return option;
     }
 
     @Nullable
     @SuppressWarnings("unchecked")
     public <T extends IMegastructureHandler> T findHandler(Class<T> type) {
-        for (var handler : this.handlers.values()) {
+        for (IMegastructureHandler handler : this.handlers.values()) {
             if (type.isInstance(handler)) return (T) handler;
         }
         return null;
@@ -107,22 +89,22 @@ public class CfaMegastructureManager {
         );
     }
 
-    // ==================== 巨构刻逻辑 ====================
-
     public void serverTick(CelestialForgingAnvilBlockEntity be) {
-        if (this.activeMegastructureIndex >= 0) {
+        if (this.hasActiveMegastructure()) {
             IMegastructureHandler active = this.getActiveHandler(be);
             if (active != null) {
                 active.serverTick(be);
             }
             this.syncLaserRequirements(be);
         }
-        if (this.acceleratorHandler.isActive()) {
-            this.acceleratorHandler.serverTick(be);
+        for (Megastructure megastructure : ModRegistries.MEGASTRUCTURE) {
+            if (!megastructure.auxiliary()) continue;
+            IMegastructureHandler handler = this.handlers.get(megastructure.id());
+            if (handler != null) {
+                handler.serverTick(be);
+            }
         }
     }
-
-    // ==================== 激光需求 ====================
 
     public void syncLaserRequirements(CelestialForgingAnvilBlockEntity be) {
         IMegastructureHandler active = this.getActiveHandler(be);
@@ -144,92 +126,86 @@ public class CfaMegastructureManager {
         }
     }
 
-    // ==================== 建造与清除 ====================
-
-    public void buildMegastructure(int optionIndex, CelestialForgingAnvilBlockEntity be) {
-        var body = be.getCelestialBodyData();
-        if (body == null) return;
-        var options = be.getClientVisibleOptions();
-        if (optionIndex < 0 || optionIndex >= options.size()) return;
-        CelestialRefactorOption option = options.get(optionIndex);
-        if ("stellar_evolution_accelerator".equals(option.megastructure())) {
-            this.acceleratorHandler.onBuild(be);
+    public void buildMegastructure(CelestialRefactorOption option, CelestialForgingAnvilBlockEntity be) {
+        IMegastructureHandler handler = this.handlers.get(option.id());
+        if (option.auxiliary()) {
+            if (handler != null) {
+                handler.onBuild(be);
+            }
             return;
         }
-        if (this.activeMegastructureIndex >= 0) return;
-        this.activeMegastructureIndex = optionIndex;
-        this.activeMegastructureName = option.megastructure();
-        this.activeMegastructureRing = option.ring();
-        IMegastructureHandler handler = this.handlers.get(option.megastructure());
+        if (this.hasActiveMegastructure()) return;
+        this.activeMegastructureId = option.id();
+        this.clearLegacyIdentity();
         if (handler != null) {
             handler.onBuild(be);
         }
     }
 
     public void clearMegastructure(CelestialForgingAnvilBlockEntity be) {
-        if (this.activeMegastructureIndex >= 0) {
+        if (this.hasActiveMegastructure()) {
             IMegastructureHandler handler = this.getActiveHandler(be);
             if (handler != null) {
                 handler.onClear(be);
             }
         }
-        this.activeMegastructureIndex = -1;
-        this.activeMegastructureName = null;
-        this.activeMegastructureRing = -1;
+        this.activeMegastructureId = null;
+        this.clearLegacyIdentity();
         this.clearAllLaserRequirements(be);
     }
 
     public void clearAllMegastructures(CelestialForgingAnvilBlockEntity be) {
-        this.acceleratorHandler.onClear(be);
+        for (Megastructure megastructure : ModRegistries.MEGASTRUCTURE) {
+            if (!megastructure.auxiliary()) continue;
+            IMegastructureHandler handler = this.handlers.get(megastructure.id());
+            if (handler != null) {
+                handler.onClear(be);
+            }
+        }
         this.clearMegastructure(be);
     }
 
-    // ==================== 磁盘持久化 ====================
-
     public void saveAdditional(ValueOutput output) {
-        output.putInt("activeMegastructure", this.activeMegastructureIndex);
-        this.saveActiveIdentity(output);
-        for (var handler : this.handlers.values()) {
+        if (this.activeMegastructureId != null) {
+            output.putString("activeMegastructureId", this.activeMegastructureId.toString());
+        }
+        for (IMegastructureHandler handler : this.handlers.values()) {
             handler.saveAdditional(output);
         }
-        this.acceleratorHandler.saveAdditional(output);
     }
 
     public void loadAdditional(ValueInput input) {
-        this.activeMegastructureIndex = input.getIntOr("activeMegastructure", -1);
-        this.loadActiveIdentity(input);
-        for (var handler : this.handlers.values()) {
+        this.loadActiveIdentity(
+            input.getStringOr("activeMegastructureId", ""),
+            input.getStringOr("activeMegastructureName", ""),
+            input.getIntOr("activeMegastructureRing", -1),
+            input.getIntOr("activeMegastructure", -1)
+        );
+        for (IMegastructureHandler handler : this.handlers.values()) {
             handler.loadAdditional(input);
         }
-        this.acceleratorHandler.loadAdditional(input);
     }
 
-    // ==================== 基于 CompoundTag 的网络同步 ====================
-
     public void writeUpdateTag(CompoundTag tag, HolderLookup.Provider registries) {
-        tag.putInt("activeMegastructure", this.activeMegastructureIndex);
-        if (this.activeMegastructureName != null) {
-            tag.putString("activeMegastructureName", this.activeMegastructureName);
-            tag.putInt("activeMegastructureRing", this.activeMegastructureRing);
+        if (this.activeMegastructureId != null) {
+            tag.putString("activeMegastructureId", this.activeMegastructureId.toString());
         }
-        for (var handler : this.handlers.values()) {
+        for (IMegastructureHandler handler : this.handlers.values()) {
             handler.writeUpdateTag(tag, registries);
         }
-        this.acceleratorHandler.writeUpdateTag(tag, registries);
     }
 
     public void readUpdateTag(CompoundTag tag, HolderLookup.Provider registries) {
-        this.activeMegastructureIndex = tag.getIntOr("activeMegastructure", -1);
-        String activeName = tag.getStringOr("activeMegastructureName", "");
-        this.activeMegastructureName = activeName.isEmpty() ? null : activeName;
-        this.activeMegastructureRing = tag.getIntOr("activeMegastructureRing", -1);
-        for (var handler : this.handlers.values()) {
+        this.loadActiveIdentity(
+            tag.getStringOr("activeMegastructureId", ""),
+            tag.getStringOr("activeMegastructureName", ""),
+            tag.getIntOr("activeMegastructureRing", -1),
+            tag.getIntOr("activeMegastructure", -1)
+        );
+        for (IMegastructureHandler handler : this.handlers.values()) {
             handler.readUpdateTag(tag, registries);
         }
-        this.acceleratorHandler.readUpdateTag(tag, registries);
     }
-
-    // ==================== 电力 ====================
 
     public int getInputPower(CelestialForgingAnvilBlockEntity be) {
         IMegastructureHandler handler = this.getActiveHandler(be);
@@ -241,13 +217,14 @@ public class CfaMegastructureManager {
         return handler != null ? handler.getOutputPower(be) : 0;
     }
 
-    /** 戴森球在恒星演化第一阶段是否正在提供无限电力。 */
+    /** Returns whether a Dyson sphere is supplying unlimited power during stellar acceleration. */
     public boolean isInfinitePower(CelestialForgingAnvilBlockEntity be) {
         if (!be.isAcceleratorActive() || be.getAcceleratorStage() != 1 || !be.isAmplifierPresent()) {
             return false;
         }
-        CelestialRefactorOption option = this.getActiveOption(be);
-        return option != null && option.megastructure().contains("dyson_sphere");
+        Identifier id = this.getActiveId(be);
+        return ModMegastructures.DYSON_SPHERE_SMALL.getId().equals(id)
+            || ModMegastructures.DYSON_SPHERE_LARGE.getId().equals(id);
     }
 
     public PowerComponentType getComponentType(CelestialForgingAnvilBlockEntity be) {
@@ -259,18 +236,53 @@ public class CfaMegastructureManager {
     public void gridTick(CelestialForgingAnvilBlockEntity be) {
         IMegastructureHandler handler = this.getActiveHandler(be);
         if (handler != null) handler.gridTick(be);
-        this.acceleratorHandler.gridTick(be);
+        for (Megastructure megastructure : ModRegistries.MEGASTRUCTURE) {
+            if (!megastructure.auxiliary()) continue;
+            IMegastructureHandler auxiliary = this.handlers.get(megastructure.id());
+            if (auxiliary != null) auxiliary.gridTick(be);
+        }
     }
 
-    private void saveActiveIdentity(ValueOutput output) {
-        if (this.activeMegastructureName == null) return;
-        output.putString("activeMegastructureName", this.activeMegastructureName);
-        output.putInt("activeMegastructureRing", this.activeMegastructureRing);
+    private void resolveLegacyIdentity(CelestialForgingAnvilBlockEntity be) {
+        if (this.activeMegastructureId != null) return;
+        if (this.legacyActiveMegastructureName != null) {
+            this.activeMegastructureId = CelestialRefactorRegistry.findLegacyId(
+                this.legacyActiveMegastructureName,
+                this.legacyActiveMegastructureRing,
+                be.getCelestialBodyData(),
+                be.isAmplify(),
+                be.getPlanetaryResourceSet()
+            );
+        }
+        if (this.activeMegastructureId == null && this.legacyActiveMegastructureIndex >= 0) {
+            var options = CelestialRefactorRegistry.getOptions(
+                be.getCelestialBodyData(),
+                be.isAmplify(),
+                be.getPlanetaryResourceSet()
+            );
+            if (this.legacyActiveMegastructureIndex < options.size()) {
+                this.activeMegastructureId = options.get(this.legacyActiveMegastructureIndex).id();
+            }
+        }
+        if (this.activeMegastructureId != null) {
+            this.clearLegacyIdentity();
+        }
     }
 
-    private void loadActiveIdentity(ValueInput input) {
-        String activeName = input.getStringOr("activeMegastructureName", "");
-        this.activeMegastructureName = activeName.isEmpty() ? null : activeName;
-        this.activeMegastructureRing = input.getIntOr("activeMegastructureRing", -1);
+    private void loadActiveIdentity(String id, String legacyName, int legacyRing, int legacyIndex) {
+        this.activeMegastructureId = id.isEmpty() ? null : Identifier.tryParse(id);
+        if (this.activeMegastructureId != null) {
+            this.clearLegacyIdentity();
+            return;
+        }
+        this.legacyActiveMegastructureName = legacyName.isEmpty() ? null : legacyName;
+        this.legacyActiveMegastructureRing = legacyRing;
+        this.legacyActiveMegastructureIndex = legacyIndex;
+    }
+
+    private void clearLegacyIdentity() {
+        this.legacyActiveMegastructureName = null;
+        this.legacyActiveMegastructureRing = -1;
+        this.legacyActiveMegastructureIndex = -1;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorOption.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorOption.java
@@ -2,53 +2,44 @@ package dev.dubhe.anvilcraft.block.entity.celestial;
 
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.ItemLike;
 
-/**
- * 束星环的巨构重构选项，每个选项把指定环改造为一种巨构。
- *
- * @param ring          要重构的环编号（R1-R6）
- * @param megastructure 巨构模型名称后缀
- * @param modelLocation 巨构模型资源标识
- * @param displayName   巨构显示名称翻译键
- * @param material      所需建材；不需要时为 {@link ItemStack#EMPTY}
- * @param materialCount 所需建材数量
- */
+/** A megastructure definition resolved for one celestial body. */
 public record CelestialRefactorOption(
+    Megastructure definition,
+    Megastructure.Context context,
     int ring,
-    String megastructure,
     Identifier modelLocation,
     String displayName,
     ItemStack material,
     int materialCount
 ) {
-    /** 创建不需要建材的重构选项。 */
-    public static CelestialRefactorOption noMaterial(
-        int ring, String megastructure, Identifier modelLocation, String displayName
-    ) {
+    public static CelestialRefactorOption resolve(Megastructure definition, Megastructure.Context context) {
+        int ring = definition.ring(context);
         return new CelestialRefactorOption(
-            ring, megastructure, modelLocation, displayName, ItemStack.EMPTY, 0
+            definition,
+            context,
+            ring,
+            definition.modelLocation(ring),
+            definition.displayName(),
+            definition.material(),
+            definition.materialCount()
         );
     }
 
-    /**
-     * 创建需要指定建材的重构选项。
-     *
-     * @param ring          环编号（1-6）
-     * @param megastructure 巨构名称后缀
-     * @param modelLocation 模型资源标识
-     * @param displayName   显示名称翻译键
-     * @param material      所需物品
-     * @param materialCount 所需数量
-     */
-    public static CelestialRefactorOption withMaterial(
-        int ring, String megastructure, Identifier modelLocation, String displayName,
-        ItemLike material, int materialCount
-    ) {
-        return new CelestialRefactorOption(
-            ring, megastructure, modelLocation, displayName,
-            new ItemStack(material), materialCount
-        );
+    public Identifier id() {
+        return this.definition.id();
+    }
+
+    public String megastructure() {
+        return this.definition.name();
+    }
+
+    public boolean auxiliary() {
+        return this.definition.auxiliary();
+    }
+
+    public float rotation(float baseRotation, float bodyRotation) {
+        return this.definition.rotation(this.context, this.ring, baseRotation, bodyRotation);
     }
 
     public boolean needsMaterial() {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorRegistry.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/CelestialRefactorRegistry.java
@@ -1,289 +1,75 @@
 package dev.dubhe.anvilcraft.block.entity.celestial;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
-import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.init.registry.ModRegistries;
+import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
-import net.minecraft.world.item.Items;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * 根据天体数据生成束星环巨构重构选项。
- * 岩石行星、巨行星、小型恒星和大型恒星的最内环分别为 R1、R2、R4 和 R5；
- * 恒星大小以 48 为分界。巨构的工作/停机变体在世界中单独渲染，界面只显示主模型。
- */
+/** Resolves registered megastructures for a Celestial Forging Anvil context. */
 public final class CelestialRefactorRegistry {
-
     private CelestialRefactorRegistry() {
     }
 
-    /** 获取指定天体的最内环；增幅模式下最小为恒星尺度的 R4。 */
-    public static int getInnermostRing(CelestialBodyData body, boolean amplified) {
-        boolean isLarge = body.size() >= 48;
-        int ring = switch (body) {
-            case StarData ignored -> isLarge ? 5 : 4;
-            case GiantPlanetData ignored -> 2;
-            case RockyPlanetData ignored -> 1;
-            case SpecialCelestialBodyData s -> s.isErrorPlanet() ? 0 : 1;
-        };
-        if (amplified) {
-            ring = Math.max(ring, 4);
-        }
-        return ring;
-    }
-
-    /**
-     * 获取锁定天体可用的重构选项。普通锻星砧提供 R1-R2 巨构，增幅锻星砧提供 R4-R5 巨构。
-     *
-     * @param resources 天体资源集合，用于过滤依赖资源的巨构；为空时只按天体和环过滤
-     */
     public static List<CelestialRefactorOption> getOptions(
         @Nullable CelestialBodyData body,
         boolean amplified,
         @Nullable PlanetaryResourceSet resources
     ) {
         if (body == null) return Collections.emptyList();
-        // 错误行星不能建造巨构。
-        if (body instanceof SpecialCelestialBodyData s && s.isErrorPlanet()) {
-            return Collections.emptyList();
-        }
-        int innermostRing = CelestialRefactorRegistry.getInnermostRing(body, amplified);
-        int maxRing = amplified ? 5 : 2;
-        List<CelestialRefactorOption> options = CelestialRefactorRegistry.getOptionsForRing(innermostRing, maxRing);
-
-        // 行星开采器要求岩石或特殊行星拥有液体。
-        if (!CelestialRefactorRegistry.hasLiquid(body)) {
-            options.removeIf(opt -> "planet_exctractor".equals(opt.megastructure()));
-        }
-
-        // 巨行星抽取器仅适用于巨行星。
-        if (!(body instanceof GiantPlanetData)) {
-            options.removeIf(opt -> "giant_planet_exctractor".equals(opt.megastructure()));
-        }
-
-        // 星环对撞机仅适用于小型普通恒星，黑洞和中子星不能建造。
-        if (!(body instanceof StarData star && star.size() < 48
-            && star.bodyClass() != CelestialBodyClass.NEUTRON_STAR
-            && star.bodyClass() != CelestialBodyClass.BLACK_HOLE)) {
-            options.removeIf(opt -> "stellar_ring_collider".equals(opt.megastructure()));
-        }
-
-        // 恒星残骸不能建造恒星演化加速器。
-        if (body instanceof StarData star
-            && (star.bodyClass() == CelestialBodyClass.WHITE_DWARF
-                || star.bodyClass() == CelestialBodyClass.NEUTRON_STAR
-                || star.bodyClass() == CelestialBodyClass.BLACK_HOLE)) {
-            options.removeIf(opt -> "stellar_evolution_accelerator".equals(opt.megastructure()));
-        }
-
-        // 磁星线圈仅适用于中子星。
-        if (!(body instanceof StarData star && star.bodyClass() == CelestialBodyClass.NEUTRON_STAR)) {
-            options.removeIf(opt -> "magnetar_coil".equals(opt.megastructure()));
-        }
-
-        // 小型恒星使用 R5 加速器模型，大型恒星使用 R6 模型。
-        if (body instanceof StarData star) {
-            boolean isLarge = star.size() >= 48;
-            options.removeIf(opt -> "stellar_evolution_accelerator".equals(opt.megastructure())
-                && ((isLarge && opt.ring() == 5) || (!isLarge && opt.ring() == 6)));
-        }
-
-        // 戴森球仅适用于普通恒星；黑洞、中子星和行星均不可建造。
-        if (!(body instanceof StarData star
-            && star.bodyClass() != CelestialBodyClass.NEUTRON_STAR
-            && star.bodyClass() != CelestialBodyClass.BLACK_HOLE)) {
-            options.removeIf(opt -> "dyson_sphere_small".equals(opt.megastructure())
-                || "dyson_sphere_large".equals(opt.megastructure()));
-        } else {
-            boolean isLarge = star.size() >= 48;
-            options.removeIf(opt -> "dyson_sphere_small".equals(opt.megastructure()) && isLarge);
-            options.removeIf(opt -> "dyson_sphere_large".equals(opt.megastructure()) && !isLarge);
-        }
-
-        // 彭罗斯球仅适用于黑洞。
-        if (!(body instanceof StarData star && star.bodyClass() == CelestialBodyClass.BLACK_HOLE)) {
-            options.removeIf(opt -> "penrose_sphere".equals(opt.megastructure()));
-        }
-
-        // 虫洞稳定器仅适用于增幅模式下的黑洞。
-        if (!(body instanceof StarData star && star.bodyClass() == CelestialBodyClass.BLACK_HOLE && amplified)) {
-            options.removeIf(opt -> "wormhole_stabilizer".equals(opt.megastructure()));
-        }
-
-        // 物质解压器仅适用于中子星或黑洞。
-        if (!(body instanceof StarData star
-            && (star.bodyClass() == CelestialBodyClass.NEUTRON_STAR
-                || star.bodyClass() == CelestialBodyClass.BLACK_HOLE))) {
-            options.removeIf(opt -> "matter_decompressor".equals(opt.megastructure()));
-        }
-
-        // 生态站要求存在生物资源且没有低级文明。
-        if (resources != null) {
-            options.removeIf(opt -> "eco_station".equals(opt.megastructure())
-                && !CelestialRefactorRegistry.isEcoStationEligible(resources));
-            // 神庙要求存在低级文明。
-            options.removeIf(opt -> "temple".equals(opt.megastructure())
-                && !resources.hasCivilization());
-        }
-
-        return options;
-    }
-
-    /** 判断天体资源是否满足生态站建造条件。 */
-    private static boolean hasLiquid(CelestialBodyData body) {
-        if (body instanceof RockyPlanetData rocky) return rocky.liquidCoverage() != LiquidCoverage.NONE;
-        if (body instanceof SpecialCelestialBodyData s) {
-            LiquidCoverage lc = s.liquidCoverage();
-            return lc != null && lc != LiquidCoverage.NONE;
-        }
-        return false;
-    }
-
-    private static boolean isEcoStationEligible(PlanetaryResourceSet resources) {
-        if (resources.hasCivilization()) return false;
-        return !resources.getBiologicalItems().isEmpty()
-            || !resources.getBiologicalFluids().isEmpty();
-    }
-
-    /** 获取环范围 [innermostRing, maxRing] 内的巨构选项，内环可建造外环对应巨构。 */
-    public static List<CelestialRefactorOption> getOptionsForRing(int innermostRing, int maxRing) {
+        Megastructure.Context context = new Megastructure.Context(body, amplified, resources);
         List<CelestialRefactorOption> options = new ArrayList<>();
-        String prefix = "screen.anvilcraft.cfa.megastructure.";
-
-        if (innermostRing <= 1 && 1 <= maxRing) {
-            // R1 巨构，主要用于小型岩石行星。
-            options.add(CelestialRefactorOption.withMaterial(
-                1,
-                "planet_excavator",
-                CelestialRefactorRegistry.ringModel(1, "excavator"),
-                prefix + "planet_excavator",
-                ModBlocks.RUBY_PRISM.asItem(),
-                16
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                1,
-                "planet_exctractor",
-                CelestialRefactorRegistry.ringModel(1, "exctractor"),
-                prefix + "planet_exctractor",
-                ModBlocks.PUMP.asItem(),
-                16
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                1,
-                "eco_station",
-                CelestialRefactorRegistry.ringModel(1, "eco_station"),
-                prefix + "eco_station",
-                ModBlocks.TEMPERING_GLASS.asItem(),
-                64
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                1,
-                "temple",
-                CelestialRefactorRegistry.ringModel(1, "temple"),
-                prefix + "temple",
-                Items.GOLD_BLOCK,
-                64
-            ));
-        }
-        if (innermostRing <= 2 && 2 <= maxRing) {
-            // R2 巨构，主要用于小型巨行星。
-            options.add(CelestialRefactorOption.withMaterial(
-                2,
-                "giant_planet_exctractor",
-                CelestialRefactorRegistry.ringModel(2, "exctractor"),
-                prefix + "giant_planet_exctractor",
-                ModBlocks.PUMP.asItem(),
-                32
-            ));
-        }
-        if (innermostRing <= 4 && 4 <= maxRing) {
-            // R4 巨构，主要用于小型恒星和致密天体。
-            options.add(CelestialRefactorOption.withMaterial(
-                4,
-                "stellar_ring_collider",
-                CelestialRefactorRegistry.ringModel(4, "collider"),
-                prefix + "stellar_ring_collider",
-                ModItems.STELLAR_RING_COMPONENT,
-                8
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                4,
-                "dyson_sphere_small",
-                CelestialRefactorRegistry.ringModel(4, "dyson_sphere"),
-                prefix + "dyson_sphere_small",
-                ModItems.DYSON_SPHERE_COMPONENT,
-                16
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                4,
-                "magnetar_coil",
-                CelestialRefactorRegistry.ringModel(4, "coil"),
-                prefix + "magnetar_coil",
-                ModItems.MAGNETAR_COIL_COMPONENT,
-                4
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                4,
-                "penrose_sphere",
-                CelestialRefactorRegistry.ringModel(4, "penrose_sphere"),
-                prefix + "penrose_sphere",
-                ModItems.PENROSE_SPHERE_COMPONENT,
-                8
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                4,
-                "matter_decompressor",
-                CelestialRefactorRegistry.ringModel(4, "matter_decompressor"),
-                prefix + "matter_decompressor",
-                ModItems.MATTER_DECOMPRESSOR_COMPONENT,
-                2
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                4,
-                "wormhole_stabilizer",
-                CelestialRefactorRegistry.ringModel(4, "wormhole_stabilizer"),
-                prefix + "wormhole_stabilizer",
-                ModItems.WORMHOLE_STABILIZER_COMPONENT,
-                4
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                5,
-                "stellar_evolution_accelerator",
-                CelestialRefactorRegistry.ringModel(5, "stellar_evolution_accelerator"),
-                prefix + "stellar_evolution_accelerator",
-                ModItems.STELLAR_EVOLUTION_ACCELERATOR_COMPONENT,
-                8
-            ));
-        }
-        if (innermostRing <= 5 && 5 <= maxRing) {
-            // R5 巨构，主要用于大型恒星。
-            options.add(CelestialRefactorOption.withMaterial(
-                5,
-                "dyson_sphere_large",
-                CelestialRefactorRegistry.ringModel(5, "dyson_sphere"),
-                prefix + "dyson_sphere_large",
-                ModItems.DYSON_SPHERE_COMPONENT,
-                32
-            ));
-            options.add(CelestialRefactorOption.withMaterial(
-                6,
-                "stellar_evolution_accelerator",
-                CelestialRefactorRegistry.ringModel(6, "stellar_evolution_accelerator"),
-                prefix + "stellar_evolution_accelerator",
-                ModItems.STELLAR_EVOLUTION_ACCELERATOR_COMPONENT,
-                8
-            ));
+        for (Megastructure megastructure : ModRegistries.MEGASTRUCTURE) {
+            if (!megastructure.isAvailable(context)) continue;
+            int ring = megastructure.ring(context);
+            if (!CelestialRefactorRegistry.isRingSupported(ring, amplified)) continue;
+            options.add(CelestialRefactorOption.resolve(megastructure, context));
         }
         return options;
     }
 
-    private static Identifier ringModel(int ring, String megastructure) {
-        return AnvilCraft.of(
-            "block/celestial_forging_anvil_ring_" + ring + "_" + megastructure
+    public static @Nullable CelestialRefactorOption getOption(
+        Identifier id,
+        @Nullable CelestialBodyData body,
+        boolean amplified,
+        @Nullable PlanetaryResourceSet resources
+    ) {
+        if (body == null) return null;
+        Megastructure megastructure = CelestialRefactorRegistry.get(id);
+        if (megastructure == null) return null;
+        return CelestialRefactorOption.resolve(
+            megastructure,
+            new Megastructure.Context(body, amplified, resources)
         );
+    }
+
+    public static @Nullable Megastructure get(Identifier id) {
+        return ModRegistries.MEGASTRUCTURE.get(id).map(Holder.Reference::value).orElse(null);
+    }
+
+    public static @Nullable Identifier findLegacyId(
+        String name,
+        int ring,
+        @Nullable CelestialBodyData body,
+        boolean amplified,
+        @Nullable PlanetaryResourceSet resources
+    ) {
+        Megastructure.Context context = body == null ? null : new Megastructure.Context(body, amplified, resources);
+        Identifier nameMatch = null;
+        for (Megastructure megastructure : ModRegistries.MEGASTRUCTURE) {
+            if (!megastructure.name().equals(name)) continue;
+            nameMatch = megastructure.id();
+            if (context != null && megastructure.ring(context) == ring) {
+                return megastructure.id();
+            }
+        }
+        return nameMatch;
+    }
+
+    private static boolean isRingSupported(int ring, boolean amplified) {
+        return amplified ? ring >= 4 && ring <= 6 : ring >= 1 && ring <= 2;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/Megastructure.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/Megastructure.java
@@ -1,0 +1,204 @@
+package dev.dubhe.anvilcraft.block.entity.celestial;
+
+import dev.dubhe.anvilcraft.block.entity.megastructure.IMegastructureHandler;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+
+/**
+ * Code-registered definition of a Celestial Forging Anvil megastructure.
+ */
+public final class Megastructure {
+    private final Identifier id;
+    private final String name;
+    private final String displayName;
+    private final Prerequisite prerequisite;
+    private final ToIntFunction<Context> ringFunction;
+    private final RotationFunction rotationFunction;
+    private final Map<Integer, Identifier> modelLocations;
+    private final @Nullable ItemLike material;
+    private final int materialCount;
+    private final Supplier<? extends IMegastructureHandler> handlerFactory;
+    private final boolean auxiliary;
+
+    private Megastructure(Builder builder) {
+        this.id = builder.id;
+        this.name = builder.name;
+        this.displayName = builder.displayName;
+        this.prerequisite = builder.prerequisite;
+        this.ringFunction = Objects.requireNonNull(builder.ringFunction, "Megastructure ring function was not set");
+        this.rotationFunction = builder.rotationFunction;
+        this.modelLocations = Collections.unmodifiableMap(new LinkedHashMap<>(builder.modelLocations));
+        this.material = builder.material;
+        this.materialCount = builder.materialCount;
+        this.handlerFactory = Objects.requireNonNull(builder.handlerFactory, "Megastructure handler factory was not set");
+        this.auxiliary = builder.auxiliary;
+        if (this.modelLocations.isEmpty()) {
+            throw new IllegalStateException("Megastructure must provide at least one model: " + this.id);
+        }
+    }
+
+    public static Builder builder(Identifier id, String name) {
+        return new Builder(id, name);
+    }
+
+    public Identifier id() {
+        return this.id;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public String displayName() {
+        return this.displayName;
+    }
+
+    public Map<Integer, Identifier> modelLocations() {
+        return this.modelLocations;
+    }
+
+    public ItemStack material() {
+        return this.material == null ? ItemStack.EMPTY : new ItemStack(this.material);
+    }
+
+    public int materialCount() {
+        return this.materialCount;
+    }
+
+    public boolean auxiliary() {
+        return this.auxiliary;
+    }
+
+    public boolean isAvailable(Context context) {
+        return this.prerequisite.test(context);
+    }
+
+    public int ring(Context context) {
+        return this.ringFunction.applyAsInt(context);
+    }
+
+    public Identifier modelLocation(int ring) {
+        Identifier location = this.modelLocations.get(ring);
+        if (location == null) {
+            throw new IllegalStateException("No model registered for megastructure " + this.id + " on ring " + ring);
+        }
+        return location;
+    }
+
+    public float rotation(Context context, int ring, float baseRotation, float bodyRotation) {
+        return this.rotationFunction.apply(new RotationContext(context.body(), ring, baseRotation, bodyRotation));
+    }
+
+    public IMegastructureHandler createHandler() {
+        return this.handlerFactory.get();
+    }
+
+    public record Context(
+        CelestialBodyData body,
+        boolean amplified,
+        @Nullable PlanetaryResourceSet resources
+    ) {
+    }
+
+    public record RotationContext(
+        CelestialBodyData body,
+        int ring,
+        float baseRotation,
+        float bodyRotation
+    ) {
+    }
+
+    @FunctionalInterface
+    public interface Prerequisite {
+        boolean test(Context context);
+    }
+
+    @FunctionalInterface
+    public interface RotationFunction {
+        float apply(RotationContext context);
+    }
+
+    public static final class Builder {
+        private final Identifier id;
+        private final String name;
+        private String displayName;
+        private Prerequisite prerequisite = context -> true;
+        private @Nullable ToIntFunction<Context> ringFunction;
+        private RotationFunction rotationFunction = RotationContext::baseRotation;
+        private final Map<Integer, Identifier> modelLocations = new LinkedHashMap<>();
+        private @Nullable ItemLike material;
+        private int materialCount;
+        private @Nullable Supplier<? extends IMegastructureHandler> handlerFactory;
+        private boolean auxiliary;
+
+        private Builder(Identifier id, String name) {
+            this.id = Objects.requireNonNull(id);
+            this.name = Objects.requireNonNull(name);
+            this.displayName = "screen.anvilcraft.cfa.megastructure." + name;
+        }
+
+        public Builder displayName(String displayName) {
+            this.displayName = Objects.requireNonNull(displayName);
+            return this;
+        }
+
+        public Builder prerequisite(Prerequisite prerequisite) {
+            this.prerequisite = Objects.requireNonNull(prerequisite);
+            return this;
+        }
+
+        public Builder ring(int ring) {
+            return this.ring(context -> ring);
+        }
+
+        public Builder ring(ToIntFunction<Context> ringFunction) {
+            this.ringFunction = Objects.requireNonNull(ringFunction);
+            return this;
+        }
+
+        public Builder rotation(RotationFunction rotationFunction) {
+            this.rotationFunction = Objects.requireNonNull(rotationFunction);
+            return this;
+        }
+
+        public Builder model(int ring, Identifier modelLocation) {
+            Identifier previous = this.modelLocations.put(ring, Objects.requireNonNull(modelLocation));
+            if (previous != null) {
+                throw new IllegalArgumentException("Duplicate model ring " + ring + " for megastructure " + this.id);
+            }
+            return this;
+        }
+
+        public Builder material(ItemLike material, int count) {
+            if (count <= 0) {
+                throw new IllegalArgumentException("Megastructure material count must be positive");
+            }
+            this.material = Objects.requireNonNull(material);
+            this.materialCount = count;
+            return this;
+        }
+
+        public Builder handler(Supplier<? extends IMegastructureHandler> handlerFactory) {
+            this.handlerFactory = Objects.requireNonNull(handlerFactory);
+            return this;
+        }
+
+        public Builder auxiliary() {
+            this.auxiliary = true;
+            return this;
+        }
+
+        public Megastructure build() {
+            return new Megastructure(this);
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/PlanetResourceGenerator.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/PlanetResourceGenerator.java
@@ -188,7 +188,7 @@ public final class PlanetResourceGenerator {
             PlanetResourceRecipe.GiantData gd = recipe.giantData();
             if (gd != null) {
                 for (PlanetResourceRecipe.WeightedEntry entry : gd.entries()) {
-                    set.addGiantItem(new PlanetaryResourceSet.WeightedItemStack(entry.resourceId(), entry.weight()));
+                    set.addGiantItem(new PlanetaryResourceSet.WeightedItemStack(entry.select(random), entry.weight()));
                 }
             }
         }
@@ -199,7 +199,7 @@ public final class PlanetResourceGenerator {
             PlanetResourceRecipe.GiantData gd = recipe.giantData();
             if (gd != null) {
                 for (PlanetResourceRecipe.WeightedEntry entry : gd.entries()) {
-                    set.addGiantFluid(new PlanetaryResourceSet.WeightedFluidStack(entry.resourceId(), entry.weight()));
+                    set.addGiantFluid(new PlanetaryResourceSet.WeightedFluidStack(entry.select(random), entry.weight()));
                 }
             }
         }
@@ -242,16 +242,7 @@ public final class PlanetResourceGenerator {
         if (random.nextInt(100) >= od.civilizationChance()) return false;
 
         for (PlanetResourceRecipe.WeightedEntry entry : od.entries()) {
-            Identifier id = entry.resourceId();
-            if ("anvilcraft:gem_amulet_random".equals(id.toString())) {
-                Identifier randomAmulet = PlanetResourceGenerator.pickRandomGemAmulet(random);
-                set.addOffering(new PlanetaryResourceSet.WeightedItemStack(randomAmulet, entry.weight()));
-            } else if ("anvilcraft:gem_block_random".equals(id.toString())) {
-                Identifier randomBlock = PlanetResourceGenerator.pickRandomGemBlock(random);
-                set.addOffering(new PlanetaryResourceSet.WeightedItemStack(randomBlock, entry.weight()));
-            } else {
-                set.addOffering(new PlanetaryResourceSet.WeightedItemStack(id, entry.weight()));
-            }
+            set.addOffering(new PlanetaryResourceSet.WeightedItemStack(entry.select(random), entry.weight()));
         }
         return true;
     }
@@ -314,7 +305,7 @@ public final class PlanetResourceGenerator {
         if (rocky.temperature() == Temperature.MILD && !isHighCoverage) {
             for (PlanetResourceRecipe.WeightedEntry entry : bd.mildExtraFluids()) {
                 if (random.nextInt(100) < entry.weight()) {
-                    set.addBiologicalFluid(new PlanetaryResourceSet.WeightedFluidStack(entry.resourceId(), 100));
+                    set.addBiologicalFluid(new PlanetaryResourceSet.WeightedFluidStack(entry.select(random), 100));
                 }
             }
         }
@@ -336,7 +327,7 @@ public final class PlanetResourceGenerator {
 
         set.setWasteland();
         for (PlanetResourceRecipe.WeightedEntry entry : wd.entries()) {
-            set.addWastelandItem(new PlanetaryResourceSet.WeightedItemStack(entry.resourceId(), entry.weight()));
+            set.addWastelandItem(new PlanetaryResourceSet.WeightedItemStack(entry.select(random), entry.weight()));
         }
     }
 
@@ -401,26 +392,6 @@ public final class PlanetResourceGenerator {
                 dropFrequencies.merge(entry.getKey(), weight, Integer::sum);
             }
         }
-    }
-
-    private static Identifier pickRandomGemAmulet(RandomSource random) {
-        List<Identifier> knownAmulets = List.of(
-            Identifier.parse("anvilcraft:emerald_amulet"),
-            Identifier.parse("anvilcraft:topaz_amulet"),
-            Identifier.parse("anvilcraft:ruby_amulet"),
-            Identifier.parse("anvilcraft:sapphire_amulet")
-        );
-        return knownAmulets.get(random.nextInt(knownAmulets.size()));
-    }
-
-    private static Identifier pickRandomGemBlock(RandomSource random) {
-        List<Identifier> knownBlocks = List.of(
-            Identifier.parse("minecraft:emerald_block"),
-            Identifier.parse("anvilcraft:topaz_block"),
-            Identifier.parse("anvilcraft:ruby_block"),
-            Identifier.parse("anvilcraft:sapphire_block")
-        );
-        return knownBlocks.get(random.nextInt(knownBlocks.size()));
     }
 
     private static Set<Identifier> buildItemBlacklist(HolderLookup.Provider registries, TagKey<Item> blacklistTag) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/PlanetResourceRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/celestial/PlanetResourceRecipe.java
@@ -1,13 +1,16 @@
 package dev.dubhe.anvilcraft.block.entity.celestial;
 
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.PlacementInfo;
@@ -16,11 +19,16 @@ import net.minecraft.world.item.crafting.RecipeBookCategories;
 import net.minecraft.world.item.crafting.RecipeBookCategory;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * 根据天体参数定义行星产出资源的配方。
@@ -59,24 +67,167 @@ public record PlanetResourceRecipe(
         }
     }
 
-    public record WeightedEntry(String id, int weight) {
-        public static final Codec<WeightedEntry> CODEC = RecordCodecBuilder.create(ins -> ins.group(
-                Codec.STRING.fieldOf("id")
-                    .forGetter(WeightedEntry::id), Codec.INT.fieldOf("weight").forGetter(WeightedEntry::weight)
-            )
-            .apply(ins, WeightedEntry::new));
+    public record WeightedChoice(String id, int weight) {
+        public static final Codec<WeightedChoice> CODEC = RecordCodecBuilder.create(ins -> ins.group(
+            Codec.STRING.fieldOf("id").forGetter(WeightedChoice::id),
+            Codec.INT.fieldOf("weight").forGetter(WeightedChoice::weight)
+        ).apply(ins, WeightedChoice::new));
 
-        public static final StreamCodec<RegistryFriendlyByteBuf, WeightedEntry> STREAM_CODEC = StreamCodec.composite(
+        public static final StreamCodec<RegistryFriendlyByteBuf, WeightedChoice> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.STRING_UTF8,
-            WeightedEntry::id,
+            WeightedChoice::id,
             ByteBufCodecs.INT,
-            WeightedEntry::weight,
-            WeightedEntry::new
+            WeightedChoice::weight,
+            WeightedChoice::new
         );
 
         public Identifier resourceId() {
             return Identifier.parse(this.id);
         }
+    }
+
+    public record WeightedEntry(List<WeightedChoice> choices, int weight) {
+        private record DirectEntry(String id, int weight) {
+            private static final Codec<DirectEntry> CODEC = RecordCodecBuilder.create(ins -> ins.group(
+                Codec.STRING.fieldOf("id").forGetter(DirectEntry::id),
+                Codec.INT.fieldOf("weight").forGetter(DirectEntry::weight)
+            ).apply(ins, DirectEntry::new));
+        }
+
+        private record ChoiceEntry(List<WeightedChoice> choices, int weight) {
+            private static final Codec<ChoiceEntry> CODEC = RecordCodecBuilder.create(ins -> ins.group(
+                WeightedChoice.CODEC.listOf().fieldOf("choices").forGetter(ChoiceEntry::choices),
+                Codec.INT.fieldOf("weight").forGetter(ChoiceEntry::weight)
+            ).apply(ins, ChoiceEntry::new));
+        }
+
+        public static final Codec<WeightedEntry> CODEC = Codec.either(DirectEntry.CODEC, ChoiceEntry.CODEC)
+            .xmap(
+                either -> either.map(
+                    direct -> new WeightedEntry(direct.id(), direct.weight()),
+                    choice -> new WeightedEntry(choice.choices(), choice.weight())
+                ),
+                entry -> entry.isDirect()
+                    ? Either.left(new DirectEntry(entry.choices().getFirst().id(), entry.weight()))
+                    : Either.right(new ChoiceEntry(entry.choices(), entry.weight()))
+            );
+
+        public static final StreamCodec<RegistryFriendlyByteBuf, WeightedEntry> STREAM_CODEC = StreamCodec.composite(
+            WeightedChoice.STREAM_CODEC.apply(ByteBufCodecs.list()),
+            WeightedEntry::choices,
+            ByteBufCodecs.INT,
+            WeightedEntry::weight,
+            WeightedEntry::new
+        );
+
+        public WeightedEntry {
+            choices = List.copyOf(choices);
+            if (choices.isEmpty()) {
+                throw new IllegalArgumentException("Planet resource entry must contain at least one choice");
+            }
+        }
+
+        public WeightedEntry(String id, int weight) {
+            this(List.of(new WeightedChoice(id, 1)), weight);
+        }
+
+        public boolean isDirect() {
+            return this.choices.size() == 1;
+        }
+
+        public Identifier select(RandomSource random) {
+            if (this.isDirect()) return this.choices.getFirst().resourceId();
+            int totalWeight = 0;
+            for (WeightedChoice choice : this.choices) {
+                totalWeight += Math.max(0, choice.weight());
+            }
+            if (totalWeight <= 0) return this.choices.getFirst().resourceId();
+            int selected = random.nextInt(totalWeight);
+            for (WeightedChoice choice : this.choices) {
+                selected -= Math.max(0, choice.weight());
+                if (selected < 0) return choice.resourceId();
+            }
+            return this.choices.getLast().resourceId();
+        }
+    }
+
+    public static List<WeightedEntry> entries(Consumer<EntriesBuilder> consumer) {
+        EntriesBuilder builder = new EntriesBuilder();
+        consumer.accept(builder);
+        return builder.build();
+    }
+
+    public static final class EntriesBuilder {
+        private final List<WeightedEntry> entries = new java.util.ArrayList<>();
+
+        public EntriesBuilder id(String id, int weight) {
+            return this.id(Identifier.parse(id), weight);
+        }
+
+        public EntriesBuilder id(Identifier id, int weight) {
+            this.entries.add(new WeightedEntry(id.toString(), requirePositive(weight)));
+            return this;
+        }
+
+        public EntriesBuilder item(ItemLike item, int weight) {
+            return this.id(BuiltInRegistries.ITEM.getKey(Objects.requireNonNull(item).asItem()), weight);
+        }
+
+        public EntriesBuilder fluid(Fluid fluid, int weight) {
+            return this.id(BuiltInRegistries.FLUID.getKey(Objects.requireNonNull(fluid)), weight);
+        }
+
+        public EntriesBuilder fluid(Supplier<? extends Fluid> fluid, int weight) {
+            return this.fluid(Objects.requireNonNull(fluid).get(), weight);
+        }
+
+        public EntriesBuilder chooseOne(int weight, Consumer<ChoiceBuilder> consumer) {
+            ChoiceBuilder builder = new ChoiceBuilder();
+            consumer.accept(builder);
+            this.entries.add(new WeightedEntry(builder.build(), requirePositive(weight)));
+            return this;
+        }
+
+        public List<WeightedEntry> build() {
+            return List.copyOf(this.entries);
+        }
+    }
+
+    public static final class ChoiceBuilder {
+        private final List<WeightedChoice> choices = new java.util.ArrayList<>();
+
+        public ChoiceBuilder id(String id, int weight) {
+            return this.id(Identifier.parse(id), weight);
+        }
+
+        public ChoiceBuilder id(Identifier id, int weight) {
+            this.choices.add(new WeightedChoice(id.toString(), requirePositive(weight)));
+            return this;
+        }
+
+        public ChoiceBuilder item(ItemLike item, int weight) {
+            return this.id(BuiltInRegistries.ITEM.getKey(Objects.requireNonNull(item).asItem()), weight);
+        }
+
+        public ChoiceBuilder fluid(Fluid fluid, int weight) {
+            return this.id(BuiltInRegistries.FLUID.getKey(Objects.requireNonNull(fluid)), weight);
+        }
+
+        public ChoiceBuilder fluid(Supplier<? extends Fluid> fluid, int weight) {
+            return this.fluid(Objects.requireNonNull(fluid).get(), weight);
+        }
+
+        private List<WeightedChoice> build() {
+            if (this.choices.isEmpty()) {
+                throw new IllegalStateException("Planet resource choice group cannot be empty");
+            }
+            return List.copyOf(this.choices);
+        }
+    }
+
+    private static int requirePositive(int weight) {
+        if (weight <= 0) throw new IllegalArgumentException("Planet resource weight must be positive");
+        return weight;
     }
 
     public record LifeChances(int cold, int hot, int mild) {
@@ -145,6 +296,24 @@ public record PlanetResourceRecipe(
             FluidData::outputFluid,
             FluidData::new
         );
+
+        public FluidData(String planetType, String temperature, String liquidMin, Fluid outputFluid) {
+            this(
+                planetType,
+                temperature,
+                liquidMin,
+                BuiltInRegistries.FLUID.getKey(Objects.requireNonNull(outputFluid)).toString()
+            );
+        }
+
+        public FluidData(
+            String planetType,
+            String temperature,
+            String liquidMin,
+            Supplier<? extends Fluid> outputFluid
+        ) {
+            this(planetType, temperature, liquidMin, Objects.requireNonNull(outputFluid).get());
+        }
     }
 
     public record GiantData(List<WeightedEntry> entries, String pressureType) {
@@ -233,6 +402,66 @@ public record PlanetResourceRecipe(
             WastelandData::wastelandChance,
             WastelandData::new
         );
+    }
+
+    public static Builder builder(Category category) {
+        return new Builder(category);
+    }
+
+    public static final class Builder {
+        private final Category category;
+        private Optional<MineralData> mineral = Optional.empty();
+        private Optional<FluidData> fluid = Optional.empty();
+        private Optional<GiantData> giant = Optional.empty();
+        private Optional<BiologicalData> biological = Optional.empty();
+        private Optional<OfferingData> offering = Optional.empty();
+        private Optional<WastelandData> wasteland = Optional.empty();
+
+        private Builder(Category category) {
+            this.category = Objects.requireNonNull(category);
+        }
+
+        public Builder mineral(MineralData mineral) {
+            this.mineral = Optional.of(Objects.requireNonNull(mineral));
+            return this;
+        }
+
+        public Builder fluid(FluidData fluid) {
+            this.fluid = Optional.of(Objects.requireNonNull(fluid));
+            return this;
+        }
+
+        public Builder giant(GiantData giant) {
+            this.giant = Optional.of(Objects.requireNonNull(giant));
+            return this;
+        }
+
+        public Builder biological(BiologicalData biological) {
+            this.biological = Optional.of(Objects.requireNonNull(biological));
+            return this;
+        }
+
+        public Builder offering(OfferingData offering) {
+            this.offering = Optional.of(Objects.requireNonNull(offering));
+            return this;
+        }
+
+        public Builder wasteland(WastelandData wasteland) {
+            this.wasteland = Optional.of(Objects.requireNonNull(wasteland));
+            return this;
+        }
+
+        public PlanetResourceRecipe build() {
+            return new PlanetResourceRecipe(
+                this.category,
+                this.mineral,
+                this.fluid,
+                this.giant,
+                this.biological,
+                this.offering,
+                this.wasteland
+            );
+        }
     }
 
     public static final MapCodec<PlanetResourceRecipe> CODEC = RecordCodecBuilder.mapCodec(ins -> ins.group(

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/megastructure/AcceleratorHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/megastructure/AcceleratorHandler.java
@@ -5,6 +5,7 @@ import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyClass;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyMatcher;
 import dev.dubhe.anvilcraft.block.entity.celestial.PlanetaryResourceSet;
 import dev.dubhe.anvilcraft.block.entity.celestial.StarData;
+import dev.dubhe.anvilcraft.init.ModMegastructures;
 import dev.dubhe.anvilcraft.network.ScreenShakePacket;
 import lombok.Getter;
 import lombok.Setter;
@@ -114,11 +115,8 @@ public class AcceleratorHandler extends BaseMegastructureHandler {
     }
 
     private boolean isDysonSphereBuilt(CelestialForgingAnvilBlockEntity be) {
-        if (be.getActiveMegastructureIndex() < 0) return false;
-        var option = be.getActiveMegastructureOption();
-        if (option == null) return false;
-        String name = option.megastructure();
-        return "dyson_sphere_small".equals(name) || "dyson_sphere_large".equals(name);
+        return ModMegastructures.DYSON_SPHERE_SMALL.getId().equals(be.getActiveMegastructureId())
+            || ModMegastructures.DYSON_SPHERE_LARGE.getId().equals(be.getActiveMegastructureId());
     }
 
     private void tickStage1(CelestialForgingAnvilBlockEntity be) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/megastructure/DysonSphereHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/megastructure/DysonSphereHandler.java
@@ -49,7 +49,7 @@ public class DysonSphereHandler extends BaseMegastructureHandler {
         if (be.getGrid() != null
             && be.isAcceleratorActive()
             && be.getAcceleratorStage() == 1
-            && be.getActiveMegastructureIndex() >= 0) {
+            && be.hasActiveMegastructure()) {
             this.cachedGridConsumption = be.getGrid().getConsume();
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/block/power/ring/AccelerationRingBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/power/ring/AccelerationRingBlock.java
@@ -66,8 +66,7 @@ public class AccelerationRingBlock
 
     public AccelerationRingBlock(Properties properties) {
         super(properties);
-        this.registerDefaultState(this.stateDefinition
-            .any()
+        this.registerDefaultState(this.defaultBlockState()
             .setValue(AccelerationRingBlock.HALF, DirectionCube3x3PartHalf.BOTTOM_CENTER)
             .setValue(AccelerationRingBlock.FACING, Direction.NORTH)
             .setValue(AccelerationRingBlock.OVERLOAD, true)

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/RegisterAdditionalEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/RegisterAdditionalEventListener.java
@@ -25,6 +25,7 @@ import dev.dubhe.anvilcraft.client.renderer.item.FluidTankItemRenderer;
 import dev.dubhe.anvilcraft.client.renderer.item.LargeFluidTankItemRenderer;
 import dev.dubhe.anvilcraft.client.renderer.item.SpectralSlingshotRenderer;
 import dev.dubhe.anvilcraft.client.renderer.item.SpectralWeaponLauncherRenderer;
+import dev.dubhe.anvilcraft.init.registry.ModRegistries;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.Identifier;
 import net.neoforged.api.distmarker.Dist;
@@ -35,6 +36,9 @@ import net.neoforged.neoforge.client.event.RegisterPictureInPictureRenderersEven
 import net.neoforged.neoforge.client.event.RegisterRenderBuffersEvent;
 import net.neoforged.neoforge.client.event.RegisterSpecialModelRendererEvent;
 import net.neoforged.neoforge.client.model.standalone.SimpleUnbakedStandaloneModel;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @EventBusSubscriber(modid = AnvilCraft.MOD_ID, value = Dist.CLIENT)
 public class RegisterAdditionalEventListener {
@@ -128,46 +132,21 @@ public class RegisterAdditionalEventListener {
             CFARenderer.RING6,
             SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_6"))
         );
-        // 锻星砧巨构模型。
-        event.register(
-            CFARenderer.R1_EXCAVATOR,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_1_excavator"))
-        );
+        // 注册项声明的锻星砧巨构主模型。
+        Set<Identifier> registeredMegastructureModels = new HashSet<>();
+        for (var megastructure : ModRegistries.MEGASTRUCTURE) {
+            for (Identifier modelLocation : megastructure.modelLocations().values()) {
+                if (!registeredMegastructureModels.add(modelLocation)) continue;
+                event.register(
+                    CFARenderer.getMegastructureModel(modelLocation),
+                    SimpleUnbakedStandaloneModel.blockStateModel(modelLocation)
+                );
+            }
+        }
+        // 带独立工作状态或拆分动画层的内置模型。
         event.register(
             CFARenderer.R1_EXCAVATOR_OFF,
             SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_1_excavator_off"))
-        );
-        event.register(
-            CFARenderer.R1_EXTRACTOR,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_1_exctractor"))
-        );
-        event.register(
-            CFARenderer.R2_EXTRACTOR,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_2_exctractor"))
-        );
-        event.register(
-            CFARenderer.R1_ECO_STATION,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_1_eco_station"))
-        );
-        event.register(
-            CFARenderer.R1_TEMPLE,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_1_temple"))
-        );
-        event.register(
-            CFARenderer.R4_COLLIDER,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_collider"))
-        );
-        event.register(
-            CFARenderer.R4_DYSON_SPHERE,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_dyson_sphere"))
-        );
-        event.register(
-            CFARenderer.R5_DYSON_SPHERE,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_5_dyson_sphere"))
-        );
-        event.register(
-            CFARenderer.R4_COIL,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_coil"))
         );
         event.register(
             CFARenderer.R4_COIL_FIX,
@@ -176,12 +155,6 @@ public class RegisterAdditionalEventListener {
         event.register(
             CFARenderer.R4_COIL_RING,
             SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_coil_ring"))
-        );
-        event.register(
-            CFARenderer.R4_PENROSE_SPHERE,
-            SimpleUnbakedStandaloneModel.blockStateModel(
-                AnvilCraft.of("block/celestial_forging_anvil_ring_4_penrose_sphere")
-            )
         );
         event.register(
             CFARenderer.R4_PENROSE_SPHERE_FIX,
@@ -196,34 +169,12 @@ public class RegisterAdditionalEventListener {
             SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_penrose_sphere_laser_off"))
         );
         event.register(
-            CFARenderer.R4_MATTER_DECOMPRESSOR,
-            SimpleUnbakedStandaloneModel.blockStateModel(
-                AnvilCraft.of("block/celestial_forging_anvil_ring_4_matter_decompressor")
-            )
-        );
-        event.register(
             CFARenderer.R4_MATTER_DECOMPRESSOR_FIX,
             SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_matter_decompressor_fix"))
         );
         event.register(
             CFARenderer.R4_MATTER_DECOMPRESSOR_RING,
             SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_matter_decompressor_ring"))
-        );
-        event.register(
-            CFARenderer.R4_WORMHOLE_STABILIZER,
-            SimpleUnbakedStandaloneModel.blockStateModel(AnvilCraft.of("block/celestial_forging_anvil_ring_4_wormhole_stabilizer"))
-        );
-        event.register(
-            CFARenderer.R5_ACCELERATOR,
-            SimpleUnbakedStandaloneModel.blockStateModel(
-                AnvilCraft.of("block/celestial_forging_anvil_ring_5_stellar_evolution_accelerator")
-            )
-        );
-        event.register(
-            CFARenderer.R6_ACCELERATOR,
-            SimpleUnbakedStandaloneModel.blockStateModel(
-                AnvilCraft.of("block/celestial_forging_anvil_ring_6_stellar_evolution_accelerator")
-            )
         );
         // 锻星砧天体模型。
         event.register(

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CelestialForgingAnvilScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CelestialForgingAnvilScreen.java
@@ -989,7 +989,7 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
     private void renderRefactorSection(GuiGraphicsExtractor g, int guiLeft, int guiTop, int relX, int relY) {
         CelestialBodyData body = getMenu().getBlockEntity().getCelestialBodyData();
         boolean hasAcceleratorActive = getMenu().getBlockEntity().isAcceleratorActive();
-        boolean hasMegastructure = getMenu().getBlockEntity().getActiveMegastructureIndex() >= 0;
+        boolean hasMegastructure = getMenu().getBlockEntity().hasActiveMegastructure();
         CelestialRefactorOption activeOption = hasMegastructure
             ? getMenu().getBlockEntity().getActiveMegastructureOption()
             : null;
@@ -1005,7 +1005,7 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
             );
             if (hasMegastructure) {
                 this.refactorOptions = this.refactorOptions.stream()
-                    .filter(opt -> "stellar_evolution_accelerator".equals(opt.megastructure()))
+                    .filter(CelestialRefactorOption::auxiliary)
                     .toList();
             }
         } else {
@@ -1018,9 +1018,7 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
         int btnCount = this.refactorOptions.size();
         List<FormattedCharSequence> usageLines = List.of();
         if (hasMegastructure && activeOption != null) {
-            Component usage = Component.translatable(
-                "screen.anvilcraft.cfa.megastructure." + activeOption.megastructure() + ".usage"
-            );
+            Component usage = Component.translatable(activeOption.displayName() + ".usage");
             usageLines = this.font.split(usage, BUILT_MEGASTRUCTURE_WRAP_WIDTH);
         }
 
@@ -1373,7 +1371,7 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
 
     private int getRefactorOptionAt(int rx, int ry) {
         if (this.refactorOptions.isEmpty()) return -1;
-        boolean hasMegastructure = getMenu().getBlockEntity().getActiveMegastructureIndex() >= 0;
+        boolean hasMegastructure = getMenu().getBlockEntity().hasActiveMegastructure();
         for (int visibleRow = 0; visibleRow < RF_ROWS_VISIBLE; visibleRow++) {
             for (int col = 0; col < RF_COLS; col++) {
                 int contentRow = this.rfScrollRow + visibleRow;
@@ -1412,13 +1410,13 @@ public class CelestialForgingAnvilScreen extends AbstractContainerScreen<Celesti
     }
 
     private boolean isHoveringBuiltMegastructureButton(int rx, int ry) {
-        if (this.rfScrollRow != 0 || getMenu().getBlockEntity().getActiveMegastructureIndex() < 0) return false;
+        if (this.rfScrollRow != 0 || !getMenu().getBlockEntity().hasActiveMegastructure()) return false;
         return rx >= RF_BTN_X[0] && rx < RF_BTN_X[0] + RF_BTN_W
             && ry >= RF_BTN_Y[0] && ry < RF_BTN_Y[0] + RF_BTN_H;
     }
 
     private boolean isRefactorStartVisible() {
-        return getMenu().getBlockEntity().getActiveMegastructureIndex() < 0 || !this.refactorOptions.isEmpty();
+        return !getMenu().getBlockEntity().hasActiveMegastructure() || !this.refactorOptions.isEmpty();
     }
 
     private boolean isOverRefactorStart(int rx, int ry) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/cfa/CelestialBodyPreviewRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/cfa/CelestialBodyPreviewRenderer.java
@@ -78,8 +78,8 @@ public final class CelestialBodyPreviewRenderer {
         graphics.submitPictureInPictureRenderState(CfaPreviewPipRenderer.State.model(
             graphics,
             model,
-            animationTick * 2.0f % 360.0f,
-            option.megastructure().hashCode(),
+            option.rotation(animationTick * 2.0f % 360.0f, animationTick),
+            option.id().hashCode(),
             x,
             y,
             width,
@@ -106,23 +106,6 @@ public final class CelestialBodyPreviewRenderer {
     }
 
     private static StandaloneModelKey<BlockStateModel> resolveMegastructureModel(CelestialRefactorOption option) {
-        return switch (option.megastructure()) {
-            case "planet_excavator" -> CFARenderer.R1_EXCAVATOR;
-            case "planet_exctractor" -> CFARenderer.R1_EXTRACTOR;
-            case "eco_station" -> CFARenderer.R1_ECO_STATION;
-            case "temple" -> CFARenderer.R1_TEMPLE;
-            case "giant_planet_exctractor" -> CFARenderer.R2_EXTRACTOR;
-            case "stellar_ring_collider" -> CFARenderer.R4_COLLIDER;
-            case "dyson_sphere_small" -> CFARenderer.R4_DYSON_SPHERE;
-            case "magnetar_coil" -> CFARenderer.R4_COIL;
-            case "penrose_sphere" -> CFARenderer.R4_PENROSE_SPHERE;
-            case "matter_decompressor" -> CFARenderer.R4_MATTER_DECOMPRESSOR;
-            case "wormhole_stabilizer" -> CFARenderer.R4_WORMHOLE_STABILIZER;
-            case "dyson_sphere_large" -> CFARenderer.R5_DYSON_SPHERE;
-            case "stellar_evolution_accelerator" -> option.ring() >= 6
-                ? CFARenderer.R6_ACCELERATOR
-                : CFARenderer.R5_ACCELERATOR;
-            default -> throw new IllegalArgumentException("未知的锻星砧巨构：" + option.megastructure());
-        };
+        return CFARenderer.getMegastructureModel(option.modelLocation());
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CFARenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/CFARenderer.java
@@ -3,11 +3,15 @@ package dev.dubhe.anvilcraft.client.renderer.blockentity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import dev.anvilcraft.lib.v2.rendering.ALRPostEffects;
+import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.rendering.BlockStateModelTessellateState;
 import dev.dubhe.anvilcraft.block.cfa.CelestialForgingAnvilBlock;
 import dev.dubhe.anvilcraft.block.entity.CelestialForgingAnvilBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyClass;
 import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyData;
+import dev.dubhe.anvilcraft.block.entity.celestial.CelestialRefactorOption;
+import dev.dubhe.anvilcraft.block.entity.celestial.CelestialRefactorRegistry;
 import dev.dubhe.anvilcraft.block.entity.celestial.GiantPlanetData;
 import dev.dubhe.anvilcraft.block.entity.celestial.RingType;
 import dev.dubhe.anvilcraft.block.entity.celestial.RockyPlanetData;
@@ -15,10 +19,12 @@ import dev.dubhe.anvilcraft.block.entity.celestial.SpecialCelestialBodyData;
 import dev.dubhe.anvilcraft.block.entity.celestial.StarData;
 import dev.dubhe.anvilcraft.block.entity.celestial.Temperature;
 import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
+import dev.dubhe.anvilcraft.client.renderer.RenderState;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.celestial.CelestialBodyRenderer;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.celestial.CelestialBodyTextureBakery;
 import dev.dubhe.anvilcraft.client.renderer.blockentity.state.CFARenderState;
 import dev.dubhe.anvilcraft.client.support.FeatureRendererSupport;
+import dev.dubhe.anvilcraft.init.ModMegastructures;
 import net.minecraft.client.model.object.skull.SkullModelBase;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -65,28 +71,44 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     public static final StandaloneModelKey<BlockStateModel> RING5 = key("CFA Ring 5");
     public static final StandaloneModelKey<BlockStateModel> RING6 = key("CFA Ring 6");
     // ==================== 巨构模型 ====================
-    public static final StandaloneModelKey<BlockStateModel> R1_EXCAVATOR = key("CFA Ring 1 Excavator");
+    private static final Map<Identifier, StandaloneModelKey<BlockStateModel>> MEGASTRUCTURE_MODELS =
+        new ConcurrentHashMap<>();
+    public static final StandaloneModelKey<BlockStateModel> R1_EXCAVATOR = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_1_excavator"));
     public static final StandaloneModelKey<BlockStateModel> R1_EXCAVATOR_OFF = key("CFA Ring 1 Excavator Off");
-    public static final StandaloneModelKey<BlockStateModel> R1_EXTRACTOR = key("CFA Ring 1 Extractor");
-    public static final StandaloneModelKey<BlockStateModel> R2_EXTRACTOR = key("CFA Ring 2 Extractor");
-    public static final StandaloneModelKey<BlockStateModel> R1_ECO_STATION = key("CFA Ring 1 Eco Station");
-    public static final StandaloneModelKey<BlockStateModel> R1_TEMPLE = key("CFA Ring 1 Temple");
-    public static final StandaloneModelKey<BlockStateModel> R4_COLLIDER = key("CFA Ring 4 Collider");
-    public static final StandaloneModelKey<BlockStateModel> R4_DYSON_SPHERE = key("CFA Ring 4 Dyson Sphere");
-    public static final StandaloneModelKey<BlockStateModel> R5_DYSON_SPHERE = key("CFA Ring 5 Dyson Sphere");
-    public static final StandaloneModelKey<BlockStateModel> R4_COIL = key("CFA Ring 4 Coil");
+    public static final StandaloneModelKey<BlockStateModel> R1_EXTRACTOR = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_1_exctractor"));
+    public static final StandaloneModelKey<BlockStateModel> R2_EXTRACTOR = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_2_exctractor"));
+    public static final StandaloneModelKey<BlockStateModel> R1_ECO_STATION = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_1_eco_station"));
+    public static final StandaloneModelKey<BlockStateModel> R1_TEMPLE = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_1_temple"));
+    public static final StandaloneModelKey<BlockStateModel> R4_COLLIDER = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_4_collider"));
+    public static final StandaloneModelKey<BlockStateModel> R4_DYSON_SPHERE = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_4_dyson_sphere"));
+    public static final StandaloneModelKey<BlockStateModel> R5_DYSON_SPHERE = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_5_dyson_sphere"));
+    public static final StandaloneModelKey<BlockStateModel> R4_COIL = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_4_coil"));
     public static final StandaloneModelKey<BlockStateModel> R4_COIL_FIX = key("CFA Ring 4 Coil Fix");
     public static final StandaloneModelKey<BlockStateModel> R4_COIL_RING = key("CFA Ring 4 Coil Ring");
-    public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE = key("CFA Ring 4 Penrose Sphere");
+    public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_4_penrose_sphere"));
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_FIX = key("CFA Ring 4 Penrose Fix");
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER = key("CFA Ring 4 Penrose Laser");
     public static final StandaloneModelKey<BlockStateModel> R4_PENROSE_SPHERE_LASER_OFF = key("CFA Ring 4 Penrose Laser Off");
-    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR = key("CFA Ring 4 Matter Decompressor");
+    public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_4_matter_decompressor"));
     public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_FIX = key("CFA Ring 4 Decompressor Fix");
     public static final StandaloneModelKey<BlockStateModel> R4_MATTER_DECOMPRESSOR_RING = key("CFA Ring 4 Decompressor Ring");
-    public static final StandaloneModelKey<BlockStateModel> R4_WORMHOLE_STABILIZER = key("CFA Ring 4 Wormhole Stabilizer");
-    public static final StandaloneModelKey<BlockStateModel> R5_ACCELERATOR = key("CFA Ring 5 Accelerator");
-    public static final StandaloneModelKey<BlockStateModel> R6_ACCELERATOR = key("CFA Ring 6 Accelerator");
+    public static final StandaloneModelKey<BlockStateModel> R4_WORMHOLE_STABILIZER = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_4_wormhole_stabilizer"));
+    public static final StandaloneModelKey<BlockStateModel> R5_ACCELERATOR = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_5_stellar_evolution_accelerator"));
+    public static final StandaloneModelKey<BlockStateModel> R6_ACCELERATOR = getMegastructureModel(
+        AnvilCraft.of("block/celestial_forging_anvil_ring_6_stellar_evolution_accelerator"));
     // ==================== 天体模型 ====================
     public static final StandaloneModelKey<BlockStateModel> BODY_STAR = key("CFA Body Star");
     public static final StandaloneModelKey<BlockStateModel> BODY_NEUTRON_STAR = key("CFA Body Neutron Star");
@@ -112,6 +134,13 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         return new StandaloneModelKey<>(() -> "AnvilCraft: " + desc + " Model");
     }
 
+    public static StandaloneModelKey<BlockStateModel> getMegastructureModel(Identifier modelLocation) {
+        return MEGASTRUCTURE_MODELS.computeIfAbsent(
+            modelLocation,
+            location -> key("CFA Megastructure " + location)
+        );
+    }
+
     public CFARenderer(BlockEntityRendererProvider.Context context) {
         this.playerHeadModel = SkullBlockRenderer.createModel(context.entityModelSet(), SkullBlock.Types.PLAYER);
     }
@@ -126,10 +155,12 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     private static final float BEAM_INNER_HALF = 0.08f;
     private static final int BEAM_GLOW_LAYERS = 4;
     private static final float BEAM_GLOW_HALF_STEP = 0.06f;
+    private static final float STAR_BLOOM_SCALE = 1.0025f;
     private static final Map<BlockPos, TractorBeamData> DEFERRED_TRACTOR_BEAMS = new LinkedHashMap<>();
     private static final float SUPERNOVA_MAX_RADIUS = 8.0f;
     private static final int SUPERNOVA_RAY_COUNT = 24;
     private static final float SUPERNOVA_RAY_LENGTH = 12.0f;
+    private static final float PLAYER_HEAD_SCALE = 16.0f;
 
     private record TractorBeamData(BlockPos pos, float beamHeight, float animationProgress) {
     }
@@ -193,18 +224,35 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         state.setBodyRotation((be.getBodyRotation() + partialTicks) * rotationBoost);
 
         // 巨构渲染状态。
-        String megastructure = be.getActiveMegastructureOption() != null
-            ? be.getActiveMegastructureOption().megastructure() : null;
-        int activeIndex = be.getActiveMegastructureIndex();
+        CelestialRefactorOption activeOption = be.getActiveMegastructureOption();
+        Identifier megastructureId = activeOption == null ? null : activeOption.id();
+        state.setActiveMegastructureRing(activeOption == null ? -1 : activeOption.ring());
+        state.setActiveMegastructureRotation(
+            activeOption == null ? rot : activeOption.rotation(rot, state.getBodyRotation())
+        );
+        state.setAuxiliaryMegastructureRing(-1);
+        state.setAuxiliaryMegastructureRotation(rot);
         state.setAcceleratorActive(be.isAcceleratorActive());
+        if (state.isAcceleratorActive()) {
+            CelestialRefactorOption accelerator = CelestialRefactorRegistry.getOption(
+                ModMegastructures.STELLAR_EVOLUTION_ACCELERATOR.getId(),
+                bodyData,
+                isAmplify,
+                be.getPlanetaryResourceSet()
+            );
+            if (accelerator != null) {
+                state.setAuxiliaryMegastructureRing(accelerator.ring());
+                state.setAuxiliaryMegastructureRotation(accelerator.rotation(rot, state.getBodyRotation()));
+            }
+        }
         state.setPenroseLaserActive(be.isPenroseSphereLaserActive());
-        state.setDysonSphereR4("dyson_sphere_small".equals(megastructure));
-        state.setDysonSphereR5("dyson_sphere_large".equals(megastructure));
-        state.setMagnetarCoil("magnetar_coil".equals(megastructure));
-        state.setPenroseSphere("penrose_sphere".equals(megastructure));
-        state.setMatterDecompressor("matter_decompressor".equals(megastructure));
+        state.setDysonSphereR4(ModMegastructures.DYSON_SPHERE_SMALL.getId().equals(megastructureId));
+        state.setDysonSphereR5(ModMegastructures.DYSON_SPHERE_LARGE.getId().equals(megastructureId));
+        state.setMagnetarCoil(ModMegastructures.MAGNETAR_COIL.getId().equals(megastructureId));
+        state.setPenroseSphere(ModMegastructures.PENROSE_SPHERE.getId().equals(megastructureId));
+        state.setMatterDecompressor(ModMegastructures.MATTER_DECOMPRESSOR.getId().equals(megastructureId));
 
-        this.extractRings(be, state, megastructure, activeIndex, bodyData, prevBody);
+        this.extractRings(be, state, bodyData, prevBody);
         this.extractMegastructureRings(be, state, bodyData);
         this.extractBody(be, state, partialTicks);
         this.extractSupernova(be, state, partialTicks);
@@ -214,8 +262,6 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     private void extractRings(
         CelestialForgingAnvilBlockEntity be,
         CFARenderState state,
-        @Nullable String megastructure,
-        int activeIndex,
         @Nullable CelestialBodyData bodyData,
         @Nullable CelestialBodyData prevBody
     ) {
@@ -234,9 +280,12 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         state.setOuterRingModel(FeatureRendererSupport.createTessellation(outerKey, false));
         state.setMiddleRingModel(FeatureRendererSupport.createTessellation(middleKey, false));
         state.setInnerRingModel(FeatureRendererSupport.createTessellation(innerKey, false));
-        state.setHasOuterRing(true);
-        state.setHasMiddleRing(true);
-        state.setHasInnerRing(true);
+        CelestialBodyData effectiveBodyData = be.getEffectiveBodyDataForRendering();
+        boolean hasMechanicalRings = !(effectiveBodyData instanceof SpecialCelestialBodyData special
+            && special.isPlayerHead());
+        state.setHasOuterRing(hasMechanicalRings);
+        state.setHasMiddleRing(hasMechanicalRings);
+        state.setHasInnerRing(hasMechanicalRings);
 
         state.setOuterVisibleNow(isRingVisible(outerIndex, bodyData, isAmplify));
         state.setOuterWasVisible(prevBody == null || isRingVisible(outerIndex, prevBody, isAmplify));
@@ -269,6 +318,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
 
     /// 判断指定天体数据下的机械束星环是否可见。
     private static boolean isRingVisible(int ring, @Nullable CelestialBodyData bodyData, boolean isAmplify) {
+        if (bodyData instanceof SpecialCelestialBodyData special && special.isPlayerHead()) return false;
         if (isAmplify) {
             return switch (ring) {
                 case 4 -> bodyData == null || bodyData.size() < 48;
@@ -288,72 +338,59 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
     }
 
     private StandaloneModelKey<BlockStateModel> getRing1Model(CelestialForgingAnvilBlockEntity be) {
-        if (be.getActiveMegastructureIndex() >= 0 && be.getActiveMegastructureOption() != null) {
-            String m = be.getActiveMegastructureOption().megastructure();
-            switch (m) {
-                case "planet_excavator" -> {
-                    return be.isExcavatorLaserActive() ? R1_EXCAVATOR : R1_EXCAVATOR_OFF;
-                }
-                case "planet_exctractor" -> {
-                    return R1_EXTRACTOR;
-                }
-                case "eco_station" -> {
-                    return R1_ECO_STATION;
-                }
-                case "temple" -> {
-                    return R1_TEMPLE;
-                }
-                default -> {
-                }
-            }
-        }
-        return RING1;
+        StandaloneModelKey<BlockStateModel> active = this.getActiveRingModel(be, 1);
+        return active == null ? RING1 : active;
     }
 
     private StandaloneModelKey<BlockStateModel> getRing2Model(CelestialForgingAnvilBlockEntity be) {
-        if (be.getActiveMegastructureIndex() >= 0 && be.getActiveMegastructureOption() != null
-            && "giant_planet_exctractor".equals(be.getActiveMegastructureOption().megastructure())) {
-            return R2_EXTRACTOR;
-        }
-        return RING2;
+        StandaloneModelKey<BlockStateModel> active = this.getActiveRingModel(be, 2);
+        return active == null ? RING2 : active;
     }
 
     private StandaloneModelKey<BlockStateModel> getRing4Model(CelestialForgingAnvilBlockEntity be) {
-        if (be.getActiveMegastructureIndex() >= 0 && be.getActiveMegastructureOption() != null) {
-            String m = be.getActiveMegastructureOption().megastructure();
-            switch (m) {
-                case "stellar_ring_collider" -> {
-                    return R4_COLLIDER;
-                }
-                case "dyson_sphere_small" -> {
-                    return R4_DYSON_SPHERE;
-                }
-                case "wormhole_stabilizer" -> {
-                    return R4_WORMHOLE_STABILIZER;
-                }
-                default -> {
-                }
-            }
-        }
-        return RING4;
+        StandaloneModelKey<BlockStateModel> active = this.getActiveRingModel(be, 4);
+        return active == null ? RING4 : active;
     }
 
     private StandaloneModelKey<BlockStateModel> getRing5Model(CelestialForgingAnvilBlockEntity be) {
-        if (be.getActiveMegastructureIndex() >= 0 && be.getActiveMegastructureOption() != null
-            && "dyson_sphere_large".equals(be.getActiveMegastructureOption().megastructure())) {
-            return R5_DYSON_SPHERE;
-        }
-        if (be.isAcceleratorActive() && be.getCelestialBodyData() instanceof StarData star && star.size() < 48) {
-            return R5_ACCELERATOR;
-        }
-        return RING5;
+        StandaloneModelKey<BlockStateModel> active = this.getActiveRingModel(be, 5);
+        if (active != null) return active;
+        StandaloneModelKey<BlockStateModel> auxiliary = this.getAcceleratorRingModel(be, 5);
+        return auxiliary == null ? RING5 : auxiliary;
     }
 
     private StandaloneModelKey<BlockStateModel> getRing6Model(CelestialForgingAnvilBlockEntity be) {
-        if (be.isAcceleratorActive() && be.getCelestialBodyData() instanceof StarData star && star.size() >= 48) {
-            return R6_ACCELERATOR;
+        StandaloneModelKey<BlockStateModel> active = this.getActiveRingModel(be, 6);
+        if (active != null) return active;
+        StandaloneModelKey<BlockStateModel> auxiliary = this.getAcceleratorRingModel(be, 6);
+        return auxiliary == null ? RING6 : auxiliary;
+    }
+
+    private @Nullable StandaloneModelKey<BlockStateModel> getActiveRingModel(
+        CelestialForgingAnvilBlockEntity be,
+        int ring
+    ) {
+        CelestialRefactorOption option = be.getActiveMegastructureOption();
+        if (option == null || option.ring() != ring) return null;
+        if (ModMegastructures.PLANET_EXCAVATOR.getId().equals(option.id()) && !be.isExcavatorLaserActive()) {
+            return R1_EXCAVATOR_OFF;
         }
-        return RING6;
+        return getMegastructureModel(option.modelLocation());
+    }
+
+    private @Nullable StandaloneModelKey<BlockStateModel> getAcceleratorRingModel(
+        CelestialForgingAnvilBlockEntity be,
+        int ring
+    ) {
+        if (!be.isAcceleratorActive()) return null;
+        CelestialRefactorOption option = CelestialRefactorRegistry.getOption(
+            ModMegastructures.STELLAR_EVOLUTION_ACCELERATOR.getId(),
+            be.getCelestialBodyData(),
+            be.isAmplify(),
+            be.getPlanetaryResourceSet()
+        );
+        if (option == null || option.ring() != ring) return null;
+        return getMegastructureModel(option.modelLocation());
     }
 
     /// 初始化戴森球、彭罗斯球、磁星线圈和物质解压器的恒星同步附加模型。
@@ -491,51 +528,51 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float ringScale = state.getRingScale();
         float centerY = state.getCenterY();
 
-        pose.pushPose();
-        pose.translate(0.5, centerY, 0.5);
-        pose.scale(ringScale, ringScale, ringScale);
-
-        // 骨骼层级：最外层绕 Y 轴，外层施加固定倾角，中层绕 X 轴，内层绕 Z 轴。
-        pose.mulPose(Axis.YP.rotationDegrees(-rot));
-        pose.mulPose(Axis.XP.rotationDegrees(14.5108f));
-        pose.mulPose(Axis.YP.rotationDegrees(-3.8411f));
-        pose.mulPose(Axis.ZP.rotationDegrees(14.5109f));
-
-        // 最外环是外层骨骼的子节点。
-        this.submitRingMaybe(
+        int outerRing = state.isAmplified() ? 6 : 3;
+        int middleRing = state.isAmplified() ? 5 : 2;
+        int innerRing = state.isAmplified() ? 4 : 1;
+        this.submitMechanicalRing(
             state.getOuterRingModel(),
             state.isHasOuterRing(),
             state.isOuterVisibleNow(),
             state.isOuterWasVisible(),
+            outerRing,
+            0,
             state,
             pose,
-            collector
+            collector,
+            centerY,
+            ringScale,
+            rot
         );
-
-        // 中层骨骼绕 X 轴旋转。
-        pose.mulPose(Axis.XP.rotationDegrees(90.0f + rot));
-        this.submitRingMaybe(
+        this.submitMechanicalRing(
             state.getMiddleRingModel(),
             state.isHasMiddleRing(),
             state.isMiddleVisibleNow(),
             state.isMiddleWasVisible(),
+            middleRing,
+            1,
             state,
             pose,
-            collector
+            collector,
+            centerY,
+            ringScale,
+            rot
         );
-
-        // 内层骨骼绕 Z 轴旋转。
-        pose.mulPose(Axis.ZP.rotationDegrees(rot));
-        this.submitRingMaybe(
+        this.submitMechanicalRing(
             state.getInnerRingModel(),
             state.isHasInnerRing(),
             state.isInnerVisibleNow(),
             state.isInnerWasVisible(),
+            innerRing,
+            2,
             state,
             pose,
-            collector
+            collector,
+            centerY,
+            ringScale,
+            rot
         );
-        pose.popPose();
 
         // 提交随恒星同步的巨构环渲染层。
         this.submitMegastructureRings(state, pose, collector);
@@ -544,6 +581,9 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         if (state.isCanRenderBody() && state.getEffectiveBodyData() != null) {
             this.submitCelestialBody(state, pose, collector);
             this.submitCelestialRing(state, pose, collector);
+            if (state.getEffectiveBodyData() instanceof StarData star) {
+                this.submitStarBloom(state, star, camera);
+            }
         }
 
         // 仅记录本帧托举光束，在 AFTER_WEATHER 阶段绘制，确保光束位于云层上方。
@@ -557,6 +597,51 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         // 超新星闪光独立于当前天体，即使天体已变为残骸也继续播放。
         if (state.getSupernovaFlashTicks() > 0) {
             this.submitSupernovaFlash(state, pose, collector);
+        }
+    }
+
+    private void submitMechanicalRing(
+        @Nullable BlockStateModelTessellateState model,
+        boolean present,
+        boolean visibleNow,
+        boolean wasVisible,
+        int ring,
+        int depth,
+        CFARenderState state,
+        PoseStack pose,
+        SubmitNodeCollector collector,
+        float centerY,
+        float ringScale,
+        float baseRotation
+    ) {
+        pose.pushPose();
+        pose.translate(0.5, centerY, 0.5);
+        pose.scale(ringScale, ringScale, ringScale);
+        applyMechanicalRingBone(pose, depth, this.getMegastructureRotation(state, ring, baseRotation));
+        this.submitRingMaybe(model, present, visibleNow, wasVisible, state, pose, collector);
+        pose.popPose();
+    }
+
+    private float getMegastructureRotation(CFARenderState state, int ring, float baseRotation) {
+        if (state.getActiveMegastructureRing() == ring) {
+            return state.getActiveMegastructureRotation();
+        }
+        if (state.getAuxiliaryMegastructureRing() == ring) {
+            return state.getAuxiliaryMegastructureRotation();
+        }
+        return baseRotation;
+    }
+
+    private static void applyMechanicalRingBone(PoseStack pose, int depth, float rotation) {
+        pose.mulPose(Axis.YP.rotationDegrees(-rotation));
+        pose.mulPose(Axis.XP.rotationDegrees(14.5108f));
+        pose.mulPose(Axis.YP.rotationDegrees(-3.8411f));
+        pose.mulPose(Axis.ZP.rotationDegrees(14.5109f));
+        if (depth >= 1) {
+            pose.mulPose(Axis.XP.rotationDegrees(90.0f + rotation));
+        }
+        if (depth >= 2) {
+            pose.mulPose(Axis.ZP.rotationDegrees(rotation));
         }
     }
 
@@ -712,12 +797,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
 
     /// 应用到内层骨骼为止的完整层级变换，用于机械内环旋转。
     private static void applyMechanicalInnerBone(PoseStack pose, float rot) {
-        pose.mulPose(Axis.YP.rotationDegrees(-rot));
-        pose.mulPose(Axis.XP.rotationDegrees(14.5108f));
-        pose.mulPose(Axis.YP.rotationDegrees(-3.8411f));
-        pose.mulPose(Axis.ZP.rotationDegrees(14.5109f));
-        pose.mulPose(Axis.XP.rotationDegrees(90.0f + rot));
-        pose.mulPose(Axis.ZP.rotationDegrees(rot));
+        applyMechanicalRingBone(pose, 2, rot);
     }
 
     // ==================== 天体渲染 ====================
@@ -730,8 +810,12 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         float animProgress = state.getAnimationProgress();
 
         float baseScale = state.getBodyScaleMultiplier();
-        if (bodyData instanceof SpecialCelestialBodyData s && s.isErrorPlanet()) {
-            baseScale *= 0.25f;
+        if (bodyData instanceof SpecialCelestialBodyData special) {
+            if (special.isPlayerHead()) {
+                baseScale *= PLAYER_HEAD_SCALE;
+            } else if (special.isErrorPlanet()) {
+                baseScale *= 0.25f;
+            }
         }
         float scale = baseScale * animProgress;
         if (scale < 0.001f) return;
@@ -816,21 +900,62 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
         }
 
         // 主序星使用带动画的灰度烘焙模型。
-        if (state.getBodyModel() != null) {
-            this.tessellateModel(state.getBodyModel(), pose, collector);
+        float[] rgb = CelestialBodyRenderer.getStarColor(star);
+        this.submitRegularStarCore(state.getBodyModel(), rgb, pose, collector);
+
+        // 绘制恒星光晕。
+        this.submitHalo(pose, collector, rgb[0], rgb[1], rgb[2], 10, 1.0f, 0.6f, 1.2f, 1.125f);
+    }
+
+    private void submitStarBloom(CFARenderState state, StarData star, CameraRenderState camera) {
+        if (!RenderState.isEnhancedRenderingAvailable() || !RenderState.isBloomEffectEnabled()) return;
+        BlockStateModelTessellateState bodyModel = state.getBodyModel();
+        if (star.bodyClass().isExtreme() || bodyModel == null) return;
+
+        float scale = state.getBodyScaleMultiplier() * state.getAnimationProgress();
+        if (scale < 0.001f) return;
+
+        float[] rgb = CelestialBodyRenderer.getStarColor(star);
+        double x = state.blockPos.getX() - camera.pos.x;
+        double y = state.blockPos.getY() - camera.pos.y;
+        double z = state.blockPos.getZ() - camera.pos.z;
+        float centerY = state.getCenterY();
+        float axialTilt = star.axialTilt();
+        float rotation = state.getBodyRotation() * CelestialBodyData.getVisualRotationSpeed(star.rotationSpeed());
+
+        ALRPostEffects.getBloomPostEffect().drawBloomed((bloomCollector, bloomPose) -> {
+            bloomPose.pushPose();
+            bloomPose.translate(x, y, z);
+            bloomPose.translate(0.5, centerY, 0.5);
+            bloomPose.scale(scale, scale, scale);
+            bloomPose.mulPose(Axis.XP.rotationDegrees(axialTilt));
+            bloomPose.mulPose(Axis.YP.rotationDegrees(rotation));
+            bloomPose.translate(-0.5, -0.5, -0.5);
+            bloomPose.translate(0.5, 0.5, 0.5);
+            bloomPose.scale(STAR_BLOOM_SCALE, STAR_BLOOM_SCALE, STAR_BLOOM_SCALE);
+            bloomPose.translate(-0.5, -0.5, -0.5);
+            this.submitRegularStarCore(bodyModel, rgb, bloomPose, bloomCollector);
+            bloomPose.popPose();
+        });
+    }
+
+    private void submitRegularStarCore(
+        @Nullable BlockStateModelTessellateState bodyModel,
+        float[] rgb,
+        PoseStack pose,
+        SubmitNodeCollector collector
+    ) {
+        if (bodyModel != null) {
+            this.tessellateModel(bodyModel, pose, collector);
         }
 
         // 叠加乘法恒星颜色。
-        float[] rgb = CelestialBodyRenderer.getStarColor(star);
         pose.pushPose();
         pose.translate(0.5, 0.5, 0.5);
         pose.scale(1.005f, 1.005f, 1.005f);
         pose.translate(-0.5, -0.5, -0.5);
         this.submitColorOverlay(pose, collector, rgb[0], rgb[1], rgb[2]);
         pose.popPose();
-
-        // 绘制恒星光晕。
-        this.submitHalo(pose, collector, rgb[0], rgb[1], rgb[2], 10, 1.0f, 0.6f, 1.2f, 1.125f);
     }
 
     private void submitPlanet(
@@ -1273,7 +1398,7 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
 
     @Override
     public boolean shouldRenderOffScreen() {
-        return false;
+        return true;
     }
 
     @Override
@@ -1290,6 +1415,9 @@ public class CFARenderer implements BlockEntityRenderer<CelestialForgingAnvilBlo
             centerY += 19.0f * (be.getRedstoneSignal() / 15.0f);
         }
         float bs = body != null ? body.bodyScale() * CelestialBodyData.BODY_SCALE_FACTOR : 6.0f;
+        if (body instanceof SpecialCelestialBodyData special && special.isPlayerHead()) {
+            bs *= PLAYER_HEAD_SCALE;
+        }
         // 红石信号最大 3× 缩放后的天体和星环可能远大于 1×，渲染包围盒需留足余量。
         float bsMax = bs * 3.0f;
         float ringMax = CelestialBodyData.ringSystemScale(body, be.isAmplify()) * 3.0f;

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/state/CFARenderState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/state/CFARenderState.java
@@ -18,6 +18,10 @@ public class CFARenderState extends BlockEntityRenderState {
     // 基础束星环动画。
     private float rotation;
     private boolean amplified;
+    private int activeMegastructureRing = -1;
+    private float activeMegastructureRotation;
+    private int auxiliaryMegastructureRing = -1;
+    private float auxiliaryMegastructureRotation;
 
     // 红石驱动并经过平滑插值的缩放参数。
     private float ringScale;

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/SpectralSlingshotRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/SpectralSlingshotRenderer.java
@@ -27,11 +27,10 @@ public class SpectralSlingshotRenderer implements SpecialModelRenderer<SpectralR
 
     @Override
     public @Nullable SpectralRenderState extractArgument(ItemStack stack) {
-        if (!stack.is(ModItems.SPECTRAL_WEAPON_LAUNCHER)) return null;
+        if (!stack.is(ModItems.SPECTRAL_SLINGSHOT)) return null;
         ChargedProjectiles chargedProjectiles = stack.get(DataComponents.CHARGED_PROJECTILES);
         if (chargedProjectiles == null || chargedProjectiles.itemCopies().isEmpty()) return null;
         SpectralRenderState state = new SpectralRenderState();
-        state.setSelf(FeatureRendererSupport.initialize(stack, this.resolver));
         state.setAmmo(FeatureRendererSupport.initialize(
             chargedProjectiles.itemCopies().getFirst(),
             this.resolver
@@ -50,13 +49,6 @@ public class SpectralSlingshotRenderer implements SpecialModelRenderer<SpectralR
         int outlineColor
     ) {
         if (argument == null) return;
-        argument.getSelf().item.submit(
-            pose,
-            collector,
-            lightCoords,
-            overlayCoords,
-            outlineColor
-        );
         pose.pushPose();
         pose.translate(0F, 0.7F, 0.50F);
         pose.mulPose(Axis.YP.rotationDegrees(90));

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/SpectralWeaponLauncherRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/SpectralWeaponLauncherRenderer.java
@@ -31,7 +31,6 @@ public class SpectralWeaponLauncherRenderer implements SpecialModelRenderer<Spec
         ChargedProjectiles chargedProjectiles = stack.get(DataComponents.CHARGED_PROJECTILES);
         if (chargedProjectiles == null || chargedProjectiles.itemCopies().isEmpty()) return null;
         SpectralRenderState state = new SpectralRenderState();
-        state.setSelf(FeatureRendererSupport.initialize(stack, this.resolver));
         state.setAmmo(FeatureRendererSupport.initialize(
             chargedProjectiles.itemCopies().getFirst(),
             this.resolver
@@ -50,13 +49,6 @@ public class SpectralWeaponLauncherRenderer implements SpecialModelRenderer<Spec
         int outlineColor
     ) {
         if (argument == null) return;
-        argument.getSelf().item.submit(
-            pose,
-            collector,
-            lightCoords,
-            overlayCoords,
-            outlineColor
-        );
         pose.pushPose();
         pose.translate(0F, 7F / 16F, 7F / 8F);
         pose.mulPose(Axis.YP.rotationDegrees(90));

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/state/SpectralRenderState.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/state/SpectralRenderState.java
@@ -7,6 +7,5 @@ import net.minecraft.client.renderer.entity.state.ItemClusterRenderState;
 @Getter
 @Setter
 public class SpectralRenderState {
-    private ItemClusterRenderState self;
     private ItemClusterRenderState ammo;
 }

--- a/src/main/java/dev/dubhe/anvilcraft/data/recipe/PlanetResourceRecipeLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/recipe/PlanetResourceRecipeLoader.java
@@ -3,6 +3,10 @@ package dev.dubhe.anvilcraft.data.recipe;
 import dev.anvilcraft.lib.v2.registrum.providers.generators.RegistrumRecipeProvider;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.block.entity.celestial.PlanetResourceRecipe;
+import dev.dubhe.anvilcraft.block.state.Color;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.block.ModFluids;
+import dev.dubhe.anvilcraft.init.item.ModItems;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementRequirements;
 import net.minecraft.advancements.AdvancementRewards;
@@ -11,16 +15,13 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.common.NeoForgeMod;
 
-import java.util.List;
-import java.util.Optional;
-
-/**
- * Data generation loader for planet resource recipes.
- */
+/** Data generation loader for planet resource recipes. */
 public class PlanetResourceRecipeLoader {
-
     public static void init(RegistrumRecipeProvider provider) {
         PlanetResourceRecipeLoader.createMineralRecipe(provider);
         PlanetResourceRecipeLoader.createFluidRecipes(provider);
@@ -42,124 +43,140 @@ public class PlanetResourceRecipeLoader {
     }
 
     private static void createMineralRecipe(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "mineral", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.MINERAL,
-            Optional.of(new PlanetResourceRecipe.MineralData(
-                "c:raw_materials", "anvilcraft:non_planetary_minerals", 10
-            )),
-            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "mineral",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.MINERAL)
+                .mineral(new PlanetResourceRecipe.MineralData(
+                    "c:raw_materials",
+                    "anvilcraft:non_planetary_minerals",
+                    10
+                ))
+                .build()
+        );
     }
 
     private static void createFluidRecipes(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "fluid_water", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.FLUID,
-            Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.FluidData(
-                "rocky_planet", "", "low", "minecraft:water"
-            )),
-            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()
-        ));
-
-        PlanetResourceRecipeLoader.saveRecipe(provider, "fluid_lava", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.FLUID,
-            Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.FluidData(
-                "rocky_planet", "scorched", "low", "minecraft:lava"
-            )),
-            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "fluid_water",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.FLUID)
+                .fluid(new PlanetResourceRecipe.FluidData("rocky_planet", "", "low", Fluids.WATER))
+                .build()
+        );
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "fluid_lava",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.FLUID)
+                .fluid(new PlanetResourceRecipe.FluidData("rocky_planet", "scorched", "low", Fluids.LAVA))
+                .build()
+        );
     }
 
     private static void createGiantItemRecipes(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "giant_item_ice", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.GIANT_ITEM,
-            Optional.empty(), Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.GiantData(
-                List.of(
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:ice", 50),
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:packed_ice", 30),
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:blue_ice", 20)
-                ), "ice"
-            )),
-            Optional.empty(), Optional.empty(), Optional.empty()
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "giant_item_ice",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.GIANT_ITEM)
+                .giant(new PlanetResourceRecipe.GiantData(
+                    PlanetResourceRecipe.entries(entries -> entries
+                        .item(Items.ICE, 50)
+                        .item(Items.PACKED_ICE, 30)
+                        .item(Items.BLUE_ICE, 20)),
+                    "ice"
+                ))
+                .build()
+        );
     }
 
     private static void createGiantFluidRecipes(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "giant_fluid_gas", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.GIANT_FLUID,
-            Optional.empty(), Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.GiantData(
-                List.of(
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:primordial_matter", 100)
-                ), "gas"
-            )),
-            Optional.empty(), Optional.empty(), Optional.empty()
-        ));
-
-        PlanetResourceRecipeLoader.saveRecipe(provider, "giant_fluid_ice", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.GIANT_FLUID,
-            Optional.empty(), Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.GiantData(
-                List.of(
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:primordial_matter", 90),
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:water", 10)
-                ), "ice"
-            )),
-            Optional.empty(), Optional.empty(), Optional.empty()
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "giant_fluid_gas",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.GIANT_FLUID)
+                .giant(new PlanetResourceRecipe.GiantData(
+                    PlanetResourceRecipe.entries(entries -> entries.fluid(ModFluids.PRIMORDIAL_MATTER, 100)),
+                    "gas"
+                ))
+                .build()
+        );
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "giant_fluid_ice",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.GIANT_FLUID)
+                .giant(new PlanetResourceRecipe.GiantData(
+                    PlanetResourceRecipe.entries(entries -> entries
+                        .fluid(ModFluids.PRIMORDIAL_MATTER, 90)
+                        .fluid(Fluids.WATER, 10)),
+                    "ice"
+                ))
+                .build()
+        );
     }
 
     private static void createBiologicalRecipe(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "biological", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.BIOLOGICAL,
-            Optional.empty(), Optional.empty(), Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.BiologicalData(
-                PlanetResourceRecipe.LifeChances.DEFAULT,
-                "anvilcraft:planetary_land_animals",
-                "anvilcraft:planetary_aquatic_animals",
-                "anvilcraft:non_planetary_mob_drops",
-                List.of(
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:milk", 50),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:honey", 50)
-                )
-            )),
-            Optional.empty(), Optional.empty()
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "biological",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.BIOLOGICAL)
+                .biological(new PlanetResourceRecipe.BiologicalData(
+                    PlanetResourceRecipe.LifeChances.DEFAULT,
+                    "anvilcraft:planetary_land_animals",
+                    "anvilcraft:planetary_aquatic_animals",
+                    "anvilcraft:non_planetary_mob_drops",
+                    PlanetResourceRecipe.entries(entries -> entries
+                        .fluid(NeoForgeMod.MILK, 50)
+                        .fluid(ModFluids.HONEY, 50))
+                ))
+                .build()
+        );
     }
 
     private static void createOfferingRecipe(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "offering", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.OFFERING,
-            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.OfferingData(
-                List.of(
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:gem_block_random", 50),
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:experience_bottle", 40),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:royal_steel_ingot", 5),
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:totem_of_undying", 2),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:gem_amulet_random", 2),
-                    new PlanetResourceRecipe.WeightedEntry("minecraft:heart_of_the_sea", 1)
-                ), 50, 32, 43
-            )),
-            Optional.empty()
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "offering",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.OFFERING)
+                .offering(new PlanetResourceRecipe.OfferingData(
+                    PlanetResourceRecipe.entries(entries -> entries
+                        .chooseOne(50, choices -> choices
+                            .item(Items.EMERALD_BLOCK, 1)
+                            .item(ModBlocks.TOPAZ_BLOCK.asItem(), 1)
+                            .item(ModBlocks.RUBY_BLOCK.asItem(), 1)
+                            .item(ModBlocks.SAPPHIRE_BLOCK.asItem(), 1))
+                        .item(Items.EXPERIENCE_BOTTLE, 40)
+                        .item(ModItems.ROYAL_STEEL_INGOT, 5)
+                        .item(Items.TOTEM_OF_UNDYING, 2)
+                        .chooseOne(2, choices -> choices
+                            .item(ModItems.EMERALD_AMULET, 1)
+                            .item(ModItems.TOPAZ_AMULET, 1)
+                            .item(ModItems.RUBY_AMULET, 1)
+                            .item(ModItems.SAPPHIRE_AMULET, 1))
+                        .item(Items.HEART_OF_THE_SEA, 1)),
+                    50,
+                    32,
+                    43
+                ))
+                .build()
+        );
     }
 
     private static void createWastelandRecipe(RegistrumRecipeProvider provider) {
-        PlanetResourceRecipeLoader.saveRecipe(provider, "wasteland", new PlanetResourceRecipe(
-            PlanetResourceRecipe.Category.WASTELAND,
-            Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-            Optional.of(new PlanetResourceRecipe.WastelandData(
-                List.of(
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:reinforced_concrete_gray", 60),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:circuit_board", 30),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:processor", 5),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:raw_uranium", 3),
-                    new PlanetResourceRecipe.WeightedEntry("anvilcraft:plutonium_nugget", 2)
-                ), 35, 10
-            ))
-        ));
+        PlanetResourceRecipeLoader.saveRecipe(
+            provider,
+            "wasteland",
+            PlanetResourceRecipe.builder(PlanetResourceRecipe.Category.WASTELAND)
+                .wasteland(new PlanetResourceRecipe.WastelandData(
+                    PlanetResourceRecipe.entries(entries -> entries
+                        .item(ModBlocks.REINFORCED_CONCRETES.get(Color.GRAY).asItem(), 60)
+                        .item(ModItems.CIRCUIT_BOARD, 30)
+                        .item(ModItems.PROCESSOR, 5)
+                        .item(ModItems.RAW_URANIUM, 3)
+                        .item(ModItems.PLUTONIUM_NUGGET, 2)),
+                    35,
+                    10
+                ))
+                .build()
+        );
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModMegastructures.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModMegastructures.java
@@ -1,0 +1,249 @@
+package dev.dubhe.anvilcraft.init;
+
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyClass;
+import dev.dubhe.anvilcraft.block.entity.celestial.CelestialBodyData;
+import dev.dubhe.anvilcraft.block.entity.celestial.GiantPlanetData;
+import dev.dubhe.anvilcraft.block.entity.celestial.LiquidCoverage;
+import dev.dubhe.anvilcraft.block.entity.celestial.Megastructure;
+import dev.dubhe.anvilcraft.block.entity.celestial.PlanetaryResourceSet;
+import dev.dubhe.anvilcraft.block.entity.celestial.RockyPlanetData;
+import dev.dubhe.anvilcraft.block.entity.celestial.SpecialCelestialBodyData;
+import dev.dubhe.anvilcraft.block.entity.celestial.StarData;
+import dev.dubhe.anvilcraft.block.entity.megastructure.AcceleratorHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.ColliderHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.DysonSphereHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.EcoStationHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.ExcavatorHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.ExtractorHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.GiantExtractorHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.MagnetarCoilHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.MatterDecompressorHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.PenroseSphereHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.TempleHandler;
+import dev.dubhe.anvilcraft.block.entity.megastructure.WormholeStabilizerHandler;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.init.item.ModItems;
+import dev.dubhe.anvilcraft.init.registry.ModRegistryKeys;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.Items;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.function.Function;
+
+/** Built-in Celestial Forging Anvil megastructures. */
+public final class ModMegastructures {
+    private static final DeferredRegister<Megastructure> REGISTER = DeferredRegister.create(
+        ModRegistryKeys.MEGASTRUCTURE,
+        AnvilCraft.MOD_ID
+    );
+
+    public static final DeferredHolder<Megastructure, Megastructure> PLANET_EXCAVATOR = register(
+        "planet_excavator",
+        id -> Megastructure.builder(id, "planet_excavator")
+            .prerequisite(context -> isPlanet(context) && !isErrorPlanet(context))
+            .ring(1)
+            .model(1, ringModel(1, "excavator"))
+            .material(ModBlocks.RUBY_PRISM.asItem(), 16)
+            .handler(ExcavatorHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> PLANET_EXTRACTOR = register(
+        "planet_exctractor",
+        id -> Megastructure.builder(id, "planet_exctractor")
+            .prerequisite(context -> isPlanet(context) && !isErrorPlanet(context) && hasLiquid(context))
+            .ring(1)
+            .model(1, ringModel(1, "exctractor"))
+            .material(ModBlocks.PUMP.asItem(), 16)
+            .handler(ExtractorHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> ECO_STATION = register(
+        "eco_station",
+        id -> Megastructure.builder(id, "eco_station")
+            .prerequisite(context -> isPlanet(context) && !isErrorPlanet(context) && isEcoStationEligible(context.resources()))
+            .ring(1)
+            .model(1, ringModel(1, "eco_station"))
+            .material(ModBlocks.TEMPERING_GLASS.asItem(), 64)
+            .handler(EcoStationHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> TEMPLE = register(
+        "temple",
+        id -> Megastructure.builder(id, "temple")
+            .prerequisite(context -> isPlanet(context) && !isErrorPlanet(context)
+                && (context.resources() == null || context.resources().hasCivilization()))
+            .ring(1)
+            .model(1, ringModel(1, "temple"))
+            .material(Items.GOLD_BLOCK, 64)
+            .handler(TempleHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> GIANT_PLANET_EXTRACTOR = register(
+        "giant_planet_exctractor",
+        id -> Megastructure.builder(id, "giant_planet_exctractor")
+            .prerequisite(context -> context.body() instanceof GiantPlanetData)
+            .ring(2)
+            .model(2, ringModel(2, "exctractor"))
+            .material(ModBlocks.PUMP.asItem(), 32)
+            .handler(GiantExtractorHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> STELLAR_RING_COLLIDER = register(
+        "stellar_ring_collider",
+        id -> Megastructure.builder(id, "stellar_ring_collider")
+            .prerequisite(context -> context.body() instanceof StarData star && star.size() < 48
+                && star.bodyClass() != CelestialBodyClass.NEUTRON_STAR
+                && star.bodyClass() != CelestialBodyClass.BLACK_HOLE)
+            .ring(4)
+            .model(4, ringModel(4, "collider"))
+            .material(ModItems.STELLAR_RING_COMPONENT, 8)
+            .handler(ColliderHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> DYSON_SPHERE_SMALL = register(
+        "dyson_sphere_small",
+        id -> Megastructure.builder(id, "dyson_sphere_small")
+            .prerequisite(context -> isOrdinaryStar(context, false))
+            .ring(4)
+            .rotation(ModMegastructures::bodySynchronizedRotation)
+            .model(4, ringModel(4, "dyson_sphere"))
+            .material(ModItems.DYSON_SPHERE_COMPONENT, 16)
+            .handler(() -> new DysonSphereHandler("dyson_sphere_small"))
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> DYSON_SPHERE_LARGE = register(
+        "dyson_sphere_large",
+        id -> Megastructure.builder(id, "dyson_sphere_large")
+            .prerequisite(context -> isOrdinaryStar(context, true))
+            .ring(5)
+            .rotation(ModMegastructures::bodySynchronizedRotation)
+            .model(5, ringModel(5, "dyson_sphere"))
+            .material(ModItems.DYSON_SPHERE_COMPONENT, 32)
+            .handler(() -> new DysonSphereHandler("dyson_sphere_large"))
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> MAGNETAR_COIL = register(
+        "magnetar_coil",
+        id -> Megastructure.builder(id, "magnetar_coil")
+            .prerequisite(context -> context.body() instanceof StarData star
+                && star.bodyClass() == CelestialBodyClass.NEUTRON_STAR)
+            .ring(4)
+            .model(4, ringModel(4, "coil"))
+            .material(ModItems.MAGNETAR_COIL_COMPONENT, 4)
+            .handler(MagnetarCoilHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> PENROSE_SPHERE = register(
+        "penrose_sphere",
+        id -> Megastructure.builder(id, "penrose_sphere")
+            .prerequisite(context -> isBlackHole(context))
+            .ring(4)
+            .rotation(context -> -bodySynchronizedRotation(context))
+            .model(4, ringModel(4, "penrose_sphere"))
+            .material(ModItems.PENROSE_SPHERE_COMPONENT, 8)
+            .handler(PenroseSphereHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> MATTER_DECOMPRESSOR = register(
+        "matter_decompressor",
+        id -> Megastructure.builder(id, "matter_decompressor")
+            .prerequisite(context -> context.body() instanceof StarData star
+                && (star.bodyClass() == CelestialBodyClass.NEUTRON_STAR
+                    || star.bodyClass() == CelestialBodyClass.BLACK_HOLE))
+            .ring(4)
+            .model(4, ringModel(4, "matter_decompressor"))
+            .material(ModItems.MATTER_DECOMPRESSOR_COMPONENT, 2)
+            .handler(MatterDecompressorHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> WORMHOLE_STABILIZER = register(
+        "wormhole_stabilizer",
+        id -> Megastructure.builder(id, "wormhole_stabilizer")
+            .prerequisite(context -> context.amplified() && isBlackHole(context))
+            .ring(4)
+            .model(4, ringModel(4, "wormhole_stabilizer"))
+            .material(ModItems.WORMHOLE_STABILIZER_COMPONENT, 4)
+            .handler(WormholeStabilizerHandler::new)
+            .build()
+    );
+    public static final DeferredHolder<Megastructure, Megastructure> STELLAR_EVOLUTION_ACCELERATOR = register(
+        "stellar_evolution_accelerator",
+        id -> Megastructure.builder(id, "stellar_evolution_accelerator")
+            .prerequisite(context -> context.body() instanceof StarData star
+                && star.bodyClass() != CelestialBodyClass.WHITE_DWARF
+                && star.bodyClass() != CelestialBodyClass.NEUTRON_STAR
+                && star.bodyClass() != CelestialBodyClass.BLACK_HOLE)
+            .ring(context -> context.body().size() >= 48 ? 6 : 5)
+            .model(5, ringModel(5, "stellar_evolution_accelerator"))
+            .model(6, ringModel(6, "stellar_evolution_accelerator"))
+            .material(ModItems.STELLAR_EVOLUTION_ACCELERATOR_COMPONENT, 8)
+            .handler(AcceleratorHandler::new)
+            .auxiliary()
+            .build()
+    );
+
+    private ModMegastructures() {
+    }
+
+    public static void register(IEventBus eventBus) {
+        ModMegastructures.REGISTER.register(eventBus);
+    }
+
+    private static DeferredHolder<Megastructure, Megastructure> register(
+        String name,
+        Function<Identifier, Megastructure> factory
+    ) {
+        Identifier id = AnvilCraft.of(name);
+        return ModMegastructures.REGISTER.register(name, () -> factory.apply(id));
+    }
+
+    private static Identifier ringModel(int ring, String name) {
+        return AnvilCraft.of("block/celestial_forging_anvil_ring_" + ring + "_" + name);
+    }
+
+    private static boolean isPlanet(Megastructure.Context context) {
+        return context.body() instanceof RockyPlanetData || context.body() instanceof SpecialCelestialBodyData;
+    }
+
+    private static boolean isErrorPlanet(Megastructure.Context context) {
+        return context.body() instanceof SpecialCelestialBodyData special && special.isErrorPlanet();
+    }
+
+    private static boolean hasLiquid(Megastructure.Context context) {
+        if (context.body() instanceof RockyPlanetData rocky) {
+            return rocky.liquidCoverage() != LiquidCoverage.NONE;
+        }
+        if (context.body() instanceof SpecialCelestialBodyData special) {
+            LiquidCoverage coverage = special.liquidCoverage();
+            return coverage != null && coverage != LiquidCoverage.NONE;
+        }
+        return false;
+    }
+
+    private static boolean isEcoStationEligible(PlanetaryResourceSet resources) {
+        if (resources == null) return true;
+        if (resources.hasCivilization()) return false;
+        return !resources.getBiologicalItems().isEmpty() || !resources.getBiologicalFluids().isEmpty();
+    }
+
+    private static boolean isOrdinaryStar(Megastructure.Context context, boolean large) {
+        return context.body() instanceof StarData star
+            && (star.size() >= 48) == large
+            && star.bodyClass() != CelestialBodyClass.NEUTRON_STAR
+            && star.bodyClass() != CelestialBodyClass.BLACK_HOLE;
+    }
+
+    private static boolean isBlackHole(Megastructure.Context context) {
+        return context.body() instanceof StarData star && star.bodyClass() == CelestialBodyClass.BLACK_HOLE;
+    }
+
+    private static float bodySynchronizedRotation(Megastructure.RotationContext context) {
+        if (context.body() instanceof StarData star) {
+            return context.bodyRotation() * CelestialBodyData.getVisualRotationSpeed(star.rotationSpeed());
+        }
+        return context.baseRotation();
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/ModItems.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/ModItems.java
@@ -571,7 +571,13 @@ public class ModItems {
             ) {
                 generator.itemModelOutput.accept(
                     ctx.get(),
-                    ItemModelUtils.specialModel(ModelLocationUtils.getModelLocation(ctx.get()), SpectralSlingshotRenderer.Unbaked.INSTANCE)
+                    ItemModelUtils.composite(
+                        ItemModelUtils.plainModel(ModelLocationUtils.getModelLocation(ctx.get())),
+                        ItemModelUtils.specialModel(
+                            ModelLocationUtils.getModelLocation(ctx.get()),
+                            SpectralSlingshotRenderer.Unbaked.INSTANCE
+                        )
+                    )
                 );
             }
         })
@@ -600,13 +606,19 @@ public class ModItems {
                             ModDataComponentPredicates.INT_COMP.get(),
                             new IntegerComponentPredicate(ModComponents.STORED_ENERGY, 0)
                         )),
-                        ItemModelUtils.specialModel(
-                            ModelLocationUtils.getModelLocation(item, "_exhausted"),
-                            SpectralWeaponLauncherRenderer.Unbaked.INSTANCE
+                        ItemModelUtils.composite(
+                            ItemModelUtils.plainModel(ModelLocationUtils.getModelLocation(item, "_exhausted")),
+                            ItemModelUtils.specialModel(
+                                ModelLocationUtils.getModelLocation(item, "_exhausted"),
+                                SpectralWeaponLauncherRenderer.Unbaked.INSTANCE
+                            )
                         ),
-                        ItemModelUtils.specialModel(
-                            ModelLocationUtils.getModelLocation(item),
-                            SpectralWeaponLauncherRenderer.Unbaked.INSTANCE
+                        ItemModelUtils.composite(
+                            ItemModelUtils.plainModel(ModelLocationUtils.getModelLocation(item)),
+                            ItemModelUtils.specialModel(
+                                ModelLocationUtils.getModelLocation(item),
+                                SpectralWeaponLauncherRenderer.Unbaked.INSTANCE
+                            )
                         )
                     )
                 );

--- a/src/main/java/dev/dubhe/anvilcraft/init/registry/ModRegistries.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/registry/ModRegistries.java
@@ -5,6 +5,7 @@ import dev.dubhe.anvilcraft.api.amulet.def.IAmuletDefinition;
 import dev.dubhe.anvilcraft.api.recipe.data.ICustomDataComponent;
 import dev.dubhe.anvilcraft.api.recipe.number.INumberProvider;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.IResultModifier;
+import dev.dubhe.anvilcraft.block.entity.celestial.Megastructure;
 import dev.dubhe.anvilcraft.item.property.component.amulet.IAmulet;
 import dev.dubhe.anvilcraft.saved.storage.category.ICategory;
 import net.minecraft.core.Registry;
@@ -34,6 +35,9 @@ public class ModRegistries {
     public static final Registry<ICategory.Type<?>> CATEGORY_TYPE = ModRegistries.simple(
         ModRegistryKeys.CATEGORY_TYPE
     );
+    public static final Registry<Megastructure> MEGASTRUCTURE = ModRegistries.simple(
+        ModRegistryKeys.MEGASTRUCTURE
+    );
 
     @SubscribeEvent
     public static void registerRegistries(NewRegistryEvent event) {
@@ -43,6 +47,7 @@ public class ModRegistries {
         event.register(ModRegistries.CUSTOM_DATA_TYPE);
         event.register(ModRegistries.NUMBER_PROVIDER_TYPE);
         event.register(ModRegistries.CATEGORY_TYPE);
+        event.register(ModRegistries.MEGASTRUCTURE);
     }
 
     private static <T> Registry<T> simple(ResourceKey<Registry<T>> key) {

--- a/src/main/java/dev/dubhe/anvilcraft/init/registry/ModRegistryKeys.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/registry/ModRegistryKeys.java
@@ -5,6 +5,7 @@ import dev.dubhe.anvilcraft.api.amulet.def.IAmuletDefinition;
 import dev.dubhe.anvilcraft.api.recipe.data.ICustomDataComponent;
 import dev.dubhe.anvilcraft.api.recipe.number.INumberProvider;
 import dev.dubhe.anvilcraft.api.recipe.result.modifier.IResultModifier;
+import dev.dubhe.anvilcraft.block.entity.celestial.Megastructure;
 import dev.dubhe.anvilcraft.item.property.component.amulet.IAmulet;
 import dev.dubhe.anvilcraft.saved.storage.category.ICategory;
 import net.minecraft.core.Registry;
@@ -23,6 +24,7 @@ public class ModRegistryKeys {
     public static final ResourceKey<Registry<INumberProvider.Type<?>>> NUMBER_PROVIDER_TYPE = ModRegistryKeys.key("number_provider");
     public static final ResourceKey<Registry<ICategory.Type<?>>> CATEGORY_TYPE = ModRegistryKeys.key("category_type");
     public static final ResourceKey<Registry<ICategory>> CATEGORY = ModRegistryKeys.key("category");
+    public static final ResourceKey<Registry<Megastructure>> MEGASTRUCTURE = ModRegistryKeys.key("megastructure");
 
     @SubscribeEvent
     public static void registerRegistries(DataPackRegistryEvent.NewRegistry event) {


### PR DESCRIPTION
- 新增可注册的巨构定义体系，统一管理巨构条件、环位、模型、材料、旋转逻辑与处理器，并注册内置巨构
- 将锻星砧巨构状态改为基于资源标识符持久化，兼容旧版名称和索引数据，统一处理建造、拆除、辅助巨构及激光需求
- 重构天体重构选项解析和客户端渲染，支持巨构模型动态替换、恒星同步旋转、玩家头颅天体渲染、恒星 Bloom 与扩展渲染包围盒
- 破坏锻星砧时保留方块实体内的库存、材料和控制器数据，避免已投入物品丢失
- 将物流接口提示信息改为基于版本号的 RPC 服务端快照同步，异步刷新寺庙需求、对撞机状态和接口库存
- 扩展行星资源配方的构建器、加权条目和嵌套随机选择，更新资源数据生成逻辑及供奉、荒地配方
- 修复光谱弹弓和光谱武器发射器模型，使基础物品模型与特殊渲染层正确组合
- 修正加速环默认方块状态及相关巨构处理器的状态判断
- resolved #4328 