### PR TITLE
Synchronize English manual behavior and terminology

### DIFF
--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/000_process/015.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/000_process/015.md
@@ -30,9 +30,9 @@ The manual provides an [example machine](../009_machine/320_supercomputer.md)
 
 Use it to accelerate mass accumulation in the <ref item="anvilcraft:space_overcompressor"/>.
 
-### Collecting the Four Great Anvils
+### Collecting the Four Fundamental Anvilons
 
-Adjusting celestial parameters requires anvils (not consumed). It's recommended to prepare a stack of each of the [four great anvils](../002_material/321_anvilon.md) in advance for a good gameplay experience
+Adjusting celestial parameters requires Anvilons (not consumed). It's recommended to prepare a stack of each of the [four fundamental Anvilons](../002_material/321_anvilon.md) in advance for a good gameplay experience
 
 # <ref item="anvilcraft:celestial_forging_anvil"/>
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/210_liquid_enchantment.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/210_liquid_enchantment.md
@@ -32,9 +32,16 @@ Consume specific materials to obtain the corresponding enchantment:
 | 1mB                               | <ref item="anvilcraft:topaz"/>              | Channeling 1mB                            |
 | 12mB                              | <ref item="minecraft:amethyst_block"/>      | Timber 4mB + Harvest 4mB + Beheading 4mB  |
 
-# Using Liquid Enchantment (Incomplete)
+# Using Liquid Enchantment
 
-Content to be added
+Apply liquid enchantment to items through an <ref item="anvilcraft:auto_enchanting_table"/>.
+
+Enchantment levels 1 through 5 consume 1, 2, 4, 8, and 16mB of liquid enchantment respectively; higher levels continue doubling the amount consumed.
+
+# Transport and Filtering
+
+- Liquid enchantment cannot be released into the world or collected with a bucket; transport it through <ref item="anvilcraft:pipe"/>s
+- Because all liquid enchantments use the same fluid, mark a specific enchantment in a <ref item="anvilcraft:control_valve"/> with an enchanted book. The same filtering method applies when configuring a <ref item="anvilcraft:creative_fluid_tank"/> in Creative mode
 
 # Enchantment Duplication
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/312_transcendium.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/312_transcendium.md
@@ -38,6 +38,7 @@ Ingots and nuggets are produced as dropped items; blocks are generated at the po
 
 - Used to craft machines
 - Combined with <ref item="anvilcraft:transcendium_upgrade_smithing_template"/> to upgrade tools
+- Provides an *enchanting table* with enchantment power equivalent to 10 <ref item="minecraft:bookshelf"/>s
 
 # Transcendium Tools
 

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/332_excited_state_void_matter.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/002_material/332_excited_state_void_matter.md
@@ -18,7 +18,7 @@ items:
 # Properties
 
 - When in contact with another <ref item="anvilcraft:excited_state_void_matter_block"/>, it decays into one of: redstone block, lapis lazuli block, diamond block, netherite block, uranium block, plutonium block, sapphire block, ruby block, topaz block
-- If there is an adjacent <ref item="anvilcraft:confinement_chamber"/> when decaying, it also produces four types of anvils
+- If there is an adjacent <ref item="anvilcraft:confinement_chamber"/> when decaying, it also produces four types of Anvilons
 - Causes any <ref item="anvilcraft:void_matter_block"/> it touches to decay immediately
 
 <recipe id="anvilcraft:anvil_collision/royal_anvil_and_excited_state_void_matter_block_256"/>

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/311_transcendence_smithing_table.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/311_transcendence_smithing_table.md
@@ -1,0 +1,17 @@
+---
+navigation:
+  title: "§5Transcendence Smithing Table"
+  icon: "anvilcraft:transcendence_smithing_table"
+items:
+  - anvilcraft:transcendence_smithing_table
+---
+
+# <ref item="anvilcraft:transcendence_smithing_table"/>
+
+<recipe id="anvilcraft:two_to_one_smithing/transcendence_smithing_table"/>
+
+## Functions
+
+- Includes **all** smithing templates
+- Provides all functions of the <ref item="anvilcraft:royal_smithing_table"/>, <ref item="anvilcraft:frost_smithing_table"/>, and <ref item="anvilcraft:ember_smithing_table"/>
+- Automatically adjusts the processing GUI after selecting a template

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/330_mass_energy_inverter.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/330_mass_energy_inverter.md
@@ -13,7 +13,7 @@ items:
 <recipe id="anvilcraft:procedural_process/mass_energy_inverter_energy_first"/>
 <recipe id="anvilcraft:procedural_process/mass_energy_inverter_mass_first"/>
 
-Requires [Anvil Irradiation](../002_material/321_anvilon.md#anvilon-irradiation) to craft.
+Requires [Anvilon Irradiation](../002_material/321_anvilon.md#anvilon-irradiation) to craft.
 
 1. Continuously consumes 1024kW.
 2. Adds 5 mass per tick to horizontally adjacent <ref item="anvilcraft:space_overcompressor"/>s. This stacks.

--- a/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/331_celestial_forging_anvil.md
+++ b/src/main/resources/assets/anvilcraft/ageratum/en_us/004_block/331_celestial_forging_anvil.md
@@ -20,12 +20,12 @@ items:
 # Forging Celestial Bodies
 
 - Use <ref item="anvilcraft:confined_time_anvilon"/>, <ref item="anvilcraft:confined_space_anvilon"/>, <ref item="anvilcraft:confined_mass_anvilon"/>, <ref item="anvilcraft:confined_energy_anvilon"/> placed on the left side in sequence, and configure reasonable parameters to search for and forge a celestial body
-- Forging celestial bodies does not consume anvils
+- Forging celestial bodies does not consume Anvilons
 
 <tip>
 Debugging parameters:
   - Use the **mouse wheel** to conveniently adjust the four parameters
-  - After placing some anvils, hover over other anvil items to display the matching anvil count (will not display if previously placed anvils already cannot satisfy the condition)
+  - After placing some Anvilons, hover over other Anvilon items to display the matching Anvilon count (will not display if previously placed Anvilons already cannot satisfy the condition)
 </tip>
 
 ![Brown Dwarf.png](../../textures/cfa/heai.png)
@@ -35,7 +35,7 @@ Debugging parameters:
 ## Forging Planets
 
 1. To forge a planet, first prepare 1MW of power for operation
-2. Use the four anvils to control the four parameters, making the **intersection** of the red line (energy) and green line (time) AND the **intersection** of the blue line (space) and yellow line (mass) fall on the same color region
+2. Use the four Anvilons to control the four parameters, making the **intersection** of the red line (energy) and green line (time) AND the **intersection** of the blue line (space) and yellow line (mass) fall on the same color region
 3. The text at the bottom right shows what celestial body each of the three focus areas corresponds to. As long as the first and third lines show the same celestial body, it works
 4. Click the confirm button. After 10s of forging, click the **lock icon** below to start operating on the celestial body
 
@@ -45,7 +45,7 @@ Debugging parameters:
 
 1. To forge a star, first prepare four <ref item="anvilcraft:celestial_forging_anvil_amplifier"/> and place them at the four corners of the <ref item="anvilcraft:celestial_forging_anvil"/>
 2. Prepare 4MW of power for operation
-3. Use the four anvils to control the four parameters, ensuring all **three focus areas** of the four lines fall on the same color region
+3. Use the four Anvilons to control the four parameters, ensuring all **three focus areas** of the four lines fall on the same color region
 4. Click the confirm button. After 10s, click the **lock icon** to start operating on the celestial body
 
 <info>


### PR DESCRIPTION
Bring the audited English pages in line with current behavior and Anvilon terminology, including the missing Transcendence Smithing Table page.

Constraint: Scope is limited to PR4 audit items and remains independent from PR1 and PR2 overlaps.

Rejected: Bundling other audit findings or broad translation cleanup | Those changes belong to separate branches or are outside this PR.

Confidence: high

Scope-risk: narrow

Directive: Rebase this branch before publication if an overlapping approved documentation PR changes the shared page.

Tested: doc_audit, targeted link/anchor and terminology checks, and git diff --check.

Not-tested: No game runtime test; this is a docs-only change.