### PR TITLE
Fix laser not pushing items into containers 修复激光采矿时不往背后容器内输入物品的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -228,19 +228,24 @@ public class ItemHandlerUtil {
     public static ItemStack insertItem(@Nullable ResourceHandler<ItemResource> dest, ItemStack stack, boolean simulate) {
         if (dest == null || stack.isEmpty()) return stack;
 
+        ItemStack remainingStack = stack.copy();
+        
         if (dest instanceof PollableFilteredItemStackHandler pollable) {
             try (Transaction root = Transaction.openRoot()) {
                 for (int i = 0; i < dest.size(); i++) {
                     try (Transaction transaction = Transaction.open(root)) {
-                        stack.setCount(pollable.insertNoPolling(i, pollable.getResourceFrom(stack), stack.getCount(), transaction));
-                        if (stack.isEmpty()) {
-                            if (!simulate) {
-                                transaction.commit();
-                            }
-                            return ItemStack.EMPTY;
-                        }
+                        int inserted = pollable.insertNoPolling(
+                            i,
+                            pollable.getResourceFrom(remainingStack),
+                            remainingStack.getCount(),
+                            transaction
+                        );
+                        remainingStack.shrink(inserted);
                         if (!simulate) {
                             transaction.commit();
+                        }
+                        if (remainingStack.isEmpty()) {
+                            break;
                         }
                     }
                 }
@@ -250,15 +255,21 @@ public class ItemHandlerUtil {
             }
         } else {
             try (Transaction transaction = Transaction.openRoot()) {
-                int stackCount = stack.getCount();
-                int inserted = dest.insert(ItemResource.of(stack.getItem(), stack.getComponentsPatch()), stackCount, transaction);
-                stack.setCount(inserted);
+                int inserted = dest.insert(
+                    ItemResource.of(remainingStack.getItem(), remainingStack.getComponentsPatch()),
+                    remainingStack.getCount(),
+                    transaction
+                );
+                remainingStack.shrink(inserted);
                 if (!simulate) {
                     transaction.commit();
                 }
             }
         }
-        return stack;
+        if (remainingStack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
+        return remainingStack;
     }
 
     public static boolean isEmptyContainer(@Nullable ResourceHandler<ItemResource> handler) {


### PR DESCRIPTION
由于 `net.neoforged.neoforge.items.ItemHandlerHelper` 类于 1.21.9 被弃用，此前移植至 26.1 时重写了 `ItemHandlerUtil.insertItem`。但其逻辑不正确，导致激光采矿时不往背后容器内输入物品。该 PR 修复了上述问题。

该问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。