### PR TITLE
Fix crash on using Geode 修复使用晶洞时崩溃

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/util/BlockHighlightUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/BlockHighlightUtil.java
@@ -21,7 +21,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /// 方块高亮
@@ -96,7 +95,8 @@ public class BlockHighlightUtil {
         BlockHighlightUtil.LEVEL_REF.set(level);
     }
 
+    @Nullable
     static Level getLevel() {
-        return Objects.requireNonNull(BlockHighlightUtil.LEVEL_REF.get());
+        return BlockHighlightUtil.LEVEL_REF.get();
     }
 }


### PR DESCRIPTION
#4321 在 `BlockHighlightUtil.getLevel` 方法添加了 `Objects.requireNonNull` 空值 guard，导致 `BlockHighlightUtil.highlightBlock` 方法在调用这个方法时抛出空指针异常使游戏崩溃。该 PR 修复了上述问题。

该问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。