### PR TITLE
Fix the fish tank input logic 修复鱼缸输入逻辑

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -245,7 +245,7 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
             int countInSlot = Integer.MAX_VALUE;
             for (int i = 7; i >= 0; i--) {
                 ItemStack stackInSlot = this.getStackInSlot(i);
-                if (stackInSlot.isEmpty()) {
+                if (stackInSlot.isEmpty() && countInSlot == Integer.MAX_VALUE) {
                     slot = i;
                     continue;
                 }
@@ -463,6 +463,7 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
         return ItemHandlerUtil.insertItem(this.output, stack, false);
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private static boolean isEmpty(IItemHandler handler) {
         for (int slot = 0; slot < handler.getSlots(); slot++) {
             if (!handler.getStackInSlot(slot).isEmpty()) return false;


### PR DESCRIPTION
- fixed #4357
  现在鱼缸不会在槽位1有对应物品时向空槽位0输入物品