### PR TITLE
Fix server startup crash when collecting creative tab icons 修复服务端启动时获取创造标签页图标的崩溃

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/event/CategoryInitEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/CategoryInitEventListener.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,6 +44,21 @@ public class CategoryInitEventListener {
         // 从事件获取预设类别
         Map<String, ICategory> defaultCategories = NeoForge.EVENT_BUS.post(new ModCategoryInitEvent(registries)).getCategories();
         CategoryInitEventListener.ALL_MODS_CATEGORIES.addAll(defaultCategories.values());
+
+        Optional<Registry<Item>> registryOp = registries.registry(Registries.ITEM);
+        if (registryOp.isEmpty()) {
+            return;
+        }
+        Registry<Item> itemRegistry = registryOp.get();
+        Map<String, ItemStack> firstItemByNamespace = new HashMap<>();
+        Iterator<Holder.Reference<Item>> itemIt = itemRegistry.holders()
+            .sorted(Comparator.comparing(Holder.Reference::key))
+            .iterator();
+        while (itemIt.hasNext()) {
+            Holder.Reference<Item> itemRef = itemIt.next();
+            String namespace = itemRef.key().location().getNamespace();
+            firstItemByNamespace.putIfAbsent(namespace, itemRef.value().getDefaultInstance());
+        }
 
         Optional<Registry<CreativeModeTab>> tabRegistryOp = registries.registry(Registries.CREATIVE_MODE_TAB);
         if (tabRegistryOp.isEmpty()) {
@@ -66,7 +80,7 @@ public class CategoryInitEventListener {
             if (cache.containsKey(namespace)) {
                 continue;
             }
-            cache.put(namespace, ref.value().getIconItem());
+            cache.put(namespace, CategoryInitEventListener.resolveIcon(ref.value(), namespace, firstItemByNamespace));
         }
 
         // 提取没有创造模式标签页的模组
@@ -82,31 +96,37 @@ public class CategoryInitEventListener {
             missingIds.add(modId);
         }
 
-        Optional<Registry<Item>> registryOp = registries.registry(Registries.ITEM);
-        if (registryOp.isEmpty()) {
-            return;
-        }
-        Registry<Item> registry = registryOp.get();
-        Iterator<Holder.Reference<Item>> it = registry.holders()
-            .sorted(Comparator.comparing(Holder.Reference::key))
-            .iterator();
-
-        while (it.hasNext()) {
-            Holder.Reference<Item> ref = it.next();
-            String namespace = ref.key().location().getNamespace();
-            for (Iterator<String> iter = missingIds.iterator(); iter.hasNext(); ) {
-                String missingId = iter.next();
-                if (!Objects.equals(missingId, namespace)) {
-                    continue;
-                }
-                cache.put(missingId, ref.value().getDefaultInstance());
-                iter.remove();
+        for (String missingId : missingIds) {
+            ItemStack icon = firstItemByNamespace.getOrDefault(missingId, ItemStack.EMPTY);
+            if (!icon.isEmpty()) {
+                cache.put(missingId, icon);
             }
         }
 
         for (Map.Entry<String, ItemStack> entry : cache.entrySet()) {
+            if (entry.getValue().isEmpty()) {
+                continue;
+            }
             CategoryInitEventListener.ALL_MODS_CATEGORIES.add(new NamespaceCategory(entry.getValue(), entry.getKey()));
         }
+    }
+
+    private static ItemStack resolveIcon(
+        CreativeModeTab tab,
+        String namespace,
+        Map<String, ItemStack> firstItemByNamespace
+    ) {
+        try {
+            ItemStack icon = tab.getIconItem();
+            if (!icon.isEmpty()) {
+                return icon;
+            }
+        } catch (Exception e) {
+            // 某些模组的 getIconItem 依赖创造界面已打开或客户端上下文（如 Draconic Evolution 的 CyclingTab），
+            // 服务端启动阶段调用可能抛异常，降级为命名空间下首个物品的默认实例
+            AnvilCraft.LOGGER.warn("Failed to get icon from creative tab {}: {}", namespace, e);
+        }
+        return firstItemByNamespace.getOrDefault(namespace, ItemStack.EMPTY);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## Summary

### English

**Background**

`CategoryInitEventListener.onSetup()` runs on `ServerStartedEvent` (at `EventPriority.LOWEST`) and iterates **every registered creative mode tab** to build one "match all items of this mod" category (`NamespaceCategory`) per mod namespace, which powers the storage category settings screen. To pick a representative icon for each namespace, it calls `CreativeModeTab.getIconItem()`.

**The bug**

`getIconItem()` is arbitrary third-party code invoked during **server startup**. Some mods implement it assuming the creative inventory screen has already been opened — e.g. Draconic Evolution's `CyclingTab` (`DECreativeTabs.java:98` on the 1.21 branch):

```java
int idx = (int) (System.currentTimeMillis() / 1200) % stacks.size();
```

`stacks` is only populated inside `displayItems`, which runs only when the creative screen is opened on the client. On a dedicated server (or before the first creative-screen opening), the list is empty, so `% stacks.size()` throws `ArithmeticException: / by zero`, which propagates out of the server-start event handler and crashes server startup.

**The fix**

- Resolve the tab icon defensively via a new `resolveIcon(...)` helper: `try { tab.getIconItem() }` and fall back when it throws or returns an empty stack.
- Pre-build a `namespace -> first item` map from the item registry (one pass) and use it both as the fallback icon source and to replace the previous full second pass over the item registry for mods without creative tabs.
- Skip namespaces that end up with no icon at all (a category that can never match any item is meaningless).
- Log a `warn` when a mod's `getIconItem()` misbehaves, to aid debugging.

Well-behaved mods are unaffected and keep their tab icon; broken ones degrade to the namespace's first item instead of crashing the server.

### 中文

**背景**

`CategoryInitEventListener.onSetup()` 在 `ServerStartedEvent`（`EventPriority.LOWEST`）上执行，会遍历**所有已注册的创造模式标签页**，为每个模组命名空间生成一个"匹配该模组全部物品"的分类（`NamespaceCategory`），供仓储分类设置界面使用。为了给每个命名空间挑选代表图标，代码调用了 `CreativeModeTab.getIconItem()`。

**问题**

`getIconItem()` 是在**服务端启动阶段**执行的任意第三方代码。部分模组假设它只会在创造模式物品栏界面打开后被调用——例如龙之进化的 `CyclingTab`（1.21 分支 `DECreativeTabs.java:98`）：

```java
int idx = (int) (System.currentTimeMillis() / 1200) % stacks.size();
```

`stacks` 只在 `displayItems` 中被填充，而 `displayItems` 只在客户端打开创造界面时运行。在专用服务器上（或玩家首次打开创造界面前），列表为空，`% stacks.size()` 抛出 `ArithmeticException: / by zero`，异常从服务端启动事件处理器中向上传播，导致服务器启动崩溃。

**修复**

- 新增 `resolveIcon(...)` 辅助方法防御式解析标签页图标：`try { tab.getIconItem() }`，抛出异常或返回空栈时降级。
- 预构建物品注册表的「命名空间 → 首个物品」映射（单次遍历），既作为图标兜底来源，也替代了原先为"无创造标签页的模组"而做的第二次物品表全量遍历。
- 跳过最终仍无图标的命名空间（永远匹配不到物品的分类没有意义）。
- 当某个模组的 `getIconItem()` 行为异常时记录 `warn` 日志，便于排查。

行为正常的模组不受影响，仍保留自己的标签页图标；有问题的模组降级为命名空间首个物品图标，而不是让服务器启动崩溃。

## Verification / 验证

- `./gradlew.bat compileJava --console=plain` — BUILD SUCCESSFUL
- `git diff --check` — clean
