### PR TITLE
Document current machine behavior and resource namespaces

### DIFF
--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/003_power/103_power_convert.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/003_power/103_power_convert.md
@@ -40,7 +40,7 @@ AnvilCraft's electrical power is fundamentally different from other mods' energy
 - Conversion has loss
 - Different sizes convert different amounts of energy, see the table below for details
 
-|                         能量转换器                          | 消耗(kW) | 等价能量(FE/t) | 损耗后转换出的能量(FE/t) |
+|                        Power Converter                         | Consumption (kW) | Equivalent Energy (FE/t) | Converted Energy After Loss (FE/t) |
 |:------------------------------------------------------:|:------:|:----------:|:---------------:|
 |     <ref item="anvilcraft:power_converter_small"/>     |   1    |    100     |       90        |
 |    <ref item="anvilcraft:power_converter_middle"/>     |   16   |    1600    |      1440       |

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/009_machine/201_netherite_block.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/009_machine/201_netherite_block.md
@@ -24,7 +24,7 @@ The following two machines implement [Mass Production of Netherite](../008_recip
 
 - Fill both barrels with sufficient <ref item="minecraft:gold_block"/> and <ref item="minecraft:ancient_debris"/>
 - Set the main loop <ref item="anvilcraft:pulse_generator"/> (controlled by <ref item="minecraft:lever"/>) to (Loop Mode | 18gt | 2gt)
-- Set the <ref item="anvilcraft:pulse_generator"/> for the <ref item="minecraft:raw_gold_block"/> side to (Rising Edge Mode | 2gt | 50gt)
+- Set the <ref item="anvilcraft:pulse_generator"/> for the <ref item="minecraft:raw_gold_block"/> side to (Rising Edge Mode | 1gt | 50gt)
 - Set the <ref item="anvilcraft:pulse_generator"/> for the <ref item="minecraft:ancient_debris"/> side to (Rising Edge Mode | 22gt | 30gt)
-- Set the <ref item="anvilcraft:pulse_generator"/> for the <ref item="minecraft:piston"/> side to (Rising Edge Mode | 5"90 | 0gt)
+- Set the <ref item="anvilcraft:pulse_generator"/> for the <ref item="minecraft:piston"/> side to (Rising Edge Mode | 8"90 | 0gt)
 - All <ref item="minecraft:smooth_stone"/> can be replaced with any full opaque block

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/009_machine/320_supercomputer.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/009_machine/320_supercomputer.md
@@ -1,7 +1,7 @@
 ---
 navigation:
   title: "§5Processing: Spacetime Supercomputer"
-  icon: "minecraft:spacetime_supercomputer"
+  icon: "anvilcraft:spacetime_supercomputer"
 ---
 
 # <ref item="anvilcraft:spacetime_supercomputer"/> Auto-Processor
@@ -10,8 +10,8 @@ The recipe for the <ref item="anvilcraft:spacetime_supercomputer"/> is quite com
 
 <structure id="../../structures/machine/supercomputer.nbt"/>
 
-The <ref item="minecraft:lever"/> is the master switch. The <ref item="anvilcraft:pulse_generator"/> after it is set to (循环模式| 5gt | 3gt)
-The <ref item="anvilcraft:pulse_generator"/> controlling the <ref item="minecraft:sticky_piston"/> is set to (上升沿触发| 2gt | 14gt)
-The <ref item="anvilcraft:pulse_generator"/> controlling breaking and placing is set to (上升沿触发| 92gt | 2gt)
+The <ref item="minecraft:lever"/> is the master switch. The <ref item="anvilcraft:pulse_generator"/> after it is set to (Loop Mode | 5gt | 3gt)
+The <ref item="anvilcraft:pulse_generator"/> controlling the <ref item="minecraft:sticky_piston"/> is set to (Rising Mode | 2gt | 14gt)
+The <ref item="anvilcraft:pulse_generator"/> controlling breaking and placing is set to (Rising Mode | 92gt | 2gt)
 
 Under normal operation, one <ref item="anvilcraft:spacetime_supercomputer"/> is produced every 96gt

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/009_machine/201_netherite_block.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/009_machine/201_netherite_block.md
@@ -24,7 +24,7 @@ navigation:
 
 - 两侧木桶填充足量的<ref item="minecraft:gold_block"/>和<ref item="minecraft:ancient_debris"/>
 - <ref item="minecraft:lever"/>控制的主循环<ref item="anvilcraft:pulse_generator"/>设为(循环模式| 18gt | 2gt)
-- <ref item="minecraft:raw_gold_block"/>侧对应的<ref item="anvilcraft:pulse_generator"/>设为(上升沿模式| 2gt | 50gt)
+- <ref item="minecraft:raw_gold_block"/>侧对应的<ref item="anvilcraft:pulse_generator"/>设为(上升沿模式| 1gt | 50gt)
 - <ref item="minecraft:ancient_debris"/>侧对应的<ref item="anvilcraft:pulse_generator"/>设为(上升沿模式| 22gt | 30gt)
-- <ref item="minecraft:piston"/>侧对应的<ref item="anvilcraft:pulse_generator"/>设为(上升沿模式| 5"90 | 0gt)
+- <ref item="minecraft:piston"/>侧对应的<ref item="anvilcraft:pulse_generator"/>设为(上升沿模式| 8"90 | 0gt)
 - 所有 <ref item="minecraft:smooth_stone"/> 可替换为 任意完整不透明方块

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/009_machine/320_supercomputer.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/009_machine/320_supercomputer.md
@@ -1,7 +1,7 @@
 ---
 navigation:
   title: "§5加工：时空超算"
-  icon: "minecraft:spacetime_supercomputer"
+  icon: "anvilcraft:spacetime_supercomputer"
 ---
 
 # <ref item="anvilcraft:spacetime_supercomputer"/>自动加工机


### PR DESCRIPTION
Align the audited machine pages with current Netherite Block parameters and Supercomputer resource identifiers.

Constraint: Scope is limited to PR3 audit items and preserves existing file formatting.

Rejected: Unrelated audit findings and cleanup | They belong to separate PRs or are outside this release.

Confidence: high

Scope-risk: narrow

Directive: Keep machine documentation synchronized with generated resources and current code paths.

Tested: doc_audit, targeted machine/resource searches, and git diff --check.

Not-tested: No game runtime test; this is a docs-only change.