### PR TITLE
Keep the manual aligned with current links and resources

### DIFF
--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/000_process/014.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/000_process/014.md
@@ -18,7 +18,7 @@ Crafting <ref item="anvilcraft:charged_neutronium_ingot"/> is extremely power-hu
 ## Smithing Template
 
 1. Craft an <ref item="anvilcraft:eight_to_one_smithing_template"/> and apply multiple enchantments to it
-2. Destroy the template to trigger [Template Dissociation](../004_block/221_ember_smithing_table.md#template-dissociation) and obtain the <ref item="anvilcraft:transcendium_upgrade_smithing_template"/>
+2. Destroy the template to trigger [Template Dissociation](../004_block/221_ember_smithing_table.md#template-dissociation) and obtain up to four smithing templates
 
 ## Upgrading Equipment
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/001_feature/000_mineral.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/001_feature/000_mineral.md
@@ -24,5 +24,5 @@ items:
 
 
 - Unlike most mods, under normal conditions the ores from this mod do not generate naturally
-- To obtain this mod's metals in the early game, you need to use "something from nothing" methods — [Item Sifting](../007_struct/000_item_processing.md#过筛)
+- To obtain this mod's metals in the early game, you need to use "something from nothing" methods — [Item Sifting](../007_struct/000_item_processing.md#meshing)
 - For the metal nugget materials obtained this way [click here](../002_material/003_common_nugget.md)

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/001_feature/301_overheated_block.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/001_feature/301_overheated_block.md
@@ -18,7 +18,7 @@ items:
 # Prerequisites:
 
 - [Thermal System](../001_feature/101_heated_block.md)
-- [Anvil Collision Crafting](../004_block/215_large_electromagnet.md#铁砧撞击合成)
+- [Anvil Collision Crafting](../004_block/215_large_electromagnet.md#anvil-impact-crafting)
 
 <warning>
 If you skip the prerequisites, you won't understand this chapter

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/301_multiphase_matter.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/301_multiphase_matter.md
@@ -21,7 +21,7 @@ items:
 
 <recipe id="anvilcraft:anvil_collision/ember_anvil_and_frost_metal_block_32"/>
 
-> [Anvil Collision Crafting](../004_block/215_large_electromagnet.md#铁砧撞击合成)
+> [Anvil Collision Crafting](../004_block/215_large_electromagnet.md#anvil-impact-crafting)
 
 # Uses
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/301_negative_matter.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/301_negative_matter.md
@@ -20,7 +20,7 @@ items:
 
 <recipe id="anvilcraft:anvil_collision/anvil_tier_1_and_levitation_powder_block_32"/>
 
-> [Anvil Collision Crafting](../004_block/215_large_electromagnet.md#铁砧撞击合成)
+> [Anvil Collision Crafting](../004_block/215_large_electromagnet.md#anvil-impact-crafting)
 
 ---
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/312_transcendium.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/312_transcendium.md
@@ -37,7 +37,7 @@ Ingots and nuggets are produced as dropped items; blocks are generated at the po
 # Functions
 
 - Used to craft machines
-- Combined with <ref item="anvilcraft:transcendium_upgrade_smithing_template"/> to upgrade tools
+- Use the <ref item="anvilcraft:transcendence_smithing_table"/> to upgrade tools
 
 # Transcendium Tools
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/100_heater.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/100_heater.md
@@ -41,7 +41,7 @@ Super-Heating is a processing method that can batch-process materials in a cauld
 3. Doubles ore smelting output
 
 <warning>
-Cannot cook food. For food processing, see [Item Processing: Cooking](../007_struct/000_item_processing.md#Cooking)
+Cannot cook food. For food processing, see [Item Processing: Cooking](../007_struct/000_item_processing.md#fast-cooking)
 </warning>
 
 <recipe id="anvilcraft:super_heating_warp_raw_copper_2_copper_ingot"/>

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/311_transcendence_anvil.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/311_transcendence_anvil.md
@@ -8,7 +8,7 @@ items:
 
 # Transcendence Anvil
 
-<recipe id="anvilcraft:smithing/transcendence_anvil"/>
+<recipe id="anvilcraft:two_to_one_smithing/transcendence_anvil"/>
 
 ## Function
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/006_prop/100_amulet_box.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/006_prop/100_amulet_box.md
@@ -35,5 +35,5 @@ items:
 # Function
 
 - Holding an Amulet Box containing a Totem of Undying in your offhand is equivalent to holding a Totem of Undying
-- If you survive specific fatal damage, there is a 20% chance to obtain the corresponding [Amulet](100_amulet.md#获取). If it fails, the chance increases by an additional 10%
+- If you survive specific fatal damage, there is a 20% chance to obtain the corresponding [Amulet](100_amulet.md#acquisition). If it fails, the chance increases by an additional 10%
 - When holding the Amulet Box in your main hand or offhand, all amulets inside are active

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/006_prop/211_large_cake.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/006_prop/211_large_cake.md
@@ -66,7 +66,7 @@ Right-click with a shovel to eat the entire block
 </row>
 
 <structure id="../../structures/large_cake.snbt"/>
-- Made using the [Multiblock Transformation](../004_block/210_giant_anvil.md#功能) recipe
+- Made using the [Multiblock Transformation](../004_block/210_giant_anvil.md#function) recipe
 
 <tip>
 Try automating the Large Cake and become an automation "cake" master

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/008_recipe/index.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/008_recipe/index.md
@@ -1,7 +1,7 @@
 ---
 navigation:
   title: "Processing Recipes"
-  icon: "anvilcraft:sea_heart_shell"
+  icon: "anvilcraft:ancient_sea_reef"
 ---
 
 Introduces some production recipes not covered in other chapters

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/000_process/014.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/000_process/014.md
@@ -18,7 +18,7 @@ navigation:
 ## 锻造模板
 
 1. 制造<ref item="anvilcraft:eight_to_one_smithing_template"/>，为其附上多种附魔
-2. 摧毁模板，触发[模板解离](../004_block/221_ember_smithing_table.md#模板解离)，获得<ref item="anvilcraft:transcendium_upgrade_smithing_template"/>
+2. 摧毁模板，触发[模板解离](../004_block/221_ember_smithing_table.md#模板解离)，最多获得 4 个锻造模板
 
 ## 升级装备
 

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/002_material/312_transcendium.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/002_material/312_transcendium.md
@@ -37,7 +37,7 @@ items:
 # 功能
 
 - 用于合成机器
-- 与<ref item="anvilcraft:transcendium_upgrade_smithing_template"/>配合，升级工具
+- 使用<ref item="anvilcraft:transcendence_smithing_table"/>升级工具
 - 为*附魔台*提供等同于 10 个<ref item="minecraft:bookshelf"/>的附魔能力
 
 # 超限合金工具

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/004_block/100_heater.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/004_block/100_heater.md
@@ -41,7 +41,7 @@ items:
 3. 双倍冶炼矿物
 
 <warning>
-不可以烹饪食物，请移步[物品加工：烹饪](../007_struct/000_item_processing.md#烹饪)
+不可以烹饪食物，请移步[物品加工：烹饪](../007_struct/000_item_processing.md#快速烹饪)
 </warning>
 
 <recipe id="anvilcraft:super_heating_warp_raw_copper_2_copper_ingot"/>

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/004_block/313_transcendence_anvil.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/004_block/313_transcendence_anvil.md
@@ -8,7 +8,7 @@ items:
 
 # 超限铁砧
 
-<recipe id="anvilcraft:smithing/transcendence_anvil"/>
+<recipe id="anvilcraft:two_to_one_smithing/transcendence_anvil"/>
 
 ## 功能
 

--- a/src/main/resources/assets/anvilcraft/ageratum/zh_cn/008_recipe/index.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/zh_cn/008_recipe/index.md
@@ -1,7 +1,7 @@
 ---
 navigation:
   title: "加工配方"
-  icon: "anvilcraft:sea_heart_shell"
+  icon: "anvilcraft:ancient_sea_reef"
 ---
 
 介绍部分其他章节未涉及到的生产配方


### PR DESCRIPTION
Refresh the audited pages so links, recipe/resource references, and removed-resource entries match the current documentation surface.

Constraint: Scope is limited to PR2 audit items and preserves existing file formatting.

Rejected: Unrelated audit findings and cleanup | They belong to separate PRs or are outside this release.

Confidence: high

Scope-risk: narrow

Directive: Keep future manual references grounded in current generated resources.

Tested: doc_audit, targeted link/resource checks, and git diff --check.

Not-tested: No game runtime test; this is a docs-only change.