### PR TITLE
Fix bugs about storage system 修复仓储系统相关问题

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -1640,6 +1640,7 @@
   "screen.anvilcraft.storage.search.clear": "ɹɐǝꞁƆ",
   "screen.anvilcraft.storage.search.edit": "ɥɔɹɐǝS",
   "screen.anvilcraft.storage.search.retention": "uoᴉʇuǝʇǝᴚ",
+  "screen.anvilcraft.storage.search.tab": "qɐ⟘ ssǝɹԀ",
   "screen.anvilcraft.storage.sort": "%s ʎꞁʇuǝɹɹnƆ :ǝpoW ʇɹoS",
   "screen.anvilcraft.storage.sort.count": "ʇunoƆ ʎq",
   "screen.anvilcraft.storage.sort.mod": "ᗡI poW ʎq",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -1640,6 +1640,7 @@
   "screen.anvilcraft.storage.search.clear": "Clear",
   "screen.anvilcraft.storage.search.edit": "Search",
   "screen.anvilcraft.storage.search.retention": "Retention",
+  "screen.anvilcraft.storage.search.tab": "Press Tab",
   "screen.anvilcraft.storage.sort": "Sort Mode: Currently %s",
   "screen.anvilcraft.storage.sort.count": "by Count",
   "screen.anvilcraft.storage.sort.mod": "by Mod ID",

--- a/src/main/java/dev/dubhe/anvilcraft/block/StoragePortBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/StoragePortBlock.java
@@ -87,7 +87,15 @@ public class StoragePortBlock extends BaseEntityBlock implements IHammerRemovabl
             return ItemInteractionResult.sidedSuccess(level.isClientSide());
         }
         if (stack.isEmpty()) {
-            // 已标记 + 空手：取出走左键，右键不做任何事
+            // 已标记 + 空手：单击不做任何事（取出走左键）；双击塞入身上全部
+            // （第一次点击已把手上的物品塞入并完成标记，故第二次点击时手可能已空）
+            if (doubleClick) {
+                port.stuffAllFromPlayer(player);
+                if (!level.isClientSide()) {
+                    port.setChanged();
+                    level.sendBlockUpdated(pos, state, state, Block.UPDATE_ALL);
+                }
+            }
             return ItemInteractionResult.sidedSuccess(level.isClientSide());
         }
         if (ItemStack.isSameItemSameComponents(mark, stack)) {

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/StoragePortBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/StoragePortBlockEntity.java
@@ -65,8 +65,8 @@ public class StoragePortBlockEntity extends BlockEntity implements IItemHandlerH
     private static final int CONNECTIVITY_LIMIT = 512;
     /** 双击判定的最大间隔（tick） */
     private static final long DOUBLE_CLICK_INTERVAL = 5;
-    /** 左键取出冷却：按住左键会周期性重触发左键事件，用冷却保证单次点击只取出一次 */
-    private static final long TAKE_OUT_COOLDOWN = 7;
+    /** 长按左键时客户端取出请求的节流间隔（tick）：间隔大于该值时才会发包 */
+    private static final long TAKE_OUT_HOLD_INTERVAL = 1;
 
     @Getter
     private final ItemStackHandler buffer = new ItemStackHandler(StoragePortBlockEntity.BUFFER_SLOTS) {
@@ -277,18 +277,21 @@ public class StoragePortBlockEntity extends BlockEntity implements IItemHandlerH
     }
 
     /**
-     * 判断左键取出是否处于冷却中：按住左键会周期性重触发左键事件，
-     * 冷却保证单次点击只取出一次。每次调用会记录当前时间。
+     * 长按左键取出的客户端发包节流：按住左键时 {@code START} 事件会每 tick 重触发，
+     * 节流保证不会每 tick 都发包。只有实际发包时才会记录时间；仅在客户端使用。
      */
-    public boolean onTakeOutCooldown(Player player) {
+    public boolean onTakeOutHoldCooldown(Player player) {
         if (this.level == null) {
             return false;
         }
         long now = this.level.getGameTime();
         UUID uuid = player.getUUID();
         long last = this.lastTakeOutTicks.getLong(uuid);
+        if (last != 0 && now - last <= StoragePortBlockEntity.TAKE_OUT_HOLD_INTERVAL) {
+            return true;
+        }
         this.lastTakeOutTicks.put(uuid, now);
-        return last != 0 && now - last <= StoragePortBlockEntity.TAKE_OUT_COOLDOWN;
+        return false;
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/ClientEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/ClientEventListener.java
@@ -18,9 +18,6 @@ import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.inventory.HammerOpenedAnvilMenu;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
-import dev.dubhe.anvilcraft.item.HyperdimensionTerminalItem;
-import dev.dubhe.anvilcraft.item.LocalTerminalItem;
-import dev.dubhe.anvilcraft.item.ShulkerTerminalItem;
 import dev.dubhe.anvilcraft.network.DragonRodStopDevourPacket;
 import dev.dubhe.anvilcraft.network.OpenHammerAnvilPacket;
 import dev.dubhe.anvilcraft.network.UsePillBoxPacket;
@@ -262,7 +259,7 @@ public class ClientEventListener {
                 return;
             } else if (!carriedEmpty) {
                 // 捏着物品：根据终端的 inverted 状态决定放入存储的按键（默认右键，反向后左键）
-                boolean inverted = ClientEventListener.isTerminalInverted(slot.getItem());
+                boolean inverted = InvertedActionEventListener.isInverted();
                 boolean insertClick = inverted
                     ? minecraft.options.keyAttack.matchesMouse(event.getButton())
                     : minecraft.options.keyUse.matchesMouse(event.getButton());
@@ -305,22 +302,6 @@ public class ClientEventListener {
             );
             event.setCanceled(true);
         }
-    }
-
-    /**
-     * 根据终端类型查询其客户端记录的反转状态（容器 GUI 中终端放入存储的按键随反转对调）。
-     */
-    private static boolean isTerminalInverted(ItemStack stack) {
-        if (stack.is(ModItems.LOCAL_TERMINAL)) {
-            return InvertedActionEventListener.isInverted(LocalTerminalItem.CONFIG_ID);
-        }
-        if (stack.is(ModItems.SHULKER_TERMINAL)) {
-            return InvertedActionEventListener.isInverted(ShulkerTerminalItem.CONFIG_ID);
-        }
-        if (stack.is(ModItems.HYPERDIMENSION_TERMINAL)) {
-            return InvertedActionEventListener.isInverted(HyperdimensionTerminalItem.CONFIG_ID);
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/InvertedActionEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/InvertedActionEventListener.java
@@ -3,50 +3,19 @@ package dev.dubhe.anvilcraft.client.event;
 import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.AnvilCraftClient;
 import dev.dubhe.anvilcraft.client.rpc.BundleLikeClientStub;
-import dev.dubhe.anvilcraft.item.HyperdimensionTerminalItem;
-import dev.dubhe.anvilcraft.item.LocalTerminalItem;
-import dev.dubhe.anvilcraft.item.PillBoxItem;
-import dev.dubhe.anvilcraft.item.ShulkerTerminalItem;
-import dev.dubhe.anvilcraft.item.amulet.AmuletBoxItem;
-import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
-import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import net.minecraft.client.Minecraft;
-import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.BooleanSupplier;
-
 @EventBusSubscriber(modid = AnvilCraft.MOD_ID, value = Dist.CLIENT)
 public class InvertedActionEventListener {
-    private static final Map<ResourceLocation, BooleanSupplier> CONFIG = new HashMap<>();
-    private static final Object2BooleanMap<ResourceLocation> LAST_INVERTED = new Object2BooleanOpenHashMap<>();
+    private static boolean lastInverted = false;
 
-    static  {
-        InvertedActionEventListener.register(AmuletBoxItem.CONFIG_ID, () -> AnvilCraftClient.CONFIG.amuletBoxInvertOverrideAction);
-        InvertedActionEventListener.register(PillBoxItem.CONFIG_ID, () -> AnvilCraftClient.CONFIG.pillBoxInvertOverrideAction);
-        InvertedActionEventListener.register(LocalTerminalItem.CONFIG_ID, () -> AnvilCraftClient.CONFIG.localTerminalInvertOverrideAction);
-        InvertedActionEventListener.register(
-            ShulkerTerminalItem.CONFIG_ID,
-            () -> AnvilCraftClient.CONFIG.shulkerTerminalInvertOverrideAction
-        );
-        InvertedActionEventListener.register(
-            HyperdimensionTerminalItem.CONFIG_ID,
-            () -> AnvilCraftClient.CONFIG.hyperdimensionTerminalInvertOverrideAction
-        );
-    }
-
-    public static void register(ResourceLocation id, BooleanSupplier config) {
-        InvertedActionEventListener.CONFIG.put(id, config);
-    }
-
-    /** 客户端当前记录的指定物品反转状态（尚未与配置同步时以最近一次记录为准）。 */
-    public static boolean isInverted(ResourceLocation id) {
-        return InvertedActionEventListener.LAST_INVERTED.getOrDefault(id, false);
+    /** 所有 BundleLike 物品共用的反转状态（与客户端配置一致）。 */
+    public static boolean isInverted() {
+        return AnvilCraftClient.CONFIG.invertOverrideAction;
     }
 
     @SubscribeEvent
@@ -54,15 +23,10 @@ public class InvertedActionEventListener {
         if (Minecraft.getInstance().getConnection() == null) {
             return;
         }
-        for (Map.Entry<ResourceLocation, BooleanSupplier> entry : InvertedActionEventListener.CONFIG.entrySet()) {
-            ResourceLocation id = entry.getKey();
-            BooleanSupplier config = entry.getValue();
-            boolean inverted = config.getAsBoolean();
-            boolean lastInverted = InvertedActionEventListener.LAST_INVERTED.getOrDefault(id, false);
-            if (inverted != lastInverted) {
-                BundleLikeClientStub.updateInverted(id, inverted);
-                InvertedActionEventListener.LAST_INVERTED.put(id, inverted);
-            }
+        boolean inverted = AnvilCraftClient.CONFIG.invertOverrideAction;
+        if (inverted != InvertedActionEventListener.lastInverted) {
+            BundleLikeClientStub.updateInverted(inverted);
+            InvertedActionEventListener.lastInverted = inverted;
         }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CategorySettingsScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/CategorySettingsScreen.java
@@ -49,6 +49,8 @@ public class CategorySettingsScreen extends Screen {
     private static final int BG_WIDTH = 300;
     private static final int BG_HEIGHT = 222;
     private final BlockPos sourcePos;
+    /** 从 StorageScreen 进入时携带的界面标题；退出类别设置时原样带回，避免虚拟位置被重算成世界方块名。 */
+    private final Component storageTitle;
     private @Nullable Player player;
     private @Nullable Registry<ICategory> registry;
     private PlayerSetting draftSetting;
@@ -109,9 +111,10 @@ public class CategorySettingsScreen extends Screen {
     };
     private int alternateHead = 0;
 
-    protected CategorySettingsScreen(BlockPos sourcePos) {
+    protected CategorySettingsScreen(BlockPos sourcePos, Component storageTitle) {
         super(Component.translatable("screen.anvilcraft.storage.category.setting.title"));
         this.sourcePos = sourcePos;
+        this.storageTitle = storageTitle;
         this.draftSetting = SettingClientStub.copy();
     }
 
@@ -747,6 +750,6 @@ public class CategorySettingsScreen extends Screen {
     }
 
     private void openStorageScreen() {
-        Objects.requireNonNull(this.minecraft).setScreen(new StorageScreen(this.sourcePos));
+        Objects.requireNonNull(this.minecraft).setScreen(new StorageScreen(this.sourcePos, this.storageTitle));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StorageScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StorageScreen.java
@@ -281,7 +281,7 @@ public class StorageScreen extends Screen {
             SettingClientStub.setting(),
             button -> SettingClientStub.update(SettingClientStub.listed().stream().toList())
                 .thenRunAsync(this::reorder, this.screenExecutor),
-            button -> this.minecraft.setScreen(new CategorySettingsScreen(this.sourcePos))
+            button -> this.minecraft.setScreen(new CategorySettingsScreen(this.sourcePos, this.title))
         ));
         this.addRenderableWidget(new TexturedButton(
             this.left + 278,

--- a/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StorageScreen.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/gui/screen/StorageScreen.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.client.gui.screen;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.blaze3d.vertex.PoseStack;
 import dev.anvilcraft.lib.v2.util.MathUtil;
 import dev.anvilcraft.lib.v2.util.stack.UnlimitedItemStack;
 import dev.dubhe.anvilcraft.api.itemhandler.unlimited.UnlimitedItemStacksResourceHandler;
@@ -33,6 +34,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.Renderable;
@@ -429,7 +431,7 @@ public class StorageScreen extends Screen {
                 graphics.renderItem(itemStack, x, y);
                 StorageScreen.renderItemDecorations(
                     graphics,
-                    this.minecraft,
+                    this.minecraft.font,
                     itemStack,
                     this.getDisplayedCount(slot),
                     x,
@@ -1840,9 +1842,9 @@ public class StorageScreen extends Screen {
         );
     }
 
-    private static void renderItemDecorations(
+    public static void renderItemDecorations(
         GuiGraphics graphics,
-        Minecraft minecraft,
+        Font font,
         ItemStack stack,
         long count,
         int x,
@@ -1852,9 +1854,10 @@ public class StorageScreen extends Screen {
             return;
         }
 
+        PoseStack pose = graphics.pose();
         // 抬高 z 使耐久条与数量数字绘制在物品图标之上
-        graphics.pose().pushPose();
-        graphics.pose().translate(0, 0, 200);
+        pose.pushPose();
+        pose.translate(0, 0, 200);
 
         // 耐久条
         if (stack.isBarVisible()) {
@@ -1865,14 +1868,20 @@ public class StorageScreen extends Screen {
         }
 
         // 数量（使用缩写格式，可超过 999）
+        pose.translate(x + 17, y + 9, 0);
         Component amount = Component.literal(FormattingUtil.toAbbrNum(count))
             .withStyle(style -> style.withFont(StorageScreen.SMALL_FONT));
         int color = count == 0 ? 0xFFFFAA00 : -1;
-        graphics.drawString(minecraft.font, amount, x + 17 - minecraft.font.width(amount), y + 9, color, true);
+        int width = font.width(amount);
+        if (width > 16) {
+            pose.scale(0.75F, 0.75F, 1);
+            pose.translate(-1F, font.lineHeight * 0.25F - 0.25F, 0);
+        }
+        graphics.drawString(font, amount, -width, 0, color, true);
 
-        graphics.pose().popPose();
+        pose.popPose();
 
         // noinspection UnstableApiUsage
-        ItemDecoratorHandler.of(stack).render(graphics, minecraft.font, stack, x, y);
+        ItemDecoratorHandler.of(stack).render(graphics, font, stack, x, y);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/rpc/BundleLikeClientStub.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/rpc/BundleLikeClientStub.java
@@ -4,15 +4,13 @@ import dev.anvilcraft.lib.v2.rpc.RPC;
 import dev.anvilcraft.lib.v2.rpc.RpcTarget;
 import dev.dubhe.anvilcraft.rpc.BundleLikeServerStub;
 import net.minecraft.client.Minecraft;
-import net.minecraft.resources.ResourceLocation;
 
 public class BundleLikeClientStub {
-    public static void updateInverted(ResourceLocation location, boolean inverted) {
+    public static void updateInverted(boolean inverted) {
         RPC.call(
             RpcTarget.server(),
             BundleLikeServerStub::updateInverted,
             Minecraft.getInstance().getGameProfile().getId(),
-            location,
             inverted
         );
     }

--- a/src/main/java/dev/dubhe/anvilcraft/client/support/TerminalRemoteOverlay.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/support/TerminalRemoteOverlay.java
@@ -2,6 +2,7 @@ package dev.dubhe.anvilcraft.client.support;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import dev.anvilcraft.lib.v2.util.stack.UnlimitedItemStack;
+import dev.dubhe.anvilcraft.client.gui.screen.StorageScreen;
 import dev.dubhe.anvilcraft.client.rpc.StorageClientStub;
 import dev.dubhe.anvilcraft.client.rpc.StorageTerminalClientStub;
 import dev.dubhe.anvilcraft.client.rpc.TerminalReachabilityCache;
@@ -10,13 +11,13 @@ import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.item.property.component.TerminalBinding;
 import dev.dubhe.anvilcraft.rpc.StorageServerStub;
-import dev.dubhe.anvilcraft.util.FormattingUtil;
 import it.unimi.dsi.fastutil.ints.Int2LongMap;
 import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -161,13 +162,13 @@ public final class TerminalRemoteOverlay {
             if (!stack.isEmpty()) {
                 ItemStack itemStack = stack.toStack();
                 graphics.renderFakeItem(itemStack, x + 1, y + 1);
-                TerminalRemoteOverlay.renderItemDecorations(
+                StorageScreen.renderItemDecorations(
                     graphics,
                     font,
                     itemStack,
                     TerminalRemoteOverlay.COUNTS.get(slot),
-                    x,
-                    y
+                    x + 1,
+                    y + 1
                 );
             }
             if (TerminalRemoteOverlay.selected && orderIndex == TerminalRemoteOverlay.cursor) {
@@ -182,7 +183,7 @@ public final class TerminalRemoteOverlay {
         if (TerminalRemoteOverlay.searchBox == null) {
             return;
         }
-        TerminalRemoteOverlay.searchBox.setX(TerminalRemoteOverlay.left + TerminalRemoteOverlay.GRID_X + 1);
+        TerminalRemoteOverlay.searchBox.setX(TerminalRemoteOverlay.left + TerminalRemoteOverlay.GRID_X + 2);
         TerminalRemoteOverlay.searchBox.setY(TerminalRemoteOverlay.top + TerminalRemoteOverlay.SEARCH_Y);
         TerminalRemoteOverlay.searchBox.setWidth(TerminalRemoteOverlay.maxSearchWidth());
         // 浮窗内坐标已整体平移到 z=400，EditBox 渲染在自身层级即可；
@@ -193,24 +194,11 @@ public final class TerminalRemoteOverlay {
         int mouseY = (int) (minecraft.mouseHandler.ypos() * minecraft.getWindow().getGuiScaledHeight()
                             / minecraft.getWindow().getScreenHeight());
         TerminalRemoteOverlay.searchBox.render(graphics, mouseX, mouseY, partialTick);
-    }
-
-    private static void renderItemDecorations(GuiGraphics graphics, Font font, ItemStack stack, long count, int x, int y) {
-        // 面板整体已平移 z=400，此处再抬高 z 让耐久条与数量数字绘制在物品图标之上
-        graphics.pose().pushPose();
-        graphics.pose().translate(0.0F, 0.0F, 200.0F);
-        if (stack.isBarVisible()) {
-            int barX = x + 2;
-            int barY = y + 13;
-            graphics.fill(barX, barY, barX + 13, barY + 2, 0xFF000000);
-            graphics.fill(barX, barY, barX + stack.getBarWidth(), barY + 1, stack.getBarColor());
+        // 未激活（未聚焦）且内容为空时显示灰色 "Tab" 提示，提示可按 Tab 键激活搜索
+        if (!TerminalRemoteOverlay.searchBox.isFocused() && TerminalRemoteOverlay.searchBox.getValue().isEmpty()) {
+            Component hint = Component.translatable("screen.anvilcraft.storage.search.tab").withStyle(ChatFormatting.GRAY);
+            graphics.drawString(font, hint, TerminalRemoteOverlay.searchBox.getX(), TerminalRemoteOverlay.searchBox.getY(), 0xFFFFFFFF);
         }
-        if (count > 0) {
-            Component amount = Component.literal(FormattingUtil.toAbbrNum(count))
-                .withStyle(style -> style.withFont(TerminalRemoteOverlay.SMALL_FONT));
-            graphics.drawString(font, amount, x + 17 - font.width(amount), y + 9, 0xFFFFFFFF, true);
-        }
-        graphics.pose().popPose();
     }
 
     public static boolean mouseClicked(int mouseX, int mouseY, int button) {
@@ -306,8 +294,15 @@ public final class TerminalRemoteOverlay {
         }
         TerminalRemoteOverlay.ensureSearchBox();
         if (TerminalRemoteOverlay.searchBox != null) {
-            // 退格/方向键等由 EditBox 处理；字母数字等返回 false 的键也一律吞掉
-            TerminalRemoteOverlay.searchBox.keyPressed(keyCode, scanCode, modifiers);
+            // Tab 键激活 / 取消激活搜索栏（悬停浮窗内唯一激活搜索的方式）
+            if (keyCode == InputConstants.KEY_TAB) {
+                TerminalRemoteOverlay.searchBox.setFocused(!TerminalRemoteOverlay.searchBox.isFocused());
+                return true;
+            }
+            // 仅激活时才把键入交给搜索框；未激活时一律吞掉，避免触发下层 GUI
+            if (TerminalRemoteOverlay.searchBox.isFocused()) {
+                TerminalRemoteOverlay.searchBox.keyPressed(keyCode, scanCode, modifiers);
+            }
         }
         return true;
     }
@@ -316,9 +311,9 @@ public final class TerminalRemoteOverlay {
         if (!TerminalRemoteOverlay.isHovering()) {
             return false;
         }
-        // 悬停即聚焦：拦截所有字符输入
+        // 悬停即聚焦：拦截所有字符输入；仅激活状态才交给搜索框
         TerminalRemoteOverlay.ensureSearchBox();
-        if (TerminalRemoteOverlay.searchBox != null) {
+        if (TerminalRemoteOverlay.searchBox != null && TerminalRemoteOverlay.searchBox.isFocused()) {
             TerminalRemoteOverlay.searchBox.charTyped(codePoint, modifiers);
         }
         return true;
@@ -340,7 +335,8 @@ public final class TerminalRemoteOverlay {
             TerminalRemoteOverlay.top + TerminalRemoteOverlay.SEARCH_Y,
             TerminalRemoteOverlay.maxSearchWidth(),
             9,
-            Component.translatable("screen.anvilcraft.storage.search.edit")
+            // 占位提示由 renderSearchBox 在未激活时手动绘制（灰色 "Tab"），这里保持为空
+            Component.empty()
         );
         TerminalRemoteOverlay.searchBox.setBordered(false);
         TerminalRemoteOverlay.searchBox.setTextColor(0xFFFFFFFF);
@@ -352,8 +348,8 @@ public final class TerminalRemoteOverlay {
                 TerminalRemoteOverlay.reorder();
             }
         });
-        TerminalRemoteOverlay.searchBox.setFocused(true);
-        TerminalRemoteOverlay.searchBox.setCanLoseFocus(false);
+        // 默认未激活：按 Tab 或点击搜索框才会聚焦；可失去焦点以便 Tab 再次取消激活
+        TerminalRemoteOverlay.searchBox.setCanLoseFocus(true);
     }
 
     public static void tick() {

--- a/src/main/java/dev/dubhe/anvilcraft/config/AnvilCraftClientConfig.java
+++ b/src/main/java/dev/dubhe/anvilcraft/config/AnvilCraftClientConfig.java
@@ -28,20 +28,8 @@ public class AnvilCraftClientConfig {
     @Comment("Do not render power component tooltip when jade present")
     public boolean doNotShowTooltipWhenJadePresent = false;
 
-    @Comment("Invert the mouse button for Amulet Box’s item override operations (Primary -> Secondary)")
-    public boolean amuletBoxInvertOverrideAction = false;
-
-    @Comment("Invert the mouse button for Pill Box’s item override operations (Primary -> Secondary)")
-    public boolean pillBoxInvertOverrideAction = false;
-
-    @Comment("Invert the mouse button for Local Terminal’s item override operations (Primary -> Secondary)")
-    public boolean localTerminalInvertOverrideAction = false;
-
-    @Comment("Invert the mouse button for Shulker Terminal’s item override operations (Primary -> Secondary)")
-    public boolean shulkerTerminalInvertOverrideAction = false;
-
-    @Comment("Invert the mouse button for Hyperdimension Terminal’s item override operations (Primary -> Secondary)")
-    public boolean hyperdimensionTerminalInvertOverrideAction = false;
+    @Comment("Invert the mouse button for item override operations (Primary -> Secondary)")
+    public boolean invertOverrideAction = false;
 
     @SerializedName("Show Storage Stored ID")
     @Comment("Add a tooltip line that shows storage stored ID")

--- a/src/main/java/dev/dubhe/anvilcraft/data/lang/CategoryLang.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/lang/CategoryLang.java
@@ -8,6 +8,7 @@ import dev.anvilcraft.lib.v2.registrum.providers.RegistrumLangProvider;
 public class CategoryLang {
     public static void init(RegistrumLangProvider provider) {
         provider.add("screen.anvilcraft.storage.search.edit", "Search");
+        provider.add("screen.anvilcraft.storage.search.tab", "Press Tab");
         provider.add("screen.anvilcraft.storage.search", "Search Mode: Currently %s");
         provider.add("screen.anvilcraft.storage.search.clear", "Clear");
         provider.add("screen.anvilcraft.storage.search.retention", "Retention");

--- a/src/main/java/dev/dubhe/anvilcraft/event/BlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/BlockEventListener.java
@@ -7,6 +7,7 @@ import dev.dubhe.anvilcraft.block.entity.CreativeCrateBlockEntity;
 import dev.dubhe.anvilcraft.block.entity.StoragePortBlockEntity;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import dev.dubhe.anvilcraft.network.StoragePortTakeOutPacket;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
@@ -34,6 +35,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.common.util.TriState;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
 
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -102,6 +104,10 @@ public class BlockEventListener {
     /**
      * 左键仓储端口取出物品：左键取 1 个，shift 左键取一组；手持铁砧锤时不触发。
      * 点击外边缘半像素（1/32）框架时走正常挖掘；缓存为空时也不取消事件，让玩家可以挖掘方块。
+     *
+     * <p>取出全部在服务端执行：客户端只取消事件（阻止挖掘）并发送取出请求包，
+     * 不在本地改动任何物品，避免幻影物品与快速点击刷物品。按住左键时（取消事件后客户端
+     * 不会进入挖掘状态）{@code START} 事件会每 tick 重触发，用节流限制发包频率。</p>
      */
     @SubscribeEvent
     public static void clickStoragePortEvent(PlayerInteractEvent.LeftClickBlock event) {
@@ -123,13 +129,21 @@ public class BlockEventListener {
         if (port.isBufferEmpty()) {
             return;
         }
-        // 取出冷却：按住左键反复触发时只取一次，冷却期间也不破坏方块
-        if (port.onTakeOutCooldown(player)) {
-            event.setCanceled(true);
+        // 取消事件，阻止挖掘（客户端与服务端都会触发本事件）
+        event.setCanceled(true);
+        if (!level.isClientSide()) {
             return;
         }
-        port.giveToPlayer(player, player.isShiftKeyDown());
-        event.setCanceled(true);
+        // 客户端只发送取出请求，实际取出由服务端在收到请求包后执行
+        PlayerInteractEvent.LeftClickBlock.Action action = event.getAction();
+        if (action != PlayerInteractEvent.LeftClickBlock.Action.START
+            && action != PlayerInteractEvent.LeftClickBlock.Action.CLIENT_HOLD) {
+            return;
+        }
+        if (port.onTakeOutHoldCooldown(player)) {
+            return;
+        }
+        PacketDistributor.sendToServer(new StoragePortTakeOutPacket(pos, player.isShiftKeyDown()));
     }
 
     /**

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/tabs/FunctionalBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/tabs/FunctionalBlocks.java
@@ -112,10 +112,10 @@ public class FunctionalBlocks extends DisplayItemsGenerator {
         this.plain(ModBlocks.SPACE_OVERCOMPRESSOR); // 空间超压器
         this.plain(ModBlocks.CRATE); // 板条箱
         this.plain(ModBlocks.LARGE_CRATE); // 大板条箱
-        this.plain(ModBlocks.SHULKER_CONTAINER); // 潜影集装箱
-        this.plain(ModBlocks.HYPERDIMENSION_STORAGE_STATION); // 超维存储站
-        this.plain(ModBlocks.HYPERDIMENSION_UPLOADER); // 超维上传站
         this.plain(ModBlocks.STORAGE_PORT); // 仓储端口
+        this.plain(ModBlocks.SHULKER_CONTAINER); // 潜影集装箱
+        this.plain(ModBlocks.HYPERDIMENSION_UPLOADER); // 超维上传站
+        this.plain(ModBlocks.HYPERDIMENSION_STORAGE_STATION); // 超维存储站
 
         this.plain(ModBlocks.CHUTE); // 溜槽
         this.plain(ModBlocks.MAGNETIC_CHUTE); // 磁性溜槽

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/tabs/FunctionalBlocksSections.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/tabs/FunctionalBlocksSections.java
@@ -83,10 +83,10 @@ public class FunctionalBlocksSections extends DisplayItemsGenerator {
             content -> {
                 content.accept(ModBlocks.CRATE);
                 content.accept(ModBlocks.LARGE_CRATE);
-                content.accept(ModBlocks.SHULKER_CONTAINER);
-                content.accept(ModBlocks.HYPERDIMENSION_STORAGE_STATION);
-                content.accept(ModBlocks.HYPERDIMENSION_UPLOADER);
                 content.accept(ModBlocks.STORAGE_PORT);
+                content.accept(ModBlocks.SHULKER_CONTAINER);
+                content.accept(ModBlocks.HYPERDIMENSION_UPLOADER);
+                content.accept(ModBlocks.HYPERDIMENSION_STORAGE_STATION);
                 content.accept(ModBlocks.SINGULARITY_CRYSTAL);
                 content.accept(ModBlocks.HYPERCUBE);
                 content.accept(ModBlocks.CHUTE);

--- a/src/main/java/dev/dubhe/anvilcraft/item/BundleLikeItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/BundleLikeItem.java
@@ -3,7 +3,6 @@ package dev.dubhe.anvilcraft.item;
 import dev.dubhe.anvilcraft.rpc.BundleLikeServerStub;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.SlotAccess;
@@ -20,10 +19,8 @@ public abstract class BundleLikeItem extends Item {
         super(properties);
     }
 
-    protected abstract ResourceLocation configId();
-
     protected boolean isInvertedAction(Player player) {
-        return BundleLikeServerStub.isInvertedAction(player.getGameProfile().getId(), this.configId());
+        return BundleLikeServerStub.isInvertedAction(player.getGameProfile().getId());
     }
 
     protected ClickAction computeValidAction(@SuppressWarnings("SameParameterValue") ClickAction action, Player player) {

--- a/src/main/java/dev/dubhe/anvilcraft/item/HyperdimensionTerminalItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/HyperdimensionTerminalItem.java
@@ -1,6 +1,5 @@
 package dev.dubhe.anvilcraft.item;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.block.entity.storage.StorageBlockEntity;
 import dev.dubhe.anvilcraft.client.gui.screen.StorageScreen;
 import dev.dubhe.anvilcraft.client.rpc.StorageTerminalClientStub;
@@ -9,7 +8,6 @@ import dev.dubhe.anvilcraft.item.property.component.TerminalBinding;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -24,15 +22,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class HyperdimensionTerminalItem extends TerminalItem {
-    public static final ResourceLocation CONFIG_ID = AnvilCraft.of("hyperdimension_terminal");
-
     public HyperdimensionTerminalItem(Properties properties) {
         super(properties);
-    }
-
-    @Override
-    protected ResourceLocation configId() {
-        return HyperdimensionTerminalItem.CONFIG_ID;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/LocalTerminalItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/LocalTerminalItem.java
@@ -1,12 +1,10 @@
 package dev.dubhe.anvilcraft.item;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.gui.screen.StorageScreen;
 import dev.dubhe.anvilcraft.client.rpc.StorageTerminalClientStub;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -19,15 +17,8 @@ import net.minecraft.world.level.Level;
  * 其余功能（终端界面、超级收纳袋、JEI 补库、物品均衡）与超维终端一致。
  */
 public class LocalTerminalItem extends TerminalItem {
-    public static final ResourceLocation CONFIG_ID = AnvilCraft.of("local_terminal");
-
     public LocalTerminalItem(Properties properties) {
         super(properties);
-    }
-
-    @Override
-    protected ResourceLocation configId() {
-        return LocalTerminalItem.CONFIG_ID;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/PillBoxItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/PillBoxItem.java
@@ -1,10 +1,8 @@
 package dev.dubhe.anvilcraft.item;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.item.property.component.PillBoxContents;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
@@ -12,15 +10,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 public class PillBoxItem extends BundleLikeItem {
-    public static final ResourceLocation CONFIG_ID = AnvilCraft.of("pill_box");
-
     public PillBoxItem(Properties properties) {
         super(properties.component(ModComponents.PILL_BOX_CONTENTS, PillBoxContents.EMPTY));
-    }
-
-    @Override
-    protected ResourceLocation configId() {
-        return PillBoxItem.CONFIG_ID;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/ShulkerTerminalItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ShulkerTerminalItem.java
@@ -1,12 +1,10 @@
 package dev.dubhe.anvilcraft.item;
 
-import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.client.gui.screen.StorageScreen;
 import dev.dubhe.anvilcraft.client.rpc.StorageTerminalClientStub;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
@@ -20,15 +18,8 @@ import net.minecraft.world.level.Level;
  * 或 64 格以内的一个最近的世界潜影集装箱；其余功能与超维终端一致。
  */
 public class ShulkerTerminalItem extends TerminalItem {
-    public static final ResourceLocation CONFIG_ID = AnvilCraft.of("shulker_terminal");
-
     public ShulkerTerminalItem(Properties properties) {
         super(properties);
-    }
-
-    @Override
-    protected ResourceLocation configId() {
-        return ShulkerTerminalItem.CONFIG_ID;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/amulet/AmuletBoxItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/amulet/AmuletBoxItem.java
@@ -6,7 +6,6 @@ import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.item.BundleLikeItem;
 import dev.dubhe.anvilcraft.item.property.component.BoxContents;
 import dev.dubhe.anvilcraft.util.ColorUtil;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
@@ -27,16 +26,10 @@ import java.util.Optional;
 public class AmuletBoxItem extends BundleLikeItem {
     private static final int FULL_BAR_COLOR = 0xFF5454FF;
     private static final int BAR_COLOR = 0x7087FFFF;
-    public static final ResourceLocation CONFIG_ID = AnvilCraft.of("amulet_box");
     public static final int CAPACITY = 16;
 
     public AmuletBoxItem(Properties properties) {
         super(properties.component(ModComponents.BOX_CONTENTS, BoxContents.EMPTY));
-    }
-
-    @Override
-    protected ResourceLocation configId() {
-        return AmuletBoxItem.CONFIG_ID;
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/network/StoragePortTakeOutPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/StoragePortTakeOutPacket.java
@@ -1,0 +1,51 @@
+package dev.dubhe.anvilcraft.network;
+
+import dev.anvilcraft.lib.v2.network.packet.IPacket;
+import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.block.entity.StoragePortBlockEntity;
+import dev.dubhe.anvilcraft.item.AnvilHammerItem;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * 客户端左键仓储端口时发送：请求服务端取出 1 个（shift 时取出一组）。
+ *
+ * <p>取出完全在服务端执行（缓存与玩家背包均为权威数据），客户端不直接改动任何物品，
+ * 避免幻影物品与快速点击刷物品。</p>
+ */
+public record StoragePortTakeOutPacket(BlockPos pos, boolean fullStack) implements IServerboundPacket {
+    public static final Type<StoragePortTakeOutPacket> TYPE = IPacket.type(
+        AnvilCraft.of("storage_port_take_out")
+    );
+    public static final StreamCodec<ByteBuf, StoragePortTakeOutPacket> STREAM_CODEC = StreamCodec.composite(
+        BlockPos.STREAM_CODEC,
+        StoragePortTakeOutPacket::pos,
+        ByteBufCodecs.BOOL,
+        StoragePortTakeOutPacket::fullStack,
+        StoragePortTakeOutPacket::new
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void handleOnServer(Player player) {
+        if (player.getMainHandItem().getItem() instanceof AnvilHammerItem) {
+            return;
+        }
+        if (player.distanceToSqr(this.pos.getCenter()) > 64.0) {
+            return;
+        }
+        if (!(player.level().getBlockEntity(this.pos) instanceof StoragePortBlockEntity port)) {
+            return;
+        }
+        port.giveToPlayer(player, this.fullStack);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/rpc/BundleLikeServerStub.java
+++ b/src/main/java/dev/dubhe/anvilcraft/rpc/BundleLikeServerStub.java
@@ -1,30 +1,27 @@
 package dev.dubhe.anvilcraft.rpc;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
-import com.google.common.collect.Tables;
 import dev.anvilcraft.lib.v2.rpc.RemoteCallable;
 import lombok.experimental.UtilityClass;
-import net.minecraft.resources.ResourceLocation;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @UtilityClass
 public class BundleLikeServerStub {
-    private static final Table<UUID, ResourceLocation, Boolean> INVERTED =
-        Tables.synchronizedTable(HashBasedTable.create());
+    private static final Map<UUID, Boolean> INVERTED = new HashMap<>();
 
     @RemoteCallable
-    public static void updateInverted(UUID id, ResourceLocation location, boolean inverted) {
-        BundleLikeServerStub.INVERTED.put(id, location, inverted);
+    public static void updateInverted(UUID id, boolean inverted) {
+        BundleLikeServerStub.INVERTED.put(id, inverted);
     }
 
-    public static boolean isInvertedAction(UUID id, ResourceLocation location) {
-        return Boolean.TRUE.equals(BundleLikeServerStub.INVERTED.get(id, location));
+    public static boolean isInvertedAction(UUID id) {
+        return Boolean.TRUE.equals(BundleLikeServerStub.INVERTED.get(id));
     }
 
     /** 玩家退出时清理其反色动作状态，避免静态表永久残留。 */
     public static void clear(UUID id) {
-        BundleLikeServerStub.INVERTED.row(id).clear();
+        BundleLikeServerStub.INVERTED.remove(id);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/rpc/StorageServerStub.java
+++ b/src/main/java/dev/dubhe/anvilcraft/rpc/StorageServerStub.java
@@ -1315,9 +1315,9 @@ public final class StorageServerStub {
         if (targetId.equals(StorageServerStub.shulkerTerminalId(playerId))) {
             return StorageServerStub.shulkerTerminalStorages(player);
         }
-        return Storages.get().get(targetId, HyperdimensionStorage.class)
-            .map(List::<BaseStorage<?>>of)
-            .orElseGet(List::of);
+        return List.of(
+            Storages.get().getOrCreate(targetId, HyperdimensionStorage.class)
+        );
     }
 
     /**


### PR DESCRIPTION
- fixed #4584 
- fixed #4585 
- 将五个分物品反转操作配置合并为一个
- 修复了终端浮窗内物品耐久条无法正常显示的问题
- 修复了右键存储端口会刷物品的问题
- 修复了存储端口手动操作不符合预期的问题
- 修复了存储相关方块在创造物品栏中的顺序不符合预期的问题