### PR TITLE
Fix beheading enchantment not working 修复斩首附魔不生效的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/LivingEntityMixin.java
@@ -43,8 +43,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.UUID;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity implements ILivingEntityExtension {
@@ -110,22 +109,25 @@ public abstract class LivingEntityMixin extends Entity implements ILivingEntityE
     @Inject(
         method = "dropFromLootTable("
                  + "Lnet/minecraft/server/level/ServerLevel;"
+                 + "Lnet/minecraft/world/damagesource/DamageSource;"
+                 + "Z"
                  + "Lnet/minecraft/resources/ResourceKey;"
-                 + "Ljava/util/function/Function;"
-                 + "Ljava/util/function/BiConsumer;)Z",
+                 + "Ljava/util/function/Consumer;)V",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/storage/loot/LootTable;getRandomItems("
-                     + "Lnet/minecraft/world/level/storage/loot/LootParams;)"
-                     + "Lit/unimi/dsi/fastutil/objects/ObjectArrayList;"
+                     + "Lnet/minecraft/world/level/storage/loot/LootParams;"
+                     + "J"
+                     + "Ljava/util/function/Consumer;)V"
         )
     )
     private void dropBeheadingLoot(
         ServerLevel level,
-        ResourceKey<LootTable> key,
-        Function<LootParams.Builder, LootParams> paramsBuilder,
-        BiConsumer<ServerLevel, ItemStack> consumer,
-        CallbackInfoReturnable<Boolean> cir,
+        DamageSource source,
+        boolean playerKilled,
+        ResourceKey<LootTable> lootTable,
+        Consumer<ItemStack> itemStackConsumer,
+        CallbackInfo ci,
         @Local(name = "params") LootParams params
     ) {
         LivingEntity thiz = Util.cast(this);


### PR DESCRIPTION
MC 26.1 版本新增了 `LivingEntity.dropFromLootTable` 方法的多个重载。由于 `LivingEntityMixin.dropBeheadingLoot` 方法 mixin 了错误的重载，导致斩首附魔不生效。该 PR 修复了上述问题。

该问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。