### PR TITLE
Deprecated old item bar registration names have been identified and re-mapped. 标记并重新兼容了已弃用的旧版物品栏注册名

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 minecraft = "1.21.1"
 neoForge = "21.1.219"
 
-anvillib = "2.0.0+snapshot.512"
+anvillib = "2.0.0+snapshot.513"
 ageratum = "0.0.1+build.111"
 
 jei = "19.32.0.358"

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/ModItemGroups.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/ModItemGroups.java
@@ -52,6 +52,9 @@ public class ModItemGroups {
         DeferredHolder.create(Registries.CREATIVE_MODE_TAB, AnvilCraft.of("functional_blocks"));
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_BUILDING_BLOCKS =
         DeferredHolder.create(Registries.CREATIVE_MODE_TAB, AnvilCraft.of("building_blocks"));
+    @Deprecated
+    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_BUILD_BLOCK =
+        ANVILCRAFT_BUILDING_BLOCKS;
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_ITEMS =
         DeferredHolder.create(Registries.CREATIVE_MODE_TAB, AnvilCraft.of("items"));
 

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/ModItemGroups.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/ModItemGroups.java
@@ -64,6 +64,8 @@ public class ModItemGroups {
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_ITEMS =
         DeferredHolder.create(Registries.CREATIVE_MODE_TAB, AnvilCraft.of("items"));
 
+    // 旧版命名（ANVILCRAFT_TOOL / ANVILCRAFT_FUNCTION_BLOCK / ANVILCRAFT_BUILD_BLOCK）仅为兼容旧附属保留，
+    // 均已标记 @Deprecated，新代码请使用上方的新版命名，且建议挂靠在ANVILCRAFT_ITEMS后。
     public static void register(IEventBus modEventBus) {
         modEventBus.addListener(ModItemGroups::registerTabs);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/ModItemGroups.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/ModItemGroups.java
@@ -53,6 +53,12 @@ public class ModItemGroups {
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_BUILDING_BLOCKS =
         DeferredHolder.create(Registries.CREATIVE_MODE_TAB, AnvilCraft.of("building_blocks"));
     @Deprecated
+    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_TOOL =
+        ANVILCRAFT_TOOLS_AND_UTILITIES;
+    @Deprecated
+    public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_FUNCTION_BLOCK =
+        ANVILCRAFT_FUNCTIONAL_BLOCKS;
+    @Deprecated
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_BUILD_BLOCK =
         ANVILCRAFT_BUILDING_BLOCKS;
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> ANVILCRAFT_ITEMS =


### PR DESCRIPTION
- 这下附属不会炸了