### PR TITLE
The position of the Mass Energy Inverter in the creation mode inventory has been adjusted. 调整了创造模式物品栏内能质逆变器的位置

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/init/item/tabs/FunctionalBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/tabs/FunctionalBlocks.java
@@ -110,7 +110,6 @@ public class FunctionalBlocks extends DisplayItemsGenerator {
 
         this.plain(ModBlocks.TRANSPARENT_CRAFTING_TABLE); // 通透工作台
         this.plain(ModBlocks.SPACE_OVERCOMPRESSOR); // 空间超压器
-        this.plain(ModBlocks.MASS_ENERGY_INVERTER); // 能质逆变器
         this.plain(ModBlocks.CRATE); // 板条箱
         this.plain(ModBlocks.LARGE_CRATE); // 大板条箱
         this.plain(ModBlocks.SHULKER_CONTAINER); // 潜影集装箱
@@ -139,6 +138,7 @@ public class FunctionalBlocks extends DisplayItemsGenerator {
         this.plain(ModBlocks.CONFINEMENT_CHAMBER); // 约束仓
 
         this.plain(ModBlocks.SPACETIME_SUPERCOMPUTER); // 时空超算
+        this.plain(ModBlocks.MASS_ENERGY_INVERTER); // 能质逆变器
         this.plain(ModBlocks.CELESTIAL_FORGING_ANVIL); // 锻星砧
         this.plain(ModBlocks.CELESTIAL_FORGING_ANVIL_AMPLIFIER); // 锻星砧增幅器
         this.plain(ModBlocks.CELESTIAL_FORGING_ANVIL_LOGISTICS_INTERFACE); // 锻星砧物流接口


### PR DESCRIPTION
- 移除了能质逆变器在功能块标签中的旧注册位置
- 重新添加能质逆变器到功能块标签列表的后部
- 保持代码结构整洁，确保功能块顺序合理