### PR TITLE
Optimization: Anvils now completely skip recipe processing when landing on piezoelectric crystal, sugar block, or gunpowder block. 优化：让铁砧砸到压电晶体、糖块、火药块上时完全不触发配方处理

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -1579,6 +1579,7 @@
   "subtitles.anvilcraft.smart_block_placer_retract": "pǝʇɔɐɹʇǝɹ ɹǝɔɐꞁԀ ʞɔoꞁᗺ ʇɹɐɯS",
   "subtitles.anvilcraft.smart_block_placer_shulker_open": "sɹᴉɥʍ ɹǝɔɐꞁԀ ʞɔoꞁᗺ ʇɹɐɯS",
   "subtitles.anvilcraft.tesla_tower_strike": "sǝʞᴉɹʇs ɹǝʍo⟘ ɐꞁsǝ⟘",
+  "tag.block.anvilcraft.landing_no_recipe": "˙ᵷuᴉꞁpuɐɥ ǝdᴉɔǝɹ ɹǝᵷᵷᴉɹʇ ʇ,uoʍ ʇᴉ 'sʞɔoꞁq ǝsǝɥʇ ɟo ǝuo uo spuɐꞁ ꞁᴉʌuɐ uɐ uǝɥM",
   "tooltip.anvilcraft.burning_heater.burn_time": "%s :ǝɯᴉ⟘ uɹnᗺ ᵷuᴉuᴉɐɯǝᴚ",
   "tooltip.anvilcraft.burning_heater.burn_time_label": ":ǝɯᴉ⟘ uɹnᗺ ᵷuᴉuᴉɐɯǝᴚ",
   "tooltip.anvilcraft.burning_heater.can_smelt": ":ʇꞁǝɯS uɐƆ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -1579,6 +1579,7 @@
   "subtitles.anvilcraft.smart_block_placer_retract": "Smart Block Placer retracted",
   "subtitles.anvilcraft.smart_block_placer_shulker_open": "Smart Block Placer whirs",
   "subtitles.anvilcraft.tesla_tower_strike": "Tesla Tower strikes",
+  "tag.block.anvilcraft.landing_no_recipe": "When an anvil lands on one of these blocks, it won't trigger recipe handling.",
   "tooltip.anvilcraft.burning_heater.burn_time": "Remaining Burn Time: %s",
   "tooltip.anvilcraft.burning_heater.burn_time_label": "Remaining Burn Time:",
   "tooltip.anvilcraft.burning_heater.can_smelt": "Can Smelt:",

--- a/src/generated/resources/data/anvilcraft/tags/block/landing_no_recipe.json
+++ b/src/generated/resources/data/anvilcraft/tags/block/landing_no_recipe.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "anvilcraft:piezoelectric_crystal",
+    "anvilcraft:sugar_block",
+    "anvilcraft:gunpowder_block"
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/BlockLang.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/BlockLang.java
@@ -1,6 +1,7 @@
 package dev.dubhe.anvilcraft.data.lang;
 
 import dev.anvilcraft.lib.v2.registrum.providers.RegistrumLangProvider;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 
 public class BlockLang {
     @SuppressWarnings("checkstyle:LineLength")
@@ -25,5 +26,6 @@ public class BlockLang {
         provider.add("block.anvilcraft.spacetime_supercomputer.tick_sprint_cancelled", "Tick Sprint command execution cancelled");
         provider.add("block.anvilcraft.spacetime_supercomputer.tick_sprint_reject", "✗ Reject");
         provider.add("block.anvilcraft.spacetime_supercomputer.tick_sprint_rejected", "This command execution was rejected");
+        provider.add(ModBlockTags.LANDING_NO_RECIPE, "When an anvil lands on one of these blocks, it won't trigger recipe handling.");
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -326,6 +326,13 @@ public class BlockTagLoader {
         provider.addTag(ModBlockTags.RESIN_SHOCK_COMPATIBLE)
             .add(ModBlocks.RESIN_BLOCK.getKey());
 
+        provider.addTag(ModBlockTags.LANDING_NO_RECIPE)
+            .add(
+                ModBlocks.PIEZOELECTRIC_CRYSTAL.getKey(),
+                ModBlocks.SUGAR_BLOCK.getKey(),
+                ModBlocks.GUNPOWER_BLOCK.getKey()
+            );
+
         provider.addTag(ModBlockTags.OVERHEATABLE)
             .add(ModBlocks.OVERHEATED_EMBER_METAL_BLOCK.getKey())
             .add(ModBlocks.EMBER_METAL_BLOCK.getKey());

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -331,7 +331,7 @@ public class BlockTagLoader {
                 ModBlocks.PIEZOELECTRIC_CRYSTAL.getKey(),
                 ModBlocks.SUGAR_BLOCK.getKey(),
                 ModBlocks.GUNPOWER_BLOCK.getKey()
-            );
+        );
 
         provider.addTag(ModBlockTags.OVERHEATABLE)
             .add(ModBlocks.OVERHEATED_EMBER_METAL_BLOCK.getKey())

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
@@ -17,6 +17,7 @@ import dev.dubhe.anvilcraft.block.entity.LargeCauldronBlockEntity;
 import dev.dubhe.anvilcraft.block.multipart.AbstractMultiPartBlock;
 import dev.dubhe.anvilcraft.entity.FallingGiantAnvilEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlockTags;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTriggers;
 import dev.dubhe.anvilcraft.recipe.anvil.outcome.DamageAnvil;
@@ -120,13 +121,13 @@ public class AnvilEventListener {
 
     public static void handleNeoAnvilRecipe(AnvilEvent.OnLand event) {
         Level level = event.getLevel();
-        if (!(level instanceof ServerLevel serverLevel)) return;
+        if (!(level instanceof ServerLevel serverLevel) || event.getEntity().getBlockStateOn().is(ModBlockTags.LANDING_NO_RECIPE)) return;
         NeoForge.EVENT_BUS.post(new AnvilEvent.BeforeInWorldRecipe(event));
         try {
             BlockPos pos = event.getPos();
             FallingBlockEntity entity = event.getEntity();
             InWorldRecipeManager manager = level.getRecipeManager().anvillib$getInWorldRecipeManager();
-            InWorldRecipeContext context = new InWorldRecipeContext(serverLevel, pos.getCenter().subtract(0.0, 0.5, 0.0), entity);
+            InWorldRecipeContext context = new InWorldRecipeContext(serverLevel, pos.getBottomCenter(), entity);
             FishTankBlockEntity fishTank = level.getBlockEntity(pos.below(), ModBlockEntities.FISH_TANK.get()).orElse(null);
             if (fishTank != null) fishTank.beginRecipeProcessing();
             try {

--- a/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/anvil/AnvilEventListener.java
@@ -121,7 +121,11 @@ public class AnvilEventListener {
 
     public static void handleNeoAnvilRecipe(AnvilEvent.OnLand event) {
         Level level = event.getLevel();
-        if (!(level instanceof ServerLevel serverLevel) || event.getEntity().getBlockStateOn().is(ModBlockTags.LANDING_NO_RECIPE)) return;
+        if (!(level instanceof ServerLevel serverLevel)
+            || event.getLevel().getBlockState(event.getPos().below()).is(ModBlockTags.LANDING_NO_RECIPE)
+        ) {
+            return;
+        }
         NeoForge.EVENT_BUS.post(new AnvilEvent.BeforeInWorldRecipe(event));
         try {
             BlockPos pos = event.getPos();

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlockTags.java
@@ -48,6 +48,7 @@ public class ModBlockTags {
     public static final TagKey<Block> POWER_CONVERTER = bind("power_converter");
     public static final TagKey<Block> SLIDING_RAIL_STOP_LIKE = bind("sliding_rail_stop_like");
     public static final TagKey<Block> RESIN_SHOCK_COMPATIBLE = bind("resin_shock_compatible");
+    public static final TagKey<Block> LANDING_NO_RECIPE = bind("landing_no_recipe");
 
     // common tags
     public static final TagKey<Block> ORES_TUNGSTEN = bindC("ores/tungsten");


### PR DESCRIPTION
- 添加方块标签`anvilcraft:landing_no_recipe`
  - 默认包含压电晶体、糖块、火药块
  - 铁砧砸到这些方块时跳过`AnvilEventListener.handleNeoAnvilRecipe`