### PR TITLE
Expose many api for addon mods 为附属开放许多接口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ runs/
 .claude/
 ref/
 /AGENT.md
+/.vscode

--- a/src/generated/resources/data/anvilcraft/tags/block/resin_shock_compatible.json
+++ b/src/generated/resources/data/anvilcraft/tags/block/resin_shock_compatible.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "anvilcraft:resin_block"
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/entity/IGenericAnvilEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/entity/IGenericAnvilEntity.java
@@ -1,0 +1,10 @@
+package dev.dubhe.anvilcraft.api.entity;
+
+/**
+ * 动态或自定义铁砧实体可声明自己满足「泛铁砧」谓词。
+ * {@link dev.dubhe.anvilcraft.recipe.anvil.predicate.block.HasAnvil} 仅在谓词未指定方块类型、
+ * 方块属性或 NBT 时询问此接口，因此不会误匹配专用铁砧配方。
+ */
+public interface IGenericAnvilEntity {
+    boolean anvilcraft$isGenericAnvil();
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/AnvilEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/AnvilEvent.java
@@ -96,6 +96,33 @@ public class AnvilEvent extends EntityEvent {
         }
     }
 
+    /**
+     * 世界内配方处理开始。在服务器线程、{@code handleNeoAnvilRecipe} 进入时发布。
+     * 用于隔离同一落点上的多个实体锅批次。
+     */
+    @Getter
+    public static class BeforeInWorldRecipe extends AnvilEvent {
+        private final OnLand landing;
+
+        public BeforeInWorldRecipe(OnLand landing) {
+            super(landing.getEntity());
+            this.landing = landing;
+        }
+    }
+
+    /**
+     * 世界内配方处理结束。无论成功与否都会在 {@code finally} 中发布。
+     */
+    @Getter
+    public static class AfterInWorldRecipe extends AnvilEvent {
+        private final OnLand landing;
+
+        public AfterInWorldRecipe(OnLand landing) {
+            super(landing.getEntity());
+            this.landing = landing;
+        }
+    }
+
     @Getter
     public static class HurtEntity extends AnvilEvent {
         private final BlockPos pos;

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/FishTankEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/FishTankEvent.java
@@ -1,0 +1,63 @@
+package dev.dubhe.anvilcraft.api.event;
+
+import dev.dubhe.anvilcraft.block.entity.FishTankBlockEntity;
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.Event;
+import net.neoforged.neoforge.fluids.FluidStack;
+
+/**
+ * 鱼缸扩展点。{@link ServerTick} 在本体熔岩翻新逻辑之前发布，因此非熔岩内容也可被处理。
+ */
+@Getter
+public class FishTankEvent extends Event {
+    private final Level level;
+    private final BlockPos pos;
+    private final FishTankBlockEntity tank;
+
+    public FishTankEvent(Level level, BlockPos pos, FishTankBlockEntity tank) {
+        this.level = level;
+        this.pos = pos;
+        this.tank = tank;
+    }
+
+    @Getter
+    public static class ServerTick extends FishTankEvent {
+        private final ServerLevel serverLevel;
+
+        public ServerTick(ServerLevel level, BlockPos pos, FishTankBlockEntity tank) {
+            super(level, pos, tank);
+            this.serverLevel = level;
+        }
+    }
+
+    @Getter
+    public static class EntityInside extends FishTankEvent {
+        private final BlockState state;
+        private final Entity entity;
+
+        public EntityInside(Level level, BlockPos pos, BlockState state, FishTankBlockEntity tank, Entity entity) {
+            super(level, pos, tank);
+            this.state = state;
+            this.entity = entity;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class FluidDamage extends FishTankEvent {
+        private final FluidStack fluid;
+        private float damage;
+
+        public FluidDamage(Level level, BlockPos pos, FishTankBlockEntity tank, FluidStack fluid, float damage) {
+            super(level, pos, tank);
+            this.fluid = fluid;
+            this.damage = damage;
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/GiantAnvilEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/GiantAnvilEvent.java
@@ -1,0 +1,62 @@
+package dev.dubhe.anvilcraft.api.event;
+
+import dev.dubhe.anvilcraft.block.GiantAnvilBlock;
+import dev.dubhe.anvilcraft.entity.FallingGiantAnvilEntity;
+import lombok.Getter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+/**
+ * 巨型铁砧生命周期扩展。均在服务器线程发布。
+ * 取消 {@link Multiblock} 将跳过写死的多方块转化配方；
+ * 取消 {@link BlockTick} / {@link FallingTick} 将跳过本体本 tick 的坍塌或下落逻辑。
+ */
+public class GiantAnvilEvent {
+    private GiantAnvilEvent() {
+    }
+
+    @Getter
+    public static class Multiblock extends Event implements ICancellableEvent {
+        private final AnvilEvent.GiantOnLand landing;
+
+        public Multiblock(AnvilEvent.GiantOnLand landing) {
+            this.landing = landing;
+        }
+    }
+
+    @Getter
+    public static class BlockTick extends Event implements ICancellableEvent {
+        private final GiantAnvilBlock block;
+        private final BlockState state;
+        private final ServerLevel level;
+        private final BlockPos pos;
+        private final RandomSource random;
+
+        public BlockTick(
+            GiantAnvilBlock block,
+            BlockState state,
+            ServerLevel level,
+            BlockPos pos,
+            RandomSource random
+        ) {
+            this.block = block;
+            this.state = state;
+            this.level = level;
+            this.pos = pos;
+            this.random = random;
+        }
+    }
+
+    @Getter
+    public static class FallingTick extends Event implements ICancellableEvent {
+        private final FallingGiantAnvilEntity entity;
+
+        public FallingTick(FallingGiantAnvilEntity entity) {
+            this.entity = entity;
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/LargeCauldronEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/LargeCauldronEvent.java
@@ -1,0 +1,132 @@
+package dev.dubhe.anvilcraft.api.event;
+
+import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
+
+/**
+ * 大型炼药锅扩展点。服务器事件仅在服务器线程发布；{@link UseItem} 可能在两侧调用。
+ */
+@Getter
+public class LargeCauldronEvent extends Event {
+    private final Level level;
+    private final BlockPos pos;
+
+    public LargeCauldronEvent(Level level, BlockPos pos) {
+        this.level = level;
+        this.pos = pos;
+    }
+
+    @Getter
+    public static class ServerTick extends LargeCauldronEvent {
+        private final ServerLevel serverLevel;
+        private final LargeCauldronBlockEntity cauldron;
+
+        public ServerTick(ServerLevel level, LargeCauldronBlockEntity cauldron) {
+            super(level, cauldron.getBlockPos());
+            this.serverLevel = level;
+            this.cauldron = cauldron;
+        }
+    }
+
+    @Getter
+    public static class EntityInside extends LargeCauldronEvent {
+        private final BlockState state;
+        private final Entity entity;
+
+        public EntityInside(Level level, BlockPos pos, BlockState state, Entity entity) {
+            super(level, pos);
+            this.state = state;
+            this.entity = entity;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class UseItem extends LargeCauldronEvent implements ICancellableEvent {
+        private final BlockState state;
+        private final Player player;
+        private final InteractionHand hand;
+        private final BlockHitResult hit;
+        private final ItemStack stack;
+        private ItemInteractionResult result = ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+
+        public UseItem(
+            Level level,
+            BlockPos pos,
+            BlockState state,
+            Player player,
+            InteractionHand hand,
+            BlockHitResult hit,
+            ItemStack stack
+        ) {
+            super(level, pos);
+            this.state = state;
+            this.player = player;
+            this.hand = hand;
+            this.hit = hit;
+            this.stack = stack;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class GiantAnvilImpact extends LargeCauldronEvent {
+        private final AnvilEvent.OnLand landing;
+        private final LargeCauldronBlockEntity cauldron;
+        private BlockState landedAnvilState;
+
+        public GiantAnvilImpact(
+            Level level,
+            AnvilEvent.OnLand landing,
+            LargeCauldronBlockEntity cauldron,
+            BlockState landedAnvilState
+        ) {
+            super(level, landing.getPos());
+            this.landing = landing;
+            this.cauldron = cauldron;
+            this.landedAnvilState = landedAnvilState;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class FluidDamage extends LargeCauldronEvent {
+        private final LargeCauldronBlockEntity cauldron;
+        private final FluidStack fluid;
+        private float damage;
+
+        public FluidDamage(LargeCauldronBlockEntity cauldron, FluidStack fluid, float damage) {
+            super(cauldron.getLevel(), cauldron.getBlockPos());
+            this.cauldron = cauldron;
+            this.fluid = fluid;
+            this.damage = damage;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class MixingOutput extends LargeCauldronEvent {
+        private final LargeCauldronBlockEntity cauldron;
+        private ItemStack result;
+
+        public MixingOutput(LargeCauldronBlockEntity cauldron, ItemStack result) {
+            super(cauldron.getLevel(), cauldron.getBlockPos());
+            this.cauldron = cauldron;
+            this.result = result;
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/event/SlidingBlockEvent.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/event/SlidingBlockEvent.java
@@ -1,0 +1,59 @@
+package dev.dubhe.anvilcraft.api.event;
+
+import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import lombok.Getter;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.event.entity.EntityEvent;
+import org.apache.commons.lang3.tuple.Triple;
+
+import java.util.Optional;
+
+/**
+ * 滑轨滑动实体的生命周期。{@link Start} 在构造完成、方块尚未从世界移除时于服务器线程发布；
+ * {@link Stop} 在方块写回世界之后、实体丢弃之前发布。
+ */
+@Getter
+public class SlidingBlockEvent extends EntityEvent {
+    private final SlidingBlockEntity entity;
+
+    public SlidingBlockEvent(SlidingBlockEntity entity) {
+        super(entity);
+        this.entity = entity;
+    }
+
+    @Getter
+    public static class Start extends SlidingBlockEvent {
+        private final Level level;
+        private final BlockPos origin;
+        private final Direction movement;
+        private final Iterable<Triple<BlockPos, BlockState, Optional<BlockEntity>>> blocks;
+
+        public Start(
+            SlidingBlockEntity entity,
+            Level level,
+            BlockPos origin,
+            Direction movement,
+            Iterable<Triple<BlockPos, BlockState, Optional<BlockEntity>>> blocks
+        ) {
+            super(entity);
+            this.level = level;
+            this.origin = origin;
+            this.movement = movement;
+            this.blocks = blocks;
+        }
+    }
+
+    @Getter
+    public static class Stop extends SlidingBlockEvent {
+        private final Level level;
+
+        public Stop(SlidingBlockEntity entity) {
+            super(entity);
+            this.level = entity.level();
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidPipeNetwork.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/fluid/network/FluidPipeNetwork.java
@@ -171,6 +171,72 @@ public class FluidPipeNetwork {
     }
 
     /**
+     * 事务性整桶推送：仅当某个更低且方向可达的端点能一次收下 {@code fluid} 的全部容量时才转移。
+     * 阀门/二极管/面止逆阀与重力分配使用同一套可达判定。失败时回滚源与目标，不留下半桶。
+     * 不扣减阀门 tick 预算。仅在服务器线程调用。
+     *
+     * @return 成功接收的目标容器位置；无法转移时返回 {@code null}
+     */
+    public @Nullable BlockPos pushExact(
+        IFluidHandler source,
+        BlockPos sourcePos,
+        BlockPos entryPipePos,
+        int sourceEffectiveHeight,
+        FluidStack fluid
+    ) {
+        if (fluid.isEmpty() || !this.parts.contains(entryPipePos)) {
+            return null;
+        }
+        FluidStack simulated = source.drain(fluid, IFluidHandler.FluidAction.SIMULATE);
+        if (simulated.getAmount() != fluid.getAmount()
+            || !FluidStack.isSameFluidSameComponents(simulated, fluid)) {
+            return null;
+        }
+        this.reachabilityCache.clear();
+        Reachability reachable = this.computeReachableCached(entryPipePos, fluid);
+        FluidEndpoint target = this.endpoints.stream()
+            .filter(endpoint -> endpoint.handler() != source)
+            .filter(endpoint -> endpoint.effectiveHeight() < sourceEffectiveHeight)
+            .filter(this::isPushExactConnected)
+            .filter(endpoint -> this.isEndpointReachable(reachable, endpoint))
+            .filter(endpoint -> endpoint.handler().fill(fluid, IFluidHandler.FluidAction.SIMULATE)
+                == fluid.getAmount())
+            .min(Comparator
+                .comparingInt(FluidEndpoint::effectiveHeight)
+                .thenComparingInt(endpoint -> endpoint.containerPos().distManhattan(sourcePos)))
+            .orElse(null);
+        if (target == null) {
+            return null;
+        }
+        FluidStack drained = source.drain(fluid, IFluidHandler.FluidAction.EXECUTE);
+        if (drained.getAmount() != fluid.getAmount()
+            || !FluidStack.isSameFluidSameComponents(drained, fluid)) {
+            if (!drained.isEmpty()) {
+                source.fill(drained, IFluidHandler.FluidAction.EXECUTE);
+            }
+            return null;
+        }
+        int filled = target.handler().fill(drained, IFluidHandler.FluidAction.EXECUTE);
+        if (filled == drained.getAmount()) {
+            return target.containerPos();
+        }
+        if (filled > 0) {
+            target.handler().drain(drained.copyWithAmount(filled), IFluidHandler.FluidAction.EXECUTE);
+        }
+        source.fill(drained, IFluidHandler.FluidAction.EXECUTE);
+        return null;
+    }
+
+    private boolean isPushExactConnected(FluidEndpoint endpoint) {
+        return endpoint.entity() == null || FluidContainerLookup.isEntityConnectedToPipe(
+            this.level,
+            endpoint.containerPos(),
+            endpoint.sideToPipe(),
+            endpoint.entity()
+        );
+    }
+
+    /**
      * 供外部主动泵送设备（如锻星砧流体接口）使用：把一个外部源容器当作等效高度为
      * {@code sourceEffectiveHeight} 的源，向本网络中更低的端点分配流体。
      *

--- a/src/main/java/dev/dubhe/anvilcraft/api/giantanvil/IShockFixedBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/giantanvil/IShockFixedBlock.java
@@ -1,0 +1,11 @@
+package dev.dubhe.anvilcraft.api.giantanvil;
+
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * 树脂撼地弹跳铁砧时，被标记为固定的方块保持为方块、不生成下落实体。
+ * 在服务器线程、撼地行为树执行期间调用。
+ */
+public interface IShockFixedBlock {
+    boolean anvilcraft$isFixedDuringShockBounce(BlockState state);
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -164,6 +164,10 @@ public class ItemHandlerUtil {
             itemHandler = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, context);
             if (itemHandler != null && hasItems(itemHandler)) return itemHandler;
         }
+        for (Entity entity : level.getEntitiesOfClass(Entity.class, aabb, Entity::isAlive)) {
+            itemHandler = entity.getCapability(Capabilities.ItemHandler.ENTITY);
+            if (itemHandler != null && hasExtractableItem(itemHandler)) return itemHandler;
+        }
         return null;
     }
 
@@ -200,6 +204,13 @@ public class ItemHandlerUtil {
     private static boolean hasItems(IItemHandler handler) {
         for (int slot = 0; slot < handler.getSlots(); slot++) {
             if (!handler.getStackInSlot(slot).isEmpty()) return true;
+        }
+        return false;
+    }
+
+    private static boolean hasExtractableItem(IItemHandler handler) {
+        for (int slot = 0; slot < handler.getSlots(); slot++) {
+            if (!handler.extractItem(slot, 1, true).isEmpty()) return true;
         }
         return false;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/api/menu/MenuBlockEntityLookup.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/menu/MenuBlockEntityLookup.java
@@ -1,0 +1,40 @@
+package dev.dubhe.anvilcraft.api.menu;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 菜单客户端构造在 {@link Level#getBlockEntity(BlockPos)} 失败时的查找扩展。
+ * 查找器在客户端与服务器线程都可能被调用；不得改变世界状态。
+ */
+public final class MenuBlockEntityLookup {
+    private static final List<Finder> FINDERS = new CopyOnWriteArrayList<>();
+
+    private MenuBlockEntityLookup() {
+    }
+
+    public static void register(Finder finder) {
+        FINDERS.add(finder);
+    }
+
+    public static @Nullable BlockEntity find(Level level, BlockPos pos, Class<? extends BlockEntity> type) {
+        BlockEntity existing = level.getBlockEntity(pos);
+        if (type.isInstance(existing)) return existing;
+        for (Finder finder : FINDERS) {
+            BlockEntity found = finder.find(level, pos, type);
+            if (type.isInstance(found)) return found;
+        }
+        return null;
+    }
+
+    @FunctionalInterface
+    public interface Finder {
+        @Nullable
+        BlockEntity find(Level level, BlockPos pos, Class<? extends BlockEntity> type);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/menu/package-info.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/menu/package-info.java
@@ -1,0 +1,9 @@
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+package dev.dubhe.anvilcraft.api.menu;
+
+import com.mojang.logging.annotations.FieldsAreNonnullByDefault;
+import com.mojang.logging.annotations.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/anvilcraft/api/plasma/PlasmaJetBehavior.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/plasma/PlasmaJetBehavior.java
@@ -1,0 +1,62 @@
+package dev.dubhe.anvilcraft.api.plasma;
+
+import dev.dubhe.anvilcraft.api.heat.HeaterInfo;
+import dev.dubhe.anvilcraft.block.entity.PlasmaJetsBlockEntity;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+
+/**
+ * 等离子喷流生命周期扩展。默认全部不处理。
+ * 服务器方法仅在服务器线程调用；粒子方法仅在客户端调用。
+ */
+public interface PlasmaJetBehavior {
+    default void onServerTickHead(PlasmaJetsBlockEntity jet, ServerLevel level) {
+    }
+
+    default void onServerTickTail(PlasmaJetsBlockEntity jet, ServerLevel level) {
+    }
+
+    default boolean shouldStopRaising(PlasmaJetsBlockEntity jet) {
+        return false;
+    }
+
+    default void afterRaise(PlasmaJetsBlockEntity from, PlasmaJetsBlockEntity to) {
+    }
+
+    default boolean keepInitialJet(PlasmaJetsBlockEntity jet, Level level) {
+        return false;
+    }
+
+    default HeaterInfo<?> heatInfo(PlasmaJetsBlockEntity jet, HeaterInfo<?> ordinary) {
+        return ordinary;
+    }
+
+    default float modifyDamage(PlasmaJetsBlockEntity jet, float ordinary) {
+        return ordinary;
+    }
+
+    /** 返回 {@code true} 表示已接管时长刷新，跳过原版燃油消耗。 */
+    default boolean refreshDuration(PlasmaJetsBlockEntity jet, Level level) {
+        return false;
+    }
+
+    default ParticleOptions particle(PlasmaJetsBlockEntity jet, ParticleOptions ordinary) {
+        return ordinary;
+    }
+
+    default void extraParticles(PlasmaJetsBlockEntity jet, ClientLevel level) {
+    }
+
+    default void onRemoved(PlasmaJetsBlockEntity jet) {
+    }
+
+    default void save(PlasmaJetsBlockEntity jet, CompoundTag tag, HolderLookup.Provider registries) {
+    }
+
+    default void load(PlasmaJetsBlockEntity jet, CompoundTag tag, HolderLookup.Provider registries) {
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/plasma/PlasmaJetFuelHandler.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/plasma/PlasmaJetFuelHandler.java
@@ -1,0 +1,38 @@
+package dev.dubhe.anvilcraft.api.plasma;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.util.TriState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * 等离子喷流燃料来源。{@link TriState#DEFAULT} 表示不处理，交给后续处理器或原版逻辑。
+ * {@link TriState#FALSE} 否决原版判定。查询与消耗均在服务器线程调用；
+ * 模拟性查询不得改变世界状态，{@code tryConsume*} 仅在实际消耗时改变状态。
+ */
+public interface PlasmaJetFuelHandler {
+    default TriState isIgnitedFuel(Level level, BlockPos cauldronPos) {
+        return TriState.DEFAULT;
+    }
+
+    default TriState isValidBase(Level level, BlockPos cauldronPos) {
+        return TriState.DEFAULT;
+    }
+
+    default TriState tryConsumeOnce(Level level, BlockPos cauldronPos) {
+        return TriState.DEFAULT;
+    }
+
+    default TriState usesContinuousFuel(Level level, BlockPos cauldronPos) {
+        return TriState.DEFAULT;
+    }
+
+    default TriState tryConsumeContinuousFuel(Level level, BlockPos cauldronPos, int amount) {
+        return TriState.DEFAULT;
+    }
+
+    /** 非空时覆盖原版炼药锅液量检查；小于 250 会阻止喷流生成。 */
+    default @Nullable Integer fuelAmount(Level level, BlockPos cauldronPos) {
+        return null;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/plasma/PlasmaJetHooks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/plasma/PlasmaJetHooks.java
@@ -1,0 +1,192 @@
+package dev.dubhe.anvilcraft.api.plasma;
+
+import dev.dubhe.anvilcraft.api.heat.HeaterInfo;
+import dev.dubhe.anvilcraft.block.entity.PlasmaJetsBlockEntity;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.util.TriState;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
+
+/**
+ * 等离子喷流附属扩展点。燃料查询与生成检查在服务器线程调用；粒子仅在客户端调用。
+ */
+public final class PlasmaJetHooks {
+    private static final List<Predicate<BlockState>> PASS_THROUGH = new CopyOnWriteArrayList<>();
+    private static final List<PlasmaJetFuelHandler> FUELS = new CopyOnWriteArrayList<>();
+    private static final List<PlasmaJetBehavior> BEHAVIORS = new CopyOnWriteArrayList<>();
+
+    private PlasmaJetHooks() {
+    }
+
+    public static void registerPassThrough(Predicate<BlockState> predicate) {
+        PASS_THROUGH.add(predicate);
+    }
+
+    public static void registerFuel(PlasmaJetFuelHandler handler) {
+        FUELS.add(handler);
+    }
+
+    public static void registerBehavior(PlasmaJetBehavior behavior) {
+        BEHAVIORS.add(behavior);
+    }
+
+    public static boolean isPassThrough(BlockState state) {
+        for (Predicate<BlockState> predicate : PASS_THROUGH) {
+            if (predicate.test(state)) return true;
+        }
+        return false;
+    }
+
+    public static boolean isIgnitedFuel(Level level, BlockPos pos) {
+        for (PlasmaJetFuelHandler handler : FUELS) {
+            TriState state = handler.isIgnitedFuel(level, pos);
+            if (state.isTrue()) return true;
+            if (state.isFalse()) return false;
+        }
+        return false;
+    }
+
+    public static @Nullable Boolean isValidBaseOverride(Level level, BlockPos pos) {
+        for (PlasmaJetFuelHandler handler : FUELS) {
+            TriState state = handler.isValidBase(level, pos);
+            if (state.isTrue()) return true;
+            if (state.isFalse()) return false;
+        }
+        return null;
+    }
+
+    public static @Nullable Boolean tryConsumeOnceOverride(Level level, BlockPos pos) {
+        for (PlasmaJetFuelHandler handler : FUELS) {
+            TriState state = handler.tryConsumeOnce(level, pos);
+            if (state.isTrue()) return true;
+            if (state.isFalse()) return false;
+        }
+        return null;
+    }
+
+    public static @Nullable Boolean usesContinuousFuelOverride(Level level, BlockPos pos) {
+        for (PlasmaJetFuelHandler handler : FUELS) {
+            TriState state = handler.usesContinuousFuel(level, pos);
+            if (state.isTrue()) return true;
+            if (state.isFalse()) return false;
+        }
+        return null;
+    }
+
+    public static @Nullable Boolean tryConsumeContinuousFuelOverride(Level level, BlockPos pos, int amount) {
+        for (PlasmaJetFuelHandler handler : FUELS) {
+            TriState state = handler.tryConsumeContinuousFuel(level, pos, amount);
+            if (state.isTrue()) return true;
+            if (state.isFalse()) return false;
+        }
+        return null;
+    }
+
+    public static @Nullable Integer fuelAmount(Level level, BlockPos pos) {
+        for (PlasmaJetFuelHandler handler : FUELS) {
+            Integer amount = handler.fuelAmount(level, pos);
+            if (amount != null) return amount;
+        }
+        return null;
+    }
+
+    public static void onServerTickHead(PlasmaJetsBlockEntity jet, ServerLevel level) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.onServerTickHead(jet, level);
+        }
+    }
+
+    public static void onServerTickTail(PlasmaJetsBlockEntity jet, ServerLevel level) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.onServerTickTail(jet, level);
+        }
+    }
+
+    public static boolean shouldStopRaising(PlasmaJetsBlockEntity jet) {
+        if (jet.getLevel() != null && isPassThrough(jet.getLevel().getBlockState(jet.getBlockPos().above()))) {
+            return true;
+        }
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            if (behavior.shouldStopRaising(jet)) return true;
+        }
+        return false;
+    }
+
+    public static void afterRaise(PlasmaJetsBlockEntity from, PlasmaJetsBlockEntity to) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.afterRaise(from, to);
+        }
+    }
+
+    public static boolean keepInitialJet(PlasmaJetsBlockEntity jet, Level level) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            if (behavior.keepInitialJet(jet, level)) return true;
+        }
+        return false;
+    }
+
+    public static HeaterInfo<?> heatInfo(PlasmaJetsBlockEntity jet, HeaterInfo<?> ordinary) {
+        HeaterInfo<?> result = ordinary;
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            result = behavior.heatInfo(jet, result);
+        }
+        return result;
+    }
+
+    public static float modifyDamage(PlasmaJetsBlockEntity jet, float ordinary) {
+        float result = ordinary;
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            result = behavior.modifyDamage(jet, result);
+        }
+        return result;
+    }
+
+    public static boolean refreshDuration(PlasmaJetsBlockEntity jet, Level level) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            if (behavior.refreshDuration(jet, level)) return true;
+        }
+        return false;
+    }
+
+    public static ParticleOptions particle(PlasmaJetsBlockEntity jet, ParticleOptions ordinary) {
+        ParticleOptions result = ordinary;
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            result = behavior.particle(jet, result);
+        }
+        return result;
+    }
+
+    public static void extraParticles(PlasmaJetsBlockEntity jet, ClientLevel level) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.extraParticles(jet, level);
+        }
+    }
+
+    public static void onRemoved(PlasmaJetsBlockEntity jet) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.onRemoved(jet);
+        }
+    }
+
+    public static void save(PlasmaJetsBlockEntity jet, CompoundTag tag, HolderLookup.Provider registries) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.save(jet, tag, registries);
+        }
+    }
+
+    public static void load(PlasmaJetsBlockEntity jet, CompoundTag tag, HolderLookup.Provider registries) {
+        for (PlasmaJetBehavior behavior : BEHAVIORS) {
+            behavior.load(jet, tag, registries);
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/plasma/package-info.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/plasma/package-info.java
@@ -1,0 +1,9 @@
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+package dev.dubhe.anvilcraft.api.plasma;
+
+import com.mojang.logging.annotations.FieldsAreNonnullByDefault;
+import com.mojang.logging.annotations.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingBlockStructureResolver.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingBlockStructureResolver.java
@@ -18,6 +18,7 @@ import java.util.List;
  */
 public class SlidingBlockStructureResolver {
     public static int MAX_PUSH_DEPTH = 12;
+    @Getter
     private final Level level;
     private final boolean extending;
     private final BlockPos startPos;
@@ -57,9 +58,9 @@ public class SlidingBlockStructureResolver {
         this.toDestroy.clear();
         BlockState blockstate = this.level.getBlockState(this.startPos);
         if (!PistonBaseBlock.isPushable(blockstate, this.level, this.startPos, this.pushDirection, false, this.pistonDirection)) {
-            if (!this.extending || blockstate.getPistonPushReaction() != PushReaction.DESTROY) return false;
+            if (!this.extending || this.pushReactionAt(this.startPos, blockstate) != PushReaction.DESTROY) return false;
             this.toDestroy.add(this.startPos);
-            return true;
+            return SlidingStructureHooks.expand(this);
         } else if (!this.addBlockLine(this.startPos, this.pushDirection)) {
             return false;
         } else {
@@ -69,12 +70,12 @@ public class SlidingBlockStructureResolver {
                 BlockPos blockpos = this.toPush.get(i);
                 if (this.level.getBlockState(blockpos).isStickyBlock() && !this.addBranchingBlocks(blockpos)) return false;
             }
-            return true;
+            return SlidingStructureHooks.expand(this);
         }
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private boolean addBlockLine(BlockPos originPos, Direction direction) {
+    public boolean addBlockLine(BlockPos originPos, Direction direction) {
         if (ignorePositions.contains(originPos)) return true;
         BlockState nowState = this.level.getBlockState(originPos);
         if (
@@ -145,7 +146,7 @@ public class SlidingBlockStructureResolver {
                 return false;
             }
 
-            if (nowState.getPistonPushReaction() == PushReaction.DESTROY) {
+            if (this.pushReactionAt(addingPos, nowState) == PushReaction.DESTROY) {
                 this.toDestroy.add(addingPos);
                 return true;
             }
@@ -172,7 +173,7 @@ public class SlidingBlockStructureResolver {
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private boolean addBranchingBlocks(BlockPos fromPos) {
+    public boolean addBranchingBlocks(BlockPos fromPos) {
         BlockState fromState = this.level.getBlockState(fromPos);
 
         for (Direction dir : Direction.values()) {
@@ -191,6 +192,16 @@ public class SlidingBlockStructureResolver {
         }
 
         return true;
+    }
+
+    private PushReaction pushReactionAt(BlockPos pos, BlockState state) {
+        return SlidingStructureHooks.modifyPushReaction(
+            this.level,
+            pos,
+            state,
+            state.getPistonPushReaction(),
+            this.pushDirection
+        );
     }
 
 }

--- a/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingRailLoad.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingRailLoad.java
@@ -1,0 +1,44 @@
+package dev.dubhe.anvilcraft.api.sliding;
+
+import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.phys.AABB;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 检测滑轨上的滑动载荷。在服务器 tick 中调用，查询不得改变世界状态。
+ */
+public final class SlidingRailLoad {
+    private static final List<OccupantCheck> EXTRA = new CopyOnWriteArrayList<>();
+
+    private SlidingRailLoad() {
+    }
+
+    public static void registerOccupant(OccupantCheck check) {
+        EXTRA.add(check);
+    }
+
+    public static boolean hasBlockLoad(ServerLevel level, BlockPos railPos) {
+        AABB above = new AABB(railPos.above());
+        if (!level.getEntitiesOfClass(SlidingBlockEntity.class, above).isEmpty()) {
+            return true;
+        }
+        for (OccupantCheck check : EXTRA) {
+            if (check.test(level, railPos, above)) return true;
+        }
+        return false;
+    }
+
+    public static boolean hasItemLoad(ServerLevel level, BlockPos railPos) {
+        return !level.getEntitiesOfClass(ItemEntity.class, new AABB(railPos)).isEmpty();
+    }
+
+    @FunctionalInterface
+    public interface OccupantCheck {
+        boolean test(ServerLevel level, BlockPos railPos, AABB above);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingStructureExtension.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingStructureExtension.java
@@ -1,0 +1,27 @@
+package dev.dubhe.anvilcraft.api.sliding;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+
+/**
+ * 附属可改写滑轨结构解析中的推动反应，并在原版解析成功后追加胶粘/粘性方块。
+ * 返回 {@code false} 表示结构无法移动。
+ */
+public interface SlidingStructureExtension {
+    default PushReaction modifyPushReaction(
+        Level level,
+        BlockPos pos,
+        BlockState state,
+        PushReaction original,
+        Direction pushDirection
+    ) {
+        return original;
+    }
+
+    default boolean expand(SlidingBlockStructureResolver resolver) {
+        return true;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingStructureHooks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingStructureHooks.java
@@ -1,0 +1,46 @@
+package dev.dubhe.anvilcraft.api.sliding;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 滑轨结构解析扩展：推动反应改写与解析成功后的额外收集。
+ * 在服务器线程调用；{@link #modifyPushReaction} 不得改变世界状态。
+ */
+public final class SlidingStructureHooks {
+    private static final List<SlidingStructureExtension> EXTENSIONS = new CopyOnWriteArrayList<>();
+
+    private SlidingStructureHooks() {
+    }
+
+    public static void register(SlidingStructureExtension extension) {
+        EXTENSIONS.add(extension);
+    }
+
+    public static PushReaction modifyPushReaction(
+        Level level,
+        BlockPos pos,
+        BlockState state,
+        PushReaction original,
+        Direction pushDirection
+    ) {
+        PushReaction reaction = original;
+        for (SlidingStructureExtension extension : EXTENSIONS) {
+            reaction = extension.modifyPushReaction(level, pos, state, reaction, pushDirection);
+        }
+        return reaction;
+    }
+
+    public static boolean expand(SlidingBlockStructureResolver resolver) {
+        for (SlidingStructureExtension extension : EXTENSIONS) {
+            if (!extension.expand(resolver)) return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/block/FishTankBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/FishTankBlock.java
@@ -6,6 +6,7 @@ import dev.anvilcraft.lib.v2.recipe.cache.BlockCache;
 import dev.anvilcraft.lib.v2.util.ShapeUtil;
 import dev.anvilcraft.lib.v2.util.Util;
 import dev.dubhe.anvilcraft.api.block.IIgnitableCauldron;
+import dev.dubhe.anvilcraft.api.event.FishTankEvent;
 import dev.dubhe.anvilcraft.api.hammer.HammerRotateBehavior;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.block.entity.FishTankBlockEntity;
@@ -47,6 +48,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.capabilities.Capabilities;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
@@ -170,6 +172,9 @@ public class FishTankBlock extends Block implements IMoveableEntityBlock, Hammer
 
     @Override
     protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
+        if (level.getBlockEntity(pos) instanceof FishTankBlockEntity tank) {
+            NeoForge.EVENT_BUS.post(new FishTankEvent.EntityInside(level, pos, state, tank, entity));
+        }
         if (level.isClientSide()) return;
         if (entity.isOnFire()) {
             this.tryIgnite(level, pos);

--- a/src/main/java/dev/dubhe/anvilcraft/block/GiantAnvilBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/GiantAnvilBlock.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import dev.anvilcraft.lib.v2.util.ShapeUtil;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
+import dev.dubhe.anvilcraft.api.event.GiantAnvilEvent;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.power.IPowerComponent;
 import dev.dubhe.anvilcraft.block.multipart.SimpleMultiPartBlock;
@@ -313,6 +314,9 @@ public class GiantAnvilBlock extends SimpleMultiPartBlock<Cube3x3PartHalf> imple
         BlockPos pos,
         RandomSource random
     ) {
+        if (NeoForge.EVENT_BUS.post(new GiantAnvilEvent.BlockTick(this, state, level, pos, random)).isCanceled()) {
+            return;
+        }
         BlockState ringState = level.getBlockState(pos.subtract(state.getValue(HALF).getOffset()).above(3));
 
         boolean isHeldByAcceleration = ringState.getBlock() instanceof AccelerationRingBlock

--- a/src/main/java/dev/dubhe/anvilcraft/block/LargeCauldronBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/LargeCauldronBlock.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.block;
 
 import dev.dubhe.anvilcraft.api.block.ICauldron;
 import dev.dubhe.anvilcraft.api.block.ICauldronGeometry;
+import dev.dubhe.anvilcraft.api.event.LargeCauldronEvent;
 import dev.dubhe.anvilcraft.api.fluid.FluidHandlerWrapper;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
@@ -43,6 +44,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
@@ -247,6 +249,18 @@ public class LargeCauldronBlock
         InteractionHand hand,
         BlockHitResult hit
     ) {
+        LargeCauldronEvent.UseItem useItem = NeoForge.EVENT_BUS.post(new LargeCauldronEvent.UseItem(
+            level,
+            pos,
+            state,
+            player,
+            hand,
+            hit,
+            stack
+        ));
+        if (useItem.isCanceled()) {
+            return useItem.getResult();
+        }
         if (stack.is(ModItemTags.ANVIL_HAMMER)) return ItemInteractionResult.SUCCESS;
         LargeCauldronBlockEntity cauldron = LargeCauldronBlockEntity.getMain(level, pos, state);
         if (cauldron == null) return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
@@ -331,6 +345,7 @@ public class LargeCauldronBlock
 
     @Override
     protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
+        NeoForge.EVENT_BUS.post(new LargeCauldronEvent.EntityInside(level, pos, state, entity));
         if (level.isClientSide() || !(entity instanceof ItemEntity item)) return;
         LargeCauldronBlockEntity cauldron = LargeCauldronBlockEntity.getMain(level, pos, state);
         if (cauldron != null) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/PlasmaJetsBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/PlasmaJetsBlock.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.block;
 import com.mojang.serialization.MapCodec;
 import dev.anvilcraft.lib.v2.recipe.cache.BlockCache;
 import dev.dubhe.anvilcraft.api.block.IIgnitableCauldron;
+import dev.dubhe.anvilcraft.api.plasma.PlasmaJetHooks;
 import dev.dubhe.anvilcraft.block.entity.PlasmaJetsBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
@@ -41,15 +42,23 @@ public class PlasmaJetsBlock extends BaseEntityBlock {
         ) {
             return false;
         }
-        BlockCache cache = new BlockCache(level);
-        if (
-            cache.getBlockState(pos.below()).getBlock() instanceof IIgnitableCauldron cauldron
-            && cauldron.getFluidAmount(cache, pos.below()) < 250
-        ) {
-            return false;
+        Integer hookedAmount = PlasmaJetHooks.fuelAmount(level, pos.below());
+        if (hookedAmount != null) {
+            if (hookedAmount < 250) {
+                return false;
+            }
+        } else {
+            BlockCache cache = new BlockCache(level);
+            if (
+                cache.getBlockState(pos.below()).getBlock() instanceof IIgnitableCauldron cauldron
+                && cauldron.getFluidAmount(cache, pos.below()) < 250
+            ) {
+                return false;
+            }
         }
         for (int i = 0; i < 8; i++) {
-            if (!level.getBlockState(pos.above(i)).isAir()) {
+            BlockState above = level.getBlockState(pos.above(i));
+            if (!above.isAir() && (i == 0 || !PlasmaJetHooks.isPassThrough(above))) {
                 return false;
             }
         }
@@ -82,6 +91,7 @@ public class PlasmaJetsBlock extends BaseEntityBlock {
 
     @SuppressWarnings("deprecation")
     public static boolean isIgnitedOilCauldron(Level level, BlockPos pos) {
+        if (PlasmaJetHooks.isIgnitedFuel(level, pos)) return true;
         BlockCache cache = new BlockCache(level);
         if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
         return cauldron.isIgnited(cache, pos) && cauldron.getFluid(cache, pos).is(ModFluidTags.OIL);
@@ -89,12 +99,16 @@ public class PlasmaJetsBlock extends BaseEntityBlock {
 
     @SuppressWarnings("deprecation")
     public static boolean isValidBaseCauldron(Level level, BlockPos pos) {
+        Boolean override = PlasmaJetHooks.isValidBaseOverride(level, pos);
+        if (override != null) return override;
         BlockCache cache = new BlockCache(level);
         if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
         return cauldron.isEmpty(cache, pos) || cauldron.getFluid(cache, pos).is(ModFluidTags.OIL);
     }
 
     public static boolean tryConsumeOnce(Level level, BlockPos pos) {
+        Boolean override = PlasmaJetHooks.tryConsumeOnceOverride(level, pos);
+        if (override != null) return override;
         BlockCache cache = new BlockCache(level);
         if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
         if (!cauldron.consumeOnce(cache, pos)) return false;
@@ -103,12 +117,16 @@ public class PlasmaJetsBlock extends BaseEntityBlock {
     }
 
     public static boolean usesContinuousFuel(Level level, BlockPos pos) {
+        Boolean override = PlasmaJetHooks.usesContinuousFuelOverride(level, pos);
+        if (override != null) return override;
         BlockCache cache = new BlockCache(level);
         if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
         return cauldron.usesContinuousPlasmaJetFuel(cache, pos);
     }
 
     public static boolean tryConsumeContinuousFuel(Level level, BlockPos pos, int amount) {
+        Boolean override = PlasmaJetHooks.tryConsumeContinuousFuelOverride(level, pos, amount);
+        if (override != null) return override;
         BlockCache cache = new BlockCache(level);
         if (!(cache.getBlockState(pos).getBlock() instanceof IIgnitableCauldron cauldron)) return false;
         if (!cauldron.consumeContinuousPlasmaJetFuel(cache, pos, amount)) return false;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.block.entity;
 import com.google.common.collect.ImmutableList;
 import dev.anvilcraft.lib.v2.recipe.cache.IItemHandlerCache;
 import dev.anvilcraft.lib.v2.util.MathUtil;
+import dev.dubhe.anvilcraft.api.event.FishTankEvent;
 import dev.dubhe.anvilcraft.api.fluid.FluidHandlerWrapper;
 import dev.dubhe.anvilcraft.api.fluid.IFluidHandlerHolder;
 import dev.dubhe.anvilcraft.api.fluid.network.FluidNetworkManager;
@@ -28,6 +29,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
@@ -49,6 +51,7 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.util.TriState;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -354,6 +357,9 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
     }
 
     public static void serverTick(Level level, BlockPos pos, BlockState state, FishTankBlockEntity entity) {
+        if (level instanceof ServerLevel serverLevel) {
+            NeoForge.EVENT_BUS.post(new FishTankEvent.ServerTick(serverLevel, pos, entity));
+        }
         if (!entity.fluidHandler.getFluid().is(Fluids.LAVA)) return;
         boolean changed = false;
         for (int slot = 0; slot < entity.input.getSlots(); slot++) {
@@ -848,7 +854,16 @@ public class FishTankBlockEntity extends BlockEntity implements IItemHandlerHold
                     entity.igniteForSeconds(8.0F);
                 }
             }
-            entity.hurt(level.damageSources().inFire(), 4.0F);
+            entity.hurt(
+                level.damageSources().inFire(),
+                NeoForge.EVENT_BUS.post(new FishTankEvent.FluidDamage(
+                    level,
+                    pos,
+                    this,
+                    stack,
+                    4.0F
+                )).getDamage()
+            );
         } else if (stack.is(Fluids.LAVA)) {
             entity.lavaHurt();
         } else if (entity.canFluidExtinguish(stack.getFluidType()) && entity.isOnFire()) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/LargeCauldronBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/LargeCauldronBlockEntity.java
@@ -9,11 +9,10 @@ import dev.anvilcraft.lib.v2.recipe.predicate.item.HasItemIngredient;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeContext;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeData;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeManager;
-import dev.anvilcraft.lib.v2.yukkuri.api.vapor.VaporizationCauldron;
-import dev.anvilcraft.lib.v2.yukkuri.api.vapor.VaporizationManager;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.block.ICauldron;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
+import dev.dubhe.anvilcraft.api.event.LargeCauldronEvent;
 import dev.dubhe.anvilcraft.api.fluid.FluidHandlerWrapper;
 import dev.dubhe.anvilcraft.api.fluid.IFluidHandlerHolder;
 import dev.dubhe.anvilcraft.api.fluid.LargeCauldronFluidHandler;
@@ -97,7 +96,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public class LargeCauldronBlockEntity extends BlockEntity
-    implements ICauldron, IItemHandlerHolder, IItemHandlerCache, IFluidHandlerHolder, VaporizationCauldron {
+    implements ICauldron, IItemHandlerHolder, IItemHandlerCache, IFluidHandlerHolder {
     public static final int OUTPUT_SLOTS = 32;
     public static final int MAX_PROCESS_EFFICIENCY = 9;
     private static final int[][] INPUT_SLOT_OFFSETS = {
@@ -193,7 +192,7 @@ public class LargeCauldronBlockEntity extends BlockEntity
         entity.applyFluidEffects((ServerLevel) level);
         entity.hurtEntitiesInsideFromCampfire((ServerLevel) level);
         entity.reforgeItemsInLava(level);
-        VaporizationManager.tick((ServerLevel) level, entity);
+        NeoForge.EVENT_BUS.post(new LargeCauldronEvent.ServerTick((ServerLevel) level, entity));
     }
 
     private void absorbFluidSources(Level level) {
@@ -259,26 +258,6 @@ public class LargeCauldronBlockEntity extends BlockEntity
     public FluidStack getTopFluid() {
         FluidStack fluid = this.getMainPart().topFluid();
         return fluid.isEmpty() ? FluidStack.EMPTY : fluid.copy();
-    }
-
-    @Override
-    public BlockPos vaporizationPos() {
-        return this.getBlockPos();
-    }
-
-    @Override
-    public boolean isMainVaporizationPart() {
-        return this.isMainPart();
-    }
-
-    @Override
-    public FluidStack getTopVaporizationFluid() {
-        return this.getTopFluid();
-    }
-
-    @Override
-    public FluidStack drainVaporizationFluid(FluidStack resource, IFluidHandler.FluidAction action) {
-        return this.getFluids().drainStoredFluid(resource, action);
     }
 
     public boolean isIgnited() {
@@ -496,6 +475,12 @@ public class LargeCauldronBlockEntity extends BlockEntity
         Level level = main.level;
         if (!(level instanceof ServerLevel serverLevel)) return false;
         BlockState landedAnvilState = level.getBlockState(event.getPos());
+        landedAnvilState = NeoForge.EVENT_BUS.post(new LargeCauldronEvent.GiantAnvilImpact(
+            level,
+            event,
+            main,
+            landedAnvilState
+        )).getLandedAnvilState();
         if (!(landedAnvilState.getBlock() instanceof GiantAnvilBlock giantAnvil)
             || !giantAnvil.getMainPartPos(event.getPos(), landedAnvilState).equals(main.worldPosition.above(3))) {
             return true;
@@ -671,7 +656,9 @@ public class LargeCauldronBlockEntity extends BlockEntity
             }
             boolean fits = true;
             for (ItemStack result : recipe.getItemResults()) {
-                if (!ItemHandlerHelper.insertItem(simulatedOutput, result.copy(), false).isEmpty()) {
+                ItemStack output = NeoForge.EVENT_BUS.post(new LargeCauldronEvent.MixingOutput(this, result.copy()))
+                    .getResult();
+                if (!ItemHandlerHelper.insertItem(simulatedOutput, output, false).isEmpty()) {
                     fits = false;
                     break;
                 }
@@ -680,7 +667,9 @@ public class LargeCauldronBlockEntity extends BlockEntity
 
             this.fluids.setFluids(mixedFluids);
             for (ItemStack result : recipe.getItemResults()) {
-                ItemHandlerHelper.insertItem(this.output, result.copy(), false);
+                ItemStack output = NeoForge.EVENT_BUS.post(new LargeCauldronEvent.MixingOutput(this, result.copy()))
+                    .getResult();
+                ItemHandlerHelper.insertItem(this.output, output, false);
             }
             return true;
         }
@@ -1269,7 +1258,14 @@ public class LargeCauldronBlockEntity extends BlockEntity
                     entity.setRemainingFireTicks(entity.getRemainingFireTicks() + 1);
                     if (entity.getRemainingFireTicks() == 0) entity.igniteForSeconds(8.0F);
                 }
-                entity.hurt(level.damageSources().inFire(), 4.0F);
+                entity.hurt(
+                    level.damageSources().inFire(),
+                    NeoForge.EVENT_BUS.post(new LargeCauldronEvent.FluidDamage(
+                        this,
+                        this.getTopFluid(),
+                        4.0F
+                    )).getDamage()
+                );
                 continue;
             }
             boolean touchesLava = false;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/PlasmaJetsBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/PlasmaJetsBlockEntity.java
@@ -7,6 +7,7 @@ import dev.anvilcraft.lib.v2.recipe.cache.BlockCache;
 import dev.dubhe.anvilcraft.api.block.IIgnitableCauldron;
 import dev.dubhe.anvilcraft.api.chargecollector.ChargeCollectorManager;
 import dev.dubhe.anvilcraft.api.heat.HeaterManager;
+import dev.dubhe.anvilcraft.api.plasma.PlasmaJetHooks;
 import dev.dubhe.anvilcraft.block.HeaterBlock;
 import dev.dubhe.anvilcraft.block.PlasmaJetsBlock;
 import dev.dubhe.anvilcraft.init.ModHeaterInfos;
@@ -21,16 +22,21 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -55,6 +61,7 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
     private @Nullable BlockPos cauldronPos = null;
     private int duration = 0;
     private int continuousFuelTimer = 0;
+    private CompoundTag addonData = new CompoundTag();
 
     public PlasmaJetsBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState blockState) {
         super(type, pos, blockState);
@@ -84,6 +91,7 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
 
     private boolean tryRaise() {
         if (this.tubeWalls.size() >= 4) return false;
+        if (PlasmaJetHooks.shouldStopRaising(this)) return false;
         if (this.level != null) {
             HeaterManager.removeProducer(this.getBlockPos(), level, ModHeaterInfos.NO_MAGNET_PLASMA_JETS);
             HeaterManager.removeProducer(this.getBlockPos(), level, ModHeaterInfos.MAGNET_PLASMA_JETS);
@@ -103,15 +111,26 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
         this.tubeWalls.add(TubeWallLayer.of(pos));
         this.level.removeBlock(pos, false);
         this.level.setBlock(pos.above(), ModBlocks.PLASMA_JETS.getDefaultState(), 3);
-        this.level.setBlockEntity(new PlasmaJetsBlockEntity(
+        PlasmaJetsBlockEntity raised = new PlasmaJetsBlockEntity(
             pos.above(),
             this.getBlockState(),
             this.duration,
             this.continuousFuelTimer,
             this.tubeWalls
-        ));
-        HeaterManager.addProducer(this.getBlockPos().above(), level, ModHeaterInfos.NO_MAGNET_PLASMA_JETS);
-        HeaterManager.addProducer(this.getBlockPos().above(), level, ModHeaterInfos.MAGNET_PLASMA_JETS);
+        );
+        raised.addonData = this.addonData.copy();
+        this.level.setBlockEntity(raised);
+        PlasmaJetHooks.afterRaise(this, raised);
+        HeaterManager.addProducer(
+            this.getBlockPos().above(),
+            level,
+            PlasmaJetHooks.heatInfo(raised, ModHeaterInfos.NO_MAGNET_PLASMA_JETS)
+        );
+        HeaterManager.addProducer(
+            this.getBlockPos().above(),
+            level,
+            PlasmaJetHooks.heatInfo(raised, ModHeaterInfos.MAGNET_PLASMA_JETS)
+        );
         return true;
     }
 
@@ -123,6 +142,7 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
         }
         HeaterManager.removeProducer(this.getBlockPos(), this.level, ModHeaterInfos.NO_MAGNET_PLASMA_JETS);
         HeaterManager.removeProducer(this.getBlockPos(), this.level, ModHeaterInfos.MAGNET_PLASMA_JETS);
+        PlasmaJetHooks.onRemoved(this);
     }
 
     public Pair<Set<BlockPos>, Set<BlockPos>> getHeatingPoses() {
@@ -156,6 +176,7 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
     }
 
     private void serverTick(ServerLevel level) {
+        PlasmaJetHooks.onServerTickHead(this, level);
         if (this.tryRaise()) return;
 
         this.refreshCauldronPos(level);
@@ -163,11 +184,20 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
         this.checkTubeWallIntegrity(level);
         this.refreshDuration(level);
 
-        HeaterManager.addProducer(this.getBlockPos(), level, ModHeaterInfos.NO_MAGNET_PLASMA_JETS);
-        HeaterManager.addProducer(this.getBlockPos(), level, ModHeaterInfos.MAGNET_PLASMA_JETS);
+        HeaterManager.addProducer(
+            this.getBlockPos(),
+            level,
+            PlasmaJetHooks.heatInfo(this, ModHeaterInfos.NO_MAGNET_PLASMA_JETS)
+        );
+        HeaterManager.addProducer(
+            this.getBlockPos(),
+            level,
+            PlasmaJetHooks.heatInfo(this, ModHeaterInfos.MAGNET_PLASMA_JETS)
+        );
         this.hurtEntities(level);
         this.provideCharge(level);
         this.playJetSound(level);
+        PlasmaJetHooks.onServerTickTail(this, level);
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -189,6 +219,9 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
     }
 
     protected void checkTubeWallIntegrity(Level level) {
+        if (this.shouldKeepEmptyPassThroughJet(level) || PlasmaJetHooks.keepInitialJet(this, level)) {
+            return;
+        }
         boolean wallBroken = this.tubeWalls.isEmpty();
         for (TubeWallLayer layer : this.tubeWalls) {
             if (layer.isBroken(level)) {
@@ -216,7 +249,28 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
         }
     }
 
+    private boolean shouldKeepEmptyPassThroughJet(Level level) {
+        if (!this.tubeWalls.isEmpty()) return false;
+        BlockPos jetPos = this.getBlockPos();
+        if (!PlasmaJetHooks.isPassThrough(level.getBlockState(jetPos.above()))) return false;
+        if (this.cauldronPos == null || !PlasmaJetsBlock.isValidBaseCauldron(level, this.cauldronPos)) return false;
+        BlockState heater = level.getBlockState(this.cauldronPos.below(1));
+        if (!heater.is(ModBlocks.HEATER) || heater.getOptionalValue(HeaterBlock.OVERLOAD).orElse(true)) {
+            return false;
+        }
+        for (Direction direction : Direction.Plane.HORIZONTAL) {
+            BlockPos side = jetPos.relative(direction);
+            if (!level.getBlockState(side).isFaceSturdy(level, side, direction.getOpposite())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     protected void refreshDuration(Level level) {
+        if (PlasmaJetHooks.refreshDuration(this, level)) {
+            return;
+        }
         if (this.cauldronPos != null && PlasmaJetsBlock.usesContinuousFuel(level, this.cauldronPos)) {
             if (--this.continuousFuelTimer <= 0) {
                 if (!PlasmaJetsBlock.tryConsumeContinuousFuel(
@@ -253,7 +307,7 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
         );
         for (Entity entity : entities) {
             entity.igniteForSeconds(15.0f);
-            if (entity.hurt(ModDamageTypes.plasmaJets(level), 16.0f)) {
+            if (entity.hurt(ModDamageTypes.plasmaJets(level), PlasmaJetHooks.modifyDamage(this, 16.0f))) {
                 entity.playSound(SoundEvents.GENERIC_BURN, 0.4f, 2.0f + RandomSource.create().nextFloat() * 0.4f);
             }
         }
@@ -304,9 +358,10 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
         Vec3 start = this.getParticleStartPos(level);
         Vec3 vector = start.vectorTo(this.getParticleEndPos());
         RandomSource random = level.getRandom();
+        ParticleOptions particle = PlasmaJetHooks.particle(this, ModParticles.PLASMA_JETS.get());
         for (int i = 0; i < 5; i++) {
             level.addParticle(
-                ModParticles.PLASMA_JETS.get(),
+                particle,
                 true,
                 start.x, start.y, start.z,
                 (random.nextIntBetweenInclusive(0, 20) - 10) / 100.0,
@@ -314,6 +369,7 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
                 (random.nextIntBetweenInclusive(0, 20) - 10) / 100.0
             );
         }
+        PlasmaJetHooks.extraParticles(this, level);
     }
 
     protected void refreshCauldronPos(Level level) {
@@ -352,6 +408,10 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
             tubeWalls.add(TubeWallLayer.CODEC.encode(layer, NbtOps.INSTANCE, new CompoundTag()).getOrThrow());
         }
         tag.put("tube_walls", tubeWalls);
+        PlasmaJetHooks.save(this, this.addonData, registries);
+        if (!this.addonData.isEmpty()) {
+            tag.put("addon", this.addonData);
+        }
     }
 
     @Override
@@ -367,6 +427,48 @@ public class PlasmaJetsBlockEntity extends BlockEntity {
             this.tubeWalls.add(TubeWallLayer.CODEC.decode(NbtOps.INSTANCE, tubeWallTag).getOrThrow().getFirst());
         }
         this.cauldronPos = this.getBlockPos().below(this.tubeWalls.size() + 1);
+        if (tag.contains("addon")) {
+            this.addonData = tag.getCompound("addon");
+        }
+        PlasmaJetHooks.load(this, this.addonData, registries);
+    }
+
+    public CompoundTag getAddonData() {
+        return this.addonData;
+    }
+
+    public int getDuration() {
+        return this.duration;
+    }
+
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+    public @Nullable BlockPos getCauldronPos() {
+        return this.cauldronPos;
+    }
+
+    public Set<TubeWallLayer> getTubeWalls() {
+        return this.tubeWalls;
+    }
+
+    public void syncToClient() {
+        this.setChanged();
+        if (this.level != null && !this.level.isClientSide()) {
+            BlockState state = this.getBlockState();
+            this.level.sendBlockUpdated(this.getBlockPos(), state, state, Block.UPDATE_CLIENTS);
+        }
+    }
+
+    @Override
+    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
+        return this.saveWithoutMetadata(registries);
+    }
+
+    @Override
+    public Packet<ClientGamePacketListener> getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
     }
 
     public record TubeWallLayer(Pair<BlockPos, BlockPos> first, Pair<BlockPos, BlockPos> second) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/StructureScannerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/StructureScannerBlockEntity.java
@@ -18,12 +18,16 @@ import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.decoration.Painting;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
@@ -163,9 +167,20 @@ public class StructureScannerBlockEntity extends BaseMachineBlockEntity implemen
     private String autoSaveStructureName = "";  // 自动保存的结构名称
     
     /**
-     * 缓存的方块数据
+     * 缓存的方块数据；nbt 为方块实体的完整原版结构语义数据（saveWithId），无方块实体时为 null
      */
-    public record CachedBlockData(int x, int y, int z, net.minecraft.world.level.block.state.BlockState state) {}
+    public record CachedBlockData(
+        int x,
+        int y,
+        int z,
+        net.minecraft.world.level.block.state.BlockState state,
+        @Nullable CompoundTag nbt
+    ) {}
+
+    /**
+     * 保存时刻捕获的实体条目（结构预览坐标系），字段语义与原版结构 entities 条目一致
+     */
+    public record CapturedEntityData(Vec3 pos, BlockPos blockPos, CompoundTag nbt) {}
     
     /**
      * 是否正在扫描或已完成扫描
@@ -335,7 +350,15 @@ public class StructureScannerBlockEntity extends BaseMachineBlockEntity implemen
                 net.minecraft.world.level.block.state.BlockState blockState = this.level.getBlockState(worldPos);
                 
                 if (!blockState.isAir()) {
-                    this.scannedBlocks.add(new CachedBlockData(x, this.currentScanLayer, z, blockState));
+                    // 与原版结构 fillFromWorld 一致，方块实体使用 saveWithId 保留完整数据
+                    net.minecraft.world.level.block.entity.BlockEntity worldBlockEntity =
+                        this.level.getBlockEntity(worldPos);
+                    CompoundTag blockEntityNbt = worldBlockEntity != null
+                        ? worldBlockEntity.saveWithId(this.level.registryAccess())
+                        : null;
+                    this.scannedBlocks.add(
+                        new CachedBlockData(x, this.currentScanLayer, z, blockState, blockEntityNbt)
+                    );
                 }
             }
         }
@@ -357,6 +380,148 @@ public class StructureScannerBlockEntity extends BaseMachineBlockEntity implemen
         }
     }
     
+    /**
+     * 保存时刻按原版结构 fillEntityList 语义捕获扫描区域内的实体（排除玩家），
+     * 坐标转换到与方块缓存相同的结构预览坐标系
+     */
+    public List<CapturedEntityData> captureEntities() {
+        List<CapturedEntityData> captured = new ArrayList<>();
+        if (this.level == null) {
+            return captured;
+        }
+        final int halfRangeX = this.rangeX.get() / 2;
+        BlockPos cornerA = calculateWorldPos(0, 0, 0, halfRangeX);
+        BlockPos cornerB = calculateWorldPos(
+            this.rangeX.get() - 1, this.rangeY.get() - 1, this.rangeZ.get() - 1, halfRangeX
+        );
+        BlockPos minCorner = new BlockPos(
+            Math.min(cornerA.getX(), cornerB.getX()),
+            Math.min(cornerA.getY(), cornerB.getY()),
+            Math.min(cornerA.getZ(), cornerB.getZ())
+        );
+        BlockPos maxCorner = new BlockPos(
+            Math.max(cornerA.getX(), cornerB.getX()),
+            Math.max(cornerA.getY(), cornerB.getY()),
+            Math.max(cornerA.getZ(), cornerB.getZ())
+        );
+        List<Entity> entities = this.level.getEntitiesOfClass(
+            Entity.class,
+            AABB.encapsulatingFullBlocks(minCorner, maxCorner),
+            entity -> !(entity instanceof Player)
+        );
+        for (Entity entity : entities) {
+            CompoundTag entityNbt = new CompoundTag();
+            entity.save(entityNbt);
+            Vec3 previewPos = worldToPreview(entity.position(), halfRangeX);
+            BlockPos previewBlockPos = entity instanceof Painting painting
+                ? worldBlockToPreview(painting.getPos(), halfRangeX)
+                : BlockPos.containing(previewPos);
+            captured.add(new CapturedEntityData(previewPos, previewBlockPos, entityNbt.copy()));
+        }
+        return captured;
+    }
+
+    /**
+     * 扫描器当前是否上下翻转扫描
+     */
+    public boolean isScannerUpsideDown() {
+        if (this.level == null) {
+            return false;
+        }
+        var blockState = this.level.getBlockState(this.getBlockPos());
+        return blockState.hasProperty(StructureScannerBlock.UPSIDE_DOWN)
+            && blockState.getValue(StructureScannerBlock.UPSIDE_DOWN);
+    }
+
+    /**
+     * 世界连续坐标转换到结构预览坐标系（calculateWorldPos 的逆变换）；
+     * 取反轴按格内镜像语义换算，保证实体在方块格内的相对位置一致
+     */
+    private Vec3 worldToPreview(Vec3 worldPos, int halfRangeX) {
+        BlockPos scannerPos = this.getBlockPos();
+        if (this.level == null) {
+            return Vec3.ZERO;
+        }
+        var blockState = this.level.getBlockState(scannerPos);
+        Direction scannerFacing = blockState.getValue(net.minecraft.world.level.block.HorizontalDirectionalBlock.FACING);
+        boolean upsideDown = blockState.hasProperty(StructureScannerBlock.UPSIDE_DOWN)
+            && blockState.getValue(StructureScannerBlock.UPSIDE_DOWN);
+
+        double previewY = upsideDown
+            ? (scannerPos.getY() + 1) - worldPos.y
+            : worldPos.y - scannerPos.getY();
+        double previewX;
+        double previewZ;
+        switch (scannerFacing) {
+            case SOUTH -> {
+                previewX = (scannerPos.getX() + halfRangeX + 1) - worldPos.x;
+                previewZ = (scannerPos.getZ() - 1) - worldPos.z;
+            }
+            case WEST -> {
+                previewX = (scannerPos.getZ() + halfRangeX + 1) - worldPos.z;
+                previewZ = worldPos.x - scannerPos.getX() - 2;
+            }
+            case EAST -> {
+                previewX = worldPos.z - scannerPos.getZ() + halfRangeX;
+                previewZ = (scannerPos.getX() - 1) - worldPos.x;
+            }
+            case NORTH -> {
+                previewX = worldPos.x - scannerPos.getX() + halfRangeX;
+                previewZ = worldPos.z - scannerPos.getZ() - 2;
+            }
+            // DOWN、UP 与 calculateWorldPos 的防御分支对应
+            default -> {
+                previewX = worldPos.x - scannerPos.getX() + halfRangeX;
+                previewZ = worldPos.z - scannerPos.getZ();
+            }
+        }
+        return new Vec3(previewX, previewY, previewZ);
+    }
+
+    /**
+     * 世界方块坐标转换到结构预览坐标系（用于画等以方块坐标定位的实体）
+     */
+    private BlockPos worldBlockToPreview(BlockPos worldPos, int halfRangeX) {
+        BlockPos scannerPos = this.getBlockPos();
+        if (this.level == null) {
+            return BlockPos.ZERO;
+        }
+        var blockState = this.level.getBlockState(scannerPos);
+        Direction scannerFacing = blockState.getValue(net.minecraft.world.level.block.HorizontalDirectionalBlock.FACING);
+        boolean upsideDown = blockState.hasProperty(StructureScannerBlock.UPSIDE_DOWN)
+            && blockState.getValue(StructureScannerBlock.UPSIDE_DOWN);
+
+        int previewY = upsideDown
+            ? scannerPos.getY() - worldPos.getY()
+            : worldPos.getY() - scannerPos.getY();
+        int previewX;
+        int previewZ;
+        switch (scannerFacing) {
+            case SOUTH -> {
+                previewX = scannerPos.getX() + halfRangeX - worldPos.getX();
+                previewZ = scannerPos.getZ() - 2 - worldPos.getZ();
+            }
+            case WEST -> {
+                previewX = scannerPos.getZ() + halfRangeX - worldPos.getZ();
+                previewZ = worldPos.getX() - scannerPos.getX() - 2;
+            }
+            case EAST -> {
+                previewX = worldPos.getZ() - scannerPos.getZ() + halfRangeX;
+                previewZ = scannerPos.getX() - 2 - worldPos.getX();
+            }
+            case NORTH -> {
+                previewX = worldPos.getX() - scannerPos.getX() + halfRangeX;
+                previewZ = worldPos.getZ() - scannerPos.getZ() - 2;
+            }
+            // DOWN、UP 与 calculateWorldPos 的防御分支对应
+            default -> {
+                previewX = worldPos.getX() - scannerPos.getX() + halfRangeX;
+                previewZ = worldPos.getZ() - scannerPos.getZ();
+            }
+        }
+        return new BlockPos(previewX, previewY, previewZ);
+    }
+
     /**
      * 计算世界坐标
      */
@@ -451,6 +616,9 @@ public class StructureScannerBlockEntity extends BaseMachineBlockEntity implemen
                 blockTag.putInt("y", data.y());
                 blockTag.putInt("z", data.z());
                 blockTag.put("state", net.minecraft.nbt.NbtUtils.writeBlockState(data.state()));
+                if (data.nbt() != null) {
+                    blockTag.put("nbt", data.nbt());
+                }
                 blocksTag.add(blockTag);
             }
             tag.put("scannedBlocks", blocksTag);
@@ -487,7 +655,10 @@ public class StructureScannerBlockEntity extends BaseMachineBlockEntity implemen
                     this.level.registryAccess().lookupOrThrow(net.minecraft.core.registries.Registries.BLOCK),
                     blockTag.getCompound("state")
                 );
-                this.scannedBlocks.add(new CachedBlockData(x, y, z, state));
+                CompoundTag blockEntityNbt = blockTag.contains("nbt", Tag.TAG_COMPOUND)
+                    ? blockTag.getCompound("nbt")
+                    : null;
+                this.scannedBlocks.add(new CachedBlockData(x, y, z, state, blockEntityNbt));
             }
         }
         // 加载自动保存状态

--- a/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/sliding/DetectorSlidingRailBlock.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.block.sliding;
 
 import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
+import dev.dubhe.anvilcraft.api.sliding.SlidingRailLoad;
 import dev.dubhe.anvilcraft.block.entity.DetectorSlidingRailBlockEntity;
 import dev.dubhe.anvilcraft.entity.SlidingBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
@@ -9,7 +10,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -25,7 +25,6 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.Property;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -94,8 +93,8 @@ public class DetectorSlidingRailBlock extends BaseSlidingRailBlock implements IH
     protected void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
         if (
             state.getValue(POWERED)
-            && level.getEntitiesOfClass(SlidingBlockEntity.class, new AABB(pos.above())).isEmpty()
-            && level.getEntitiesOfClass(ItemEntity.class, new AABB(pos)).isEmpty()
+            && !SlidingRailLoad.hasBlockLoad(level, pos)
+            && !SlidingRailLoad.hasItemLoad(level, pos)
         ) {
             level.setBlock(pos, state.setValue(POWERED, false), Block.UPDATE_ALL);
             level.getBlockEntity(pos, ModBlockEntities.DETECTOR_SLIDING_RAIL.get()).ifPresent(DetectorSlidingRailBlockEntity::cleanPower);

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/FishTankBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/FishTankBlockEntityRenderer.java
@@ -28,6 +28,7 @@ import net.minecraft.world.entity.animal.TropicalFish;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
@@ -50,6 +51,11 @@ public class FishTankBlockEntityRenderer implements BlockEntityRenderer<FishTank
 
     public FishTankBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {
         this.dispatcher = ctx.getBlockRenderDispatcher();
+    }
+
+    @Override
+    public AABB getRenderBoundingBox(FishTankBlockEntity tank) {
+        return new AABB(tank.getBlockPos()).expandTowards(0.0D, 2.0D, 0.0D);
     }
 
     private static class FishCacheEntry {
@@ -102,7 +108,7 @@ public class FishTankBlockEntityRenderer implements BlockEntityRenderer<FishTank
 
         this.drawTropicalFishInTank(tank, partialTick, pose, source, light);
         FishTankBlockEntityRenderer.drawFluidInTank(pose, source, light, fluid, minY, maxY);
-        if (tank.isIgnited()) {
+        if (tank.isIgnited() && FishTankRenderHooks.showVanillaFire(tank)) {
             pose.pushPose();
             pose.translate(0, maxY - (1 - TANK_W), 0);
             PoseStack.Pose last = pose.last();
@@ -122,6 +128,7 @@ public class FishTankBlockEntityRenderer implements BlockEntityRenderer<FishTank
             );
             pose.popPose();
         }
+        FishTankRenderHooks.afterRender(tank, partialTick, pose, source, light, overlay);
     }
 
     private static final float TANK_W = 1 / 16F + 0.001F; // avoiding Z-fighting

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/FishTankRenderHooks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/FishTankRenderHooks.java
@@ -1,0 +1,58 @@
+package dev.dubhe.anvilcraft.client.renderer.blockentity;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.dubhe.anvilcraft.block.entity.FishTankBlockEntity;
+import net.minecraft.client.renderer.MultiBufferSource;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 鱼缸客户端渲染扩展。仅在客户端渲染线程调用。
+ */
+public final class FishTankRenderHooks {
+    private static final List<Handler> HANDLERS = new CopyOnWriteArrayList<>();
+
+    private FishTankRenderHooks() {
+    }
+
+    public static void register(Handler handler) {
+        HANDLERS.add(handler);
+    }
+
+    public static boolean showVanillaFire(FishTankBlockEntity tank) {
+        for (Handler handler : HANDLERS) {
+            if (!handler.showVanillaFire(tank)) return false;
+        }
+        return true;
+    }
+
+    public static void afterRender(
+        FishTankBlockEntity tank,
+        float partialTick,
+        PoseStack poseStack,
+        MultiBufferSource buffers,
+        int packedLight,
+        int packedOverlay
+    ) {
+        for (Handler handler : HANDLERS) {
+            handler.afterRender(tank, partialTick, poseStack, buffers, packedLight, packedOverlay);
+        }
+    }
+
+    public interface Handler {
+        default boolean showVanillaFire(FishTankBlockEntity tank) {
+            return true;
+        }
+
+        default void afterRender(
+            FishTankBlockEntity tank,
+            float partialTick,
+            PoseStack poseStack,
+            MultiBufferSource buffers,
+            int packedLight,
+            int packedOverlay
+        ) {
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/LargeCauldronBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/LargeCauldronBlockEntityRenderer.java
@@ -72,9 +72,10 @@ public class LargeCauldronBlockEntityRenderer implements BlockEntityRenderer<Lar
         float itemY = Mth.clamp(MIN_Y + CONTENT_HEIGHT * fill - 0.08F, MIN_Y + 0.06F, MAX_Y - 0.12F);
         this.drawItems(cauldron, pose, buffers, light, overlay, itemY, fill);
         this.drawFluids(fluids, pose, buffers, light);
-        if (cauldron.isIgnited()) {
+        if (cauldron.isIgnited() && LargeCauldronRenderHooks.showVanillaFire(cauldron)) {
             this.drawFire(pose, buffers, overlay, MIN_Y + CONTENT_HEIGHT * fill);
         }
+        LargeCauldronRenderHooks.afterRender(cauldron, partialTick, pose, buffers, light, overlay);
     }
 
     private void drawItems(

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/LargeCauldronRenderHooks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/LargeCauldronRenderHooks.java
@@ -1,0 +1,58 @@
+package dev.dubhe.anvilcraft.client.renderer.blockentity;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
+import net.minecraft.client.renderer.MultiBufferSource;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 大型炼药锅客户端渲染扩展。仅在客户端渲染线程调用；不得在公共模组入口初始化其它模组的客户端 API。
+ */
+public final class LargeCauldronRenderHooks {
+    private static final List<Handler> HANDLERS = new CopyOnWriteArrayList<>();
+
+    private LargeCauldronRenderHooks() {
+    }
+
+    public static void register(Handler handler) {
+        HANDLERS.add(handler);
+    }
+
+    public static boolean showVanillaFire(LargeCauldronBlockEntity cauldron) {
+        for (Handler handler : HANDLERS) {
+            if (!handler.showVanillaFire(cauldron)) return false;
+        }
+        return true;
+    }
+
+    public static void afterRender(
+        LargeCauldronBlockEntity cauldron,
+        float partialTick,
+        PoseStack poseStack,
+        MultiBufferSource buffers,
+        int packedLight,
+        int packedOverlay
+    ) {
+        for (Handler handler : HANDLERS) {
+            handler.afterRender(cauldron, partialTick, poseStack, buffers, packedLight, packedOverlay);
+        }
+    }
+
+    public interface Handler {
+        default boolean showVanillaFire(LargeCauldronBlockEntity cauldron) {
+            return true;
+        }
+
+        default void afterRender(
+            LargeCauldronBlockEntity cauldron,
+            float partialTick,
+            PoseStack poseStack,
+            MultiBufferSource buffers,
+            int packedLight,
+            int packedOverlay
+        ) {
+        }
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/StructureDiskPreviewSupport.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/StructureDiskPreviewSupport.java
@@ -31,14 +31,29 @@ import org.lwjgl.opengl.GL30;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * 结构磁盘预览支持类
  * 管理结构磁盘的缓存和3D预览渲染
  */
 public class StructureDiskPreviewSupport {
+    private static final List<PreviewHandler> PREVIEW_HANDLERS = new CopyOnWriteArrayList<>();
+
+    /**
+     * 返回 {@code true} 表示已接管预览，跳过原版结构渲染。仅客户端调用。
+     */
+    public static void registerPreviewHandler(PreviewHandler handler) {
+        PREVIEW_HANDLERS.add(handler);
+    }
+
+    @FunctionalInterface
+    public interface PreviewHandler {
+        boolean render(GuiGraphics graphics, ItemStack stack, int mouseX, int mouseY);
+    }
 
     /**
      * 预览缓存：使用StructureUUID作为key
@@ -98,6 +113,11 @@ public class StructureDiskPreviewSupport {
      * 在指定位置渲染预览（公共方法，供事件监听器调用）
      */
     public static void renderPreviewAt(GuiGraphics guiGraphics, ItemStack diskStack, int mouseX, int mouseY) {
+        for (PreviewHandler handler : PREVIEW_HANDLERS) {
+            if (handler.render(guiGraphics, diskStack, mouseX, mouseY)) {
+                return;
+            }
+        }
         Minecraft minecraft = Minecraft.getInstance();
         if (minecraft.level == null) {
             return;

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -323,6 +323,9 @@ public class BlockTagLoader {
             .addTag(ModBlockTags.SLIDING_RAILS)
             .add(ModBlocks.SLIDING_RAIL_STOP.getKey());
 
+        provider.addTag(ModBlockTags.RESIN_SHOCK_COMPATIBLE)
+            .add(ModBlocks.RESIN_BLOCK.getKey());
+
         provider.addTag(ModBlockTags.OVERHEATABLE)
             .add(ModBlocks.OVERHEATED_EMBER_METAL_BLOCK.getKey())
             .add(ModBlocks.EMBER_METAL_BLOCK.getKey());

--- a/src/main/java/dev/dubhe/anvilcraft/entity/FallingGiantAnvilEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/FallingGiantAnvilEntity.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.entity;
 
+import dev.dubhe.anvilcraft.api.event.GiantAnvilEvent;
 import dev.dubhe.anvilcraft.block.GiantAnvilBlock;
 import dev.dubhe.anvilcraft.init.entity.ModEntities;
 import dev.dubhe.anvilcraft.util.AccelerateManager;
@@ -25,6 +26,7 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.NeoForge;
 
 public class FallingGiantAnvilEntity extends FallingBlockEntity {
     private float fallDistance = 0;
@@ -75,6 +77,9 @@ public class FallingGiantAnvilEntity extends FallingBlockEntity {
 
     @Override
     public void tick() {
+        if (NeoForge.EVENT_BUS.post(new GiantAnvilEvent.FallingTick(this)).isCanceled()) {
+            return;
+        }
         if (this.blockState.isAir()) {
             this.discard();
         } else {

--- a/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/SlidingBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.entity;
 
 import dev.anvilcraft.lib.v2.util.Util;
+import dev.dubhe.anvilcraft.api.event.SlidingBlockEvent;
 import dev.dubhe.anvilcraft.api.sliding.SlidingBlockSection;
 import dev.dubhe.anvilcraft.block.sliding.ISlidingRail;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
@@ -30,6 +31,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.apache.commons.lang3.tuple.Triple;
 
@@ -70,6 +72,7 @@ public class SlidingBlockEntity extends Entity {
         this.zo = bottomCenter.z;
         this.setStartPos(pos);
         this.moveDirection = moveDirection;
+        NeoForge.EVENT_BUS.post(new SlidingBlockEvent.Start(this, level, pos, moveDirection, infos));
     }
 
     @SuppressWarnings("UnusedReturnValue")
@@ -157,6 +160,7 @@ public class SlidingBlockEntity extends Entity {
     public void stop() {
         if (this.level().isClientSide) return;
         this.section.setBlock(this.level(), this.blockPosition(), this);
+        NeoForge.EVENT_BUS.post(new SlidingBlockEvent.Stop(this));
         this.discard();
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
@@ -46,6 +46,7 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.common.NeoForge;
 
 import java.util.List;
 import java.util.Optional;
@@ -120,24 +121,29 @@ public class AnvilEventListener {
     public static void handleNeoAnvilRecipe(AnvilEvent.OnLand event) {
         Level level = event.getLevel();
         if (!(level instanceof ServerLevel serverLevel)) return;
-        BlockPos pos = event.getPos();
-        FallingBlockEntity entity = event.getEntity();
-        InWorldRecipeManager manager = level.getRecipeManager().anvillib$getInWorldRecipeManager();
-        InWorldRecipeContext context = new InWorldRecipeContext(serverLevel, pos.getCenter().subtract(0.0, 0.5, 0.0), entity);
-        FishTankBlockEntity fishTank = level.getBlockEntity(pos.below(), ModBlockEntities.FISH_TANK.get()).orElse(null);
-        if (fishTank != null) fishTank.beginRecipeProcessing();
+        NeoForge.EVENT_BUS.post(new AnvilEvent.BeforeInWorldRecipe(event));
         try {
-            manager.trigger(ModRecipeTriggers.ON_ANVIL_FALL_ON, context);
-            boolean damageAnvil = context.get(DamageAnvil.DAMAGE_ANVIL);
-            if (!event.isAnvilDamage()) event.setAnvilDamage(damageAnvil);
-            GiantAnvilBlock.SUPPRESS_DROPS.set(true);
+            BlockPos pos = event.getPos();
+            FallingBlockEntity entity = event.getEntity();
+            InWorldRecipeManager manager = level.getRecipeManager().anvillib$getInWorldRecipeManager();
+            InWorldRecipeContext context = new InWorldRecipeContext(serverLevel, pos.getCenter().subtract(0.0, 0.5, 0.0), entity);
+            FishTankBlockEntity fishTank = level.getBlockEntity(pos.below(), ModBlockEntities.FISH_TANK.get()).orElse(null);
+            if (fishTank != null) fishTank.beginRecipeProcessing();
             try {
-                context.accept();
+                manager.trigger(ModRecipeTriggers.ON_ANVIL_FALL_ON, context);
+                boolean damageAnvil = context.get(DamageAnvil.DAMAGE_ANVIL);
+                if (!event.isAnvilDamage()) event.setAnvilDamage(damageAnvil);
+                GiantAnvilBlock.SUPPRESS_DROPS.set(true);
+                try {
+                    context.accept();
+                } finally {
+                    GiantAnvilBlock.SUPPRESS_DROPS.set(false);
+                }
             } finally {
-                GiantAnvilBlock.SUPPRESS_DROPS.set(false);
+                if (fishTank != null) fishTank.finishRecipeProcessing();
             }
         } finally {
-            if (fishTank != null) fishTank.finishRecipeProcessing();
+            NeoForge.EVENT_BUS.post(new AnvilEvent.AfterInWorldRecipe(event));
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/GiantAnvilLandingEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/GiantAnvilLandingEventListener.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.event.giantanvil;
 
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
+import dev.dubhe.anvilcraft.api.event.GiantAnvilEvent;
 import dev.dubhe.anvilcraft.block.entity.HasMobBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
@@ -24,6 +25,7 @@ import net.minecraft.world.phys.shapes.BitSetDiscreteVoxelShape;
 import net.minecraft.world.phys.shapes.DiscreteVoxelShape;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.Tags;
 
 import java.util.ArrayList;
@@ -54,6 +56,9 @@ public class GiantAnvilLandingEventListener {
 
     @SubscribeEvent
     public static void handleMultiblock(AnvilEvent.GiantOnLand event) {
+        if (NeoForge.EVENT_BUS.post(new GiantAnvilEvent.Multiblock(event)).isCanceled()) {
+            return;
+        }
         Level level = event.getLevel();
         BlockPos landPos = event.getPos().below(2);
 

--- a/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/GiantAnvilShockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/GiantAnvilShockEventListener.java
@@ -5,9 +5,11 @@ import dev.dubhe.anvilcraft.api.behavior.BehaviorTree;
 import dev.dubhe.anvilcraft.api.behavior.TreeNode;
 import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.api.giantanvil.IShockEntity;
+import dev.dubhe.anvilcraft.api.giantanvil.IShockFixedBlock;
 import dev.dubhe.anvilcraft.api.giantanvil.ShockAnvilBehavior;
 import dev.dubhe.anvilcraft.entity.FallingSpectralBlockEntity;
 import dev.dubhe.anvilcraft.init.ModSoundEvents;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.entity.ModDamageTypes;
 import dev.dubhe.anvilcraft.network.GiantAnvilShockEffectPacket;
@@ -107,11 +109,16 @@ public class GiantAnvilShockEventListener {
             )
         ).then(
             TreeNode.<ShockContext>predicatedExecutable(it ->
-                it.unwrap().testCorner(ModBlocks.RESIN_BLOCK) && it.unwrap().testBorder(ModBlocks.RESIN_BLOCK)
+                it.unwrap().testCorner(ModBlockTags.RESIN_SHOCK_COMPATIBLE)
+                    && it.unwrap().testBorder(ModBlockTags.RESIN_SHOCK_COMPATIBLE)
             ).executes(it -> {
                 Level level = it.unwrap().level();
                 for (BlockPos pos : it.unwrap().rangePosList()) {
                     BlockState state = level.getBlockState(pos);
+                    if (state.getBlock() instanceof IShockFixedBlock fixed
+                        && fixed.anvilcraft$isFixedDuringShockBounce(state)) {
+                        continue;
+                    }
                     if (state.is(ModBlocks.SPECTRAL_ANVIL.get())) {
                         FallingSpectralBlockEntity entity = FallingSpectralBlockEntity.fall(level, pos, state, false, true);
                         entity.setDeltaMovement(0, ShockContext.bounceVelocityForHeight(1.0D), 0);
@@ -249,8 +256,8 @@ public class GiantAnvilShockEventListener {
 
             // 音效与粒子
             if (AnvilCraft.CLIENT_CONFIG.groundHeaveParticlesEnabled) {
-                boolean isResin = context.testCorner(ModBlocks.RESIN_BLOCK.get())
-                    && context.testBorder(ModBlocks.RESIN_BLOCK.get());
+                boolean isResin = context.testCorner(ModBlockTags.RESIN_SHOCK_COMPATIBLE)
+                    && context.testBorder(ModBlockTags.RESIN_SHOCK_COMPATIBLE);
                 if (isResin) {
                     event.getLevel().playSound(null, event.getPos(), ModSoundEvents.GIANT_ANVIL_RESIN_SHOCK.get(),
                         SoundSource.BLOCKS, 2.0f, 0.8f + event.getLevel().random.nextFloat() * 0.4f);

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
@@ -47,6 +47,7 @@ public class ModBlockTags {
     public static final TagKey<Block> GIANT_ANVIL = bind("giant_anvil");
     public static final TagKey<Block> POWER_CONVERTER = bind("power_converter");
     public static final TagKey<Block> SLIDING_RAIL_STOP_LIKE = bind("sliding_rail_stop_like");
+    public static final TagKey<Block> RESIN_SHOCK_COMPATIBLE = bind("resin_shock_compatible");
 
     // common tags
     public static final TagKey<Block> ORES_TUNGSTEN = bindC("ores/tungsten");

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/AdvancedComparatorMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/AdvancedComparatorMenu.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.inventory;
 
+import dev.dubhe.anvilcraft.api.menu.MenuBlockEntityLookup;
 import dev.dubhe.anvilcraft.block.entity.AdvancedComparatorBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import lombok.Getter;
@@ -28,12 +29,20 @@ public class AdvancedComparatorMenu extends AbstractContainerMenu {
     }
 
     public AdvancedComparatorMenu(@Nullable MenuType<?> menuType, int containerId, Inventory inventory, FriendlyByteBuf extraData) {
-        this(
-            menuType, containerId, inventory,
-            Objects.requireNonNull(
-                inventory.player.level().getBlockEntity(extraData.readBlockPos()) instanceof AdvancedComparatorBlockEntity comparator
-                    ? comparator.readDataNbt(Objects.requireNonNull(extraData.readNbt())) : null
-            ));
+        this(menuType, containerId, inventory, readComparator(inventory, extraData));
+    }
+
+    private static AdvancedComparatorBlockEntity readComparator(Inventory inventory, FriendlyByteBuf extraData) {
+        BlockEntity found = MenuBlockEntityLookup.find(
+            inventory.player.level(),
+            extraData.readBlockPos(),
+            AdvancedComparatorBlockEntity.class
+        );
+        return Objects.requireNonNull(
+            found instanceof AdvancedComparatorBlockEntity comparator
+                ? comparator.readDataNbt(Objects.requireNonNull(extraData.readNbt()))
+                : null
+        );
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/ItemDetectorMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/ItemDetectorMenu.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.inventory;
 
+import dev.dubhe.anvilcraft.api.menu.MenuBlockEntityLookup;
 import dev.dubhe.anvilcraft.block.entity.IFilterBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.ItemDetectorBlockEntity;
 import dev.dubhe.anvilcraft.inventory.component.FilterOnlySlot;
@@ -45,7 +46,16 @@ public class ItemDetectorMenu extends AbstractContainerMenu implements IFilterMe
     }
 
     public ItemDetectorMenu(@Nullable MenuType<?> menuType, int containerId, Inventory inventory, FriendlyByteBuf extraData) {
-        this(menuType, containerId, inventory, Objects.requireNonNull(inventory.player.level().getBlockEntity(extraData.readBlockPos())));
+        this(
+            menuType,
+            containerId,
+            inventory,
+            Objects.requireNonNull(MenuBlockEntityLookup.find(
+                inventory.player.level(),
+                extraData.readBlockPos(),
+                ItemDetectorBlockEntity.class
+            ))
+        );
     }
 
     private void addPlayerInventory(Inventory playerInventory) {

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/PulseGeneratorMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/PulseGeneratorMenu.java
@@ -1,5 +1,6 @@
 package dev.dubhe.anvilcraft.inventory;
 
+import dev.dubhe.anvilcraft.api.menu.MenuBlockEntityLookup;
 import dev.dubhe.anvilcraft.block.entity.PulseGeneratorBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import lombok.Getter;
@@ -28,12 +29,20 @@ public class PulseGeneratorMenu extends AbstractContainerMenu {
     }
 
     public PulseGeneratorMenu(@Nullable MenuType<?> menuType, int containerId, Inventory inventory, FriendlyByteBuf extraData) {
-        this(
-            menuType, containerId, inventory,
-            Objects.requireNonNull(
-                inventory.player.level().getBlockEntity(extraData.readBlockPos()) instanceof PulseGeneratorBlockEntity repeater
-                    ? repeater.readDataNbt(Objects.requireNonNull(extraData.readNbt())) : null
-            ));
+        this(menuType, containerId, inventory, readGenerator(inventory, extraData));
+    }
+
+    private static PulseGeneratorBlockEntity readGenerator(Inventory inventory, FriendlyByteBuf extraData) {
+        BlockEntity found = MenuBlockEntityLookup.find(
+            inventory.player.level(),
+            extraData.readBlockPos(),
+            PulseGeneratorBlockEntity.class
+        );
+        return Objects.requireNonNull(
+            found instanceof PulseGeneratorBlockEntity repeater
+                ? repeater.readDataNbt(Objects.requireNonNull(extraData.readNbt()))
+                : null
+        );
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/property/component/StructureDiskData.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/property/component/StructureDiskData.java
@@ -2,7 +2,6 @@ package dev.dubhe.anvilcraft.item.property.component;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import dev.anvilcraft.lib.v2.codec.StreamCodecUtil;
 import net.minecraft.core.Direction;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.network.FriendlyByteBuf;
@@ -18,7 +17,8 @@ public record StructureDiskData(
     Direction direction,
     int sizeX,
     int sizeY,
-    int sizeZ
+    int sizeZ,
+    boolean upsideDown
 ) {
     public static final Codec<StructureDiskData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
         Codec.STRING.fieldOf("file").forGetter(StructureDiskData::file),
@@ -27,24 +27,36 @@ public record StructureDiskData(
         Direction.CODEC.optionalFieldOf("direction", Direction.NORTH).forGetter(StructureDiskData::direction),
         Codec.INT.fieldOf("sizeX").forGetter(StructureDiskData::sizeX),
         Codec.INT.fieldOf("sizeY").forGetter(StructureDiskData::sizeY),
-        Codec.INT.fieldOf("sizeZ").forGetter(StructureDiskData::sizeZ)
+        Codec.INT.fieldOf("sizeZ").forGetter(StructureDiskData::sizeZ),
+        Codec.BOOL.optionalFieldOf("upsideDown", false).forGetter(StructureDiskData::upsideDown)
     ).apply(instance, StructureDiskData::new));
 
-    public static final StreamCodec<FriendlyByteBuf, StructureDiskData> STREAM_CODEC = StreamCodecUtil.composite(
-        ByteBufCodecs.STRING_UTF8,
-        StructureDiskData::file,
-        ByteBufCodecs.STRING_UTF8,
-        StructureDiskData::name,
-        UUIDUtil.STREAM_CODEC,
-        StructureDiskData::uuid,
-        Direction.STREAM_CODEC,
-        StructureDiskData::direction,
-        ByteBufCodecs.VAR_INT,
-        StructureDiskData::sizeX,
-        ByteBufCodecs.VAR_INT,
-        StructureDiskData::sizeY,
-        ByteBufCodecs.VAR_INT,
-        StructureDiskData::sizeZ,
-        StructureDiskData::new
+    public static final StreamCodec<FriendlyByteBuf, StructureDiskData> STREAM_CODEC = StreamCodec.of(
+        StructureDiskData::write,
+        StructureDiskData::read
     );
+
+    private static void write(FriendlyByteBuf buffer, StructureDiskData data) {
+        ByteBufCodecs.STRING_UTF8.encode(buffer, data.file);
+        ByteBufCodecs.STRING_UTF8.encode(buffer, data.name);
+        UUIDUtil.STREAM_CODEC.encode(buffer, data.uuid);
+        Direction.STREAM_CODEC.encode(buffer, data.direction);
+        buffer.writeVarInt(data.sizeX);
+        buffer.writeVarInt(data.sizeY);
+        buffer.writeVarInt(data.sizeZ);
+        buffer.writeBoolean(data.upsideDown);
+    }
+
+    private static StructureDiskData read(FriendlyByteBuf buffer) {
+        return new StructureDiskData(
+            ByteBufCodecs.STRING_UTF8.decode(buffer),
+            ByteBufCodecs.STRING_UTF8.decode(buffer),
+            UUIDUtil.STREAM_CODEC.decode(buffer),
+            Direction.STREAM_CODEC.decode(buffer),
+            buffer.readVarInt(),
+            buffer.readVarInt(),
+            buffer.readVarInt(),
+            buffer.readBoolean()
+        );
+    }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasAnvil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasAnvil.java
@@ -6,6 +6,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.anvilcraft.lib.v2.recipe.predicate.IRecipePredicate;
 import dev.anvilcraft.lib.v2.recipe.util.InWorldRecipeContext;
 import dev.anvilcraft.lib.v2.util.predicate.BlockStatePredicate;
+import dev.dubhe.anvilcraft.api.entity.IGenericAnvilEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipePredicateTypes;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -13,6 +14,7 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.item.FallingBlockEntity;
+import net.minecraft.world.level.block.Blocks;
 
 /**
  * 铁砧条件谓词
@@ -64,8 +66,28 @@ public record HasAnvil(BlockStatePredicate anvil, boolean inverted) implements I
     @Override
     public boolean test(InWorldRecipeContext ctx) {
         if (!(ctx.getEntity() instanceof FallingBlockEntity falling)) return this.inverted;
+        if (falling instanceof IGenericAnvilEntity generic
+            && generic.anvilcraft$isGenericAnvil()
+            && this.anvil.getProperties().isEmpty()
+            && this.anvil.getNbts().isEmpty()
+            && isUnrestrictedAnvil(this.anvil)
+        ) {
+            return !this.inverted;
+        }
         if (!this.anvil.test(ctx.getLevel(), falling.getBlockState(), null)) return this.inverted;
         return !this.inverted;
+    }
+
+    /**
+     * 未指定方块类型/属性/NBT 的泛铁砧谓词。动态铁砧实体可声明自己匹配此类谓词，
+     * 而不会误匹配指定了皇家/余烬等专用铁砧的配方。
+     */
+    private static boolean isUnrestrictedAnvil(BlockStatePredicate predicate) {
+        if (predicate.getBlocks().size() == 0) return true;
+        return predicate.getBlocks().unwrap().map(
+            BlockTags.ANVIL::equals,
+            holders -> holders.size() == 1 && holders.getFirst().value() == Blocks.ANVIL
+        );
     }
 
     public static class Type implements IRecipePredicate.Type<HasAnvil> {

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/predicate/block/HasCauldron.java
@@ -45,6 +45,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 
@@ -68,6 +69,21 @@ public record HasCauldron(
     float chance,
     boolean ignited
 ) implements IRecipePredicate<HasCauldron> {
+    private static final List<EntityCauldronSelector> ENTITY_CAULDRON_SELECTORS = new CopyOnWriteArrayList<>();
+
+    /**
+     * 在最近实体锅查找之后调用。查询不得改变世界状态。
+     */
+    public static void registerEntityCauldronSelector(EntityCauldronSelector selector) {
+        ENTITY_CAULDRON_SELECTORS.add(selector);
+    }
+
+    @FunctionalInterface
+    public interface EntityCauldronSelector {
+        @Nullable
+        IEntityCauldron select(InWorldRecipeContext context, BlockPos pos, @Nullable IEntityCauldron current);
+    }
+
     private static final Codec<List<FluidStack>> TRANSFORMS_CODEC = Codec
         .either(FluidStack.CODEC, FluidStack.CODEC.listOf())
         .xmap(
@@ -403,6 +419,9 @@ public record HasCauldron(
             if (distance >= closestDistance) continue;
             closest = (IEntityCauldron) entity;
             closestDistance = distance;
+        }
+        for (EntityCauldronSelector selector : ENTITY_CAULDRON_SELECTORS) {
+            closest = selector.select(context, pos, closest);
         }
         return closest;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/util/RecipeUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/RecipeUtil.java
@@ -33,10 +33,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RecipeUtil {
     public static final ItemIngredientPredicate EMPTY_ITEM_INGREDIENT = ItemIngredientPredicate.Builder.item().build();
+    private static final List<LevelLikeCustomizer> LEVEL_LIKE_CUSTOMIZERS = new CopyOnWriteArrayList<>();
+
+    /**
+     * 在 JEI 假世界构建完成后调用。仅客户端。不得把预览数据写回真实世界。
+     */
+    @OnlyIn(Dist.CLIENT)
+    public static void registerLevelLikeCustomizer(LevelLikeCustomizer customizer) {
+        LEVEL_LIKE_CUSTOMIZERS.add(customizer);
+    }
+
+    @FunctionalInterface
+    public interface LevelLikeCustomizer {
+        void accept(BlockPattern pattern, LevelLike level);
+    }
 
     public static LootContext emptyLootContext(ServerLevel level) {
         return new LootContext.Builder(new LootParams(level, Map.of(), Map.of(), 0)).create(Optional.empty());
@@ -174,6 +189,9 @@ public class RecipeUtil {
             }
         }
 
+        for (LevelLikeCustomizer customizer : LEVEL_LIKE_CUSTOMIZERS) {
+            customizer.accept(pattern, levelLike);
+        }
         return levelLike;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/util/StructureSaveUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StructureSaveUtil.java
@@ -6,6 +6,7 @@ import dev.dubhe.anvilcraft.item.property.component.StructureDiskData;
 import net.minecraft.SharedConstants;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtIo;
@@ -105,7 +106,8 @@ public class StructureSaveUtil {
                 scannerFacing,
                 blockEntity.getRangeX().get(),
                 blockEntity.getRangeY().get(),
-                blockEntity.getRangeZ().get()
+                blockEntity.getRangeZ().get(),
+                blockEntity.isScannerUpsideDown()
             );
             outputDisk.set(ModComponents.STRUCTURE_DISK_DATA, data);
 
@@ -172,10 +174,36 @@ public class StructureSaveUtil {
                 blockTag.putInt("state", paletteIndex);
             }
 
+            // 与原版结构语义一致：方块实体数据写入该方块条目的 nbt 字段
+            if (data.nbt() != null) {
+                blockTag.put("nbt", data.nbt().copy());
+            }
+
             blocksTag.add(blockTag);
         }
         tag.put("blocks", blocksTag);
-        tag.put("entities", new ListTag());
+
+        // entities 字段：保存时刻按原版 fillEntityList 语义捕获区域内实体（排除玩家）
+        ListTag entitiesTag = new ListTag();
+        for (StructureScannerBlockEntity.CapturedEntityData entityData : blockEntity.captureEntities()) {
+            CompoundTag entityTag = new CompoundTag();
+
+            ListTag entityPosTag = new ListTag();
+            entityPosTag.add(DoubleTag.valueOf(entityData.pos().x));
+            entityPosTag.add(DoubleTag.valueOf(entityData.pos().y));
+            entityPosTag.add(DoubleTag.valueOf(entityData.pos().z));
+            entityTag.put("pos", entityPosTag);
+
+            ListTag entityBlockPosTag = new ListTag();
+            entityBlockPosTag.add(IntTag.valueOf(entityData.blockPos().getX()));
+            entityBlockPosTag.add(IntTag.valueOf(entityData.blockPos().getY()));
+            entityBlockPosTag.add(IntTag.valueOf(entityData.blockPos().getZ()));
+            entityTag.put("blockPos", entityBlockPosTag);
+
+            entityTag.put("nbt", entityData.nbt());
+            entitiesTag.add(entityTag);
+        }
+        tag.put("entities", entitiesTag);
 
         return tag;
     }

--- a/src/main/java/dev/dubhe/anvilcraft/util/StructureSaveUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StructureSaveUtil.java
@@ -186,12 +186,13 @@ public class StructureSaveUtil {
         // entities 字段：保存时刻按原版 fillEntityList 语义捕获区域内实体（排除玩家）
         ListTag entitiesTag = new ListTag();
         for (StructureScannerBlockEntity.CapturedEntityData entityData : blockEntity.captureEntities()) {
-            CompoundTag entityTag = new CompoundTag();
 
             ListTag entityPosTag = new ListTag();
             entityPosTag.add(DoubleTag.valueOf(entityData.pos().x));
             entityPosTag.add(DoubleTag.valueOf(entityData.pos().y));
             entityPosTag.add(DoubleTag.valueOf(entityData.pos().z));
+
+            CompoundTag entityTag = new CompoundTag();
             entityTag.put("pos", entityPosTag);
 
             ListTag entityBlockPosTag = new ListTag();


### PR DESCRIPTION
- 新增结构扫描仪能记录方块实体和实体
- 新增铁砧世界内配方前后事件，隔离同一落点上的多个实体锅批次
- 为鱼缸、大型炼药锅、巨型铁砧与滑动方块发布生命周期、交互与伤害事件
- 等离子喷流支持自定义燃料、行为、穿透方块、附加 NBT 与客户端同步
- 滑轨结构解析可改写推动反应并追加粘性方块，检测滑轨支持额外载荷
- 菜单客户端构造失败时可通过查找器解析方块实体
- 泛铁砧实体可匹配未限定类型的 HasAnvil 谓词，实体锅查找可注册选择器
- JEI 假世界与结构磁盘预览支持附属接管渲染或补全
- 流体管网提供事务性整桶推送，物品抽取可回退到实体物品能力
- 树脂撼地改为方块标签判定，并允许方块在弹跳时保持固定
- 大型炼药锅不再实现汽化接口，改为事件驱动扩展
- **就能少很多mixin了（**