### PR TITLE
Added a server synchronization method for previewing structure disks, fix bugs. 给结构磁盘预览的添加了服务器同步方法，修bug

### DIFF
--- a/src/generated/resources/data/minecraft/tags/item/enchantable/fire_aspect.json
+++ b/src/generated/resources/data/minecraft/tags/item/enchantable/fire_aspect.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "anvilcraft:frost_metal_heavy_halberd",
+    "anvilcraft:ember_metal_heavy_halberd",
+    "anvilcraft:transcendence_heavy_halberd"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/enchantable/sharp_weapon.json
+++ b/src/generated/resources/data/minecraft/tags/item/enchantable/sharp_weapon.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "anvilcraft:frost_metal_heavy_halberd",
+    "anvilcraft:ember_metal_heavy_halberd",
+    "anvilcraft:transcendence_heavy_halberd"
+  ]
+}

--- a/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingBlockInfo.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/sliding/SlidingBlockInfo.java
@@ -1,8 +1,6 @@
 package dev.dubhe.anvilcraft.api.sliding;
 
-import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.anvilcraft.lib.v2.codec.StreamCodecUtil;
 import it.unimi.dsi.fastutil.ints.IntIntPair;
@@ -12,7 +10,6 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.Vec3i;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -104,17 +101,21 @@ public record SlidingBlockInfo(Vec3i offset, BlockState state, @Nullable BlockEn
     }
 
     private static @Nullable BlockEntity fromTag(RegistryFriendlyByteBuf buf, BlockState state, CompoundTag tag) {
-        RegistryAccess registries = buf.registryAccess();
-        DataResult<BlockEntityType<?>> entityType = BuiltInRegistries.BLOCK_ENTITY_TYPE.byNameCodec()
-            .decode(registries.createSerializationContext(NbtOps.INSTANCE), tag.get("id"))
-            .map(Pair::getFirst);
-        if (entityType.isError()) return null;
-        BlockEntityType<?> blockEntityType = entityType.getOrThrow();
+        String id = tag.getString("id");
+        if (id.isEmpty()) return null;
+        BlockEntityType<?> blockEntityType = BuiltInRegistries.BLOCK_ENTITY_TYPE.get(ResourceLocation.parse(id));
+        if (blockEntityType == null) return null;
         int x = !tag.contains("x") ? 0 : tag.getInt("x");
         int y = !tag.contains("y") ? 0 : tag.getInt("y");
         int z = !tag.contains("z") ? 0 : tag.getInt("z");
         BlockEntity be = blockEntityType.create(new BlockPos(x, y, z), state);
-        if (be != null) be.loadWithComponents(tag, registries);
+        if (be == null) return null;
+        try {
+            be.loadWithComponents(tag, buf.registryAccess());
+        } catch (RuntimeException ignored) {
+            // ignored: 方块实体数据解码失败时保留已加载的部分数据，
+            // 避免滑动方块因为单个方块实体解码失败而丢失整个内容。
+        }
         return be;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/CrushingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/CrushingTableBlock.java
@@ -196,7 +196,10 @@ public class CrushingTableBlock extends Block implements
         BlockPos pos,
         Player player
     ) {
-        // 生存模式中键选择时，目标统一指向冲压台的物品
+        // 创造模式选取时指向自身方块，生存模式中键选择时统一指向冲压台的物品
+        if (player.getAbilities().instabuild) {
+            return new ItemStack(this);
+        }
         return new ItemStack(ModBlocks.STAMPING_PLATFORM);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/CrushingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/CrushingTableBlock.java
@@ -4,8 +4,8 @@ import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
 import dev.dubhe.anvilcraft.block.entity.CrushingTableBlockEntity;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -187,6 +187,7 @@ public class CrushingTableBlock extends Block implements
         }
         return super.updateShape(blockState, direction, blockState2, levelAccessor, blockPos, blockPos2);
     }
+
     @Override
     public ItemStack getCloneItemStack(
         BlockState state,

--- a/src/main/java/dev/dubhe/anvilcraft/block/CrushingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/CrushingTableBlock.java
@@ -4,6 +4,7 @@ import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
 import dev.dubhe.anvilcraft.block.entity.CrushingTableBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -17,6 +18,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -28,6 +30,7 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -183,5 +186,16 @@ public class CrushingTableBlock extends Block implements
             levelAccessor.scheduleTick(blockPos, Fluids.WATER, Fluids.WATER.getTickDelay(levelAccessor));
         }
         return super.updateShape(blockState, direction, blockState2, levelAccessor, blockPos, blockPos2);
+    }
+    @Override
+    public ItemStack getCloneItemStack(
+        BlockState state,
+        HitResult target,
+        LevelReader level,
+        BlockPos pos,
+        Player player
+    ) {
+        // 生存模式中键选择时，目标统一指向冲压台的物品
+        return new ItemStack(ModBlocks.STAMPING_PLATFORM);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/SiftingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SiftingTableBlock.java
@@ -4,6 +4,7 @@ import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
 import dev.dubhe.anvilcraft.block.entity.SiftingTableBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -17,6 +18,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -27,6 +29,7 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -173,5 +176,16 @@ public class SiftingTableBlock extends Block implements
             level.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }
         return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
+    }
+    @Override
+    public ItemStack getCloneItemStack(
+        BlockState state,
+        HitResult target,
+        LevelReader level,
+        BlockPos pos,
+        Player player
+    ) {
+        // 生存模式中键选择时，目标统一指向冲压台的物品
+        return new ItemStack(ModBlocks.STAMPING_PLATFORM);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/SiftingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SiftingTableBlock.java
@@ -186,7 +186,10 @@ public class SiftingTableBlock extends Block implements
         BlockPos pos,
         Player player
     ) {
-        // 生存模式中键选择时，目标统一指向冲压台的物品
+        // 创造模式选取时指向自身方块，生存模式中键选择时统一指向冲压台的物品
+        if (player.getAbilities().instabuild) {
+            return new ItemStack(this);
+        }
         return new ItemStack(ModBlocks.STAMPING_PLATFORM);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/SiftingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/SiftingTableBlock.java
@@ -4,8 +4,8 @@ import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
 import dev.dubhe.anvilcraft.block.entity.SiftingTableBlockEntity;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -177,6 +177,7 @@ public class SiftingTableBlock extends Block implements
         }
         return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
     }
+
     @Override
     public ItemStack getCloneItemStack(
         BlockState state,

--- a/src/main/java/dev/dubhe/anvilcraft/block/UnpackingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/UnpackingTableBlock.java
@@ -4,6 +4,7 @@ import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
 import dev.dubhe.anvilcraft.block.entity.UnpackingTableBlockEntity;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -17,6 +18,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -28,6 +30,7 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
@@ -179,5 +182,16 @@ public class UnpackingTableBlock extends Block implements
             level.scheduleTick(pos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
         }
         return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
+    }
+    @Override
+    public ItemStack getCloneItemStack(
+        BlockState state,
+        HitResult target,
+        LevelReader level,
+        BlockPos pos,
+        Player player
+    ) {
+        // 生存模式中键选择时，目标统一指向冲压台的物品
+        return new ItemStack(ModBlocks.STAMPING_PLATFORM);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/UnpackingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/UnpackingTableBlock.java
@@ -4,8 +4,8 @@ import dev.anvilcraft.lib.v2.piston.IMoveableEntityBlock;
 import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.api.itemhandler.ItemHandlerUtil;
 import dev.dubhe.anvilcraft.block.entity.UnpackingTableBlockEntity;
-import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.block.ModBlockEntities;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -183,6 +183,7 @@ public class UnpackingTableBlock extends Block implements
         }
         return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
     }
+
     @Override
     public ItemStack getCloneItemStack(
         BlockState state,

--- a/src/main/java/dev/dubhe/anvilcraft/block/UnpackingTableBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/UnpackingTableBlock.java
@@ -192,7 +192,10 @@ public class UnpackingTableBlock extends Block implements
         BlockPos pos,
         Player player
     ) {
-        // 生存模式中键选择时，目标统一指向冲压台的物品
+        // 创造模式选取时指向自身方块，生存模式中键选择时统一指向冲压台的物品
+        if (player.getAbilities().instabuild) {
+            return new ItemStack(this);
+        }
         return new ItemStack(ModBlocks.STAMPING_PLATFORM);
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/block/container/storage/LargeCrateBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/container/storage/LargeCrateBlock.java
@@ -32,6 +32,7 @@ import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.api.distmarker.Dist;
@@ -126,6 +127,17 @@ public class LargeCrateBlock
             }
         }
         return super.use(state, level, pos, player, hand, hitResult);
+    }
+
+    @Override
+    protected VoxelShape getCollisionShape(
+        BlockState state,
+        BlockGetter level,
+        BlockPos pos,
+        CollisionContext context
+    ) {
+        // 碰撞箱用完整方块，选择框仍用多方块组合形状（getShape 不受影响）
+        return Shapes.block();
     }
 
     // region VoxelShapes

--- a/src/main/java/dev/dubhe/anvilcraft/block/container/storage/ShulkerContainerBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/container/storage/ShulkerContainerBlock.java
@@ -52,6 +52,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.api.distmarker.Dist;
@@ -91,6 +92,17 @@ public class ShulkerContainerBlock
             StorageBlockEntity.applyPickStorageId(stack, realLevel, pos, state, ModStorageTypes.SHULKER_CONTAINER);
         }
         return stack;
+    }
+
+    @Override
+    protected VoxelShape getCollisionShape(
+        BlockState state,
+        BlockGetter level,
+        BlockPos pos,
+        CollisionContext context
+    ) {
+        // 碰撞箱用完整方块，选择框仍用多方块组合形状（getShape 不受影响）
+        return Shapes.block();
     }
 
     private static final ImmutableMap<Direction, ImmutableList<Vec3i>> UPDATE_OFFSET = ImmutableMap.of(

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/SpacetimeSupercomputerBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/SpacetimeSupercomputerBlockEntity.java
@@ -19,6 +19,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.Connection;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -250,6 +251,25 @@ public class SpacetimeSupercomputerBlockEntity extends BlockEntity implements IP
             tag.put("processing", processing);
         }
         return tag;
+    }
+
+    @Override
+    public void onDataPacket(
+        Connection net,
+        ClientboundBlockEntityDataPacket pkt,
+        HolderLookup.Provider lookupProvider
+    ) {
+        super.onDataPacket(net, pkt, lookupProvider);
+        // NeoForge 默认 onDataPacket 在空 tag 时会跳过 loadWithComponents，
+        // 而合成完成时 getUpdateTag 不写入 processing 导致 tag 为空，
+        // 客户端无法触发 loadAdditional 的清除分支，进度文本会停留在最后一步。
+        if (!pkt.getTag().contains("processing")) {
+            this.pendingRecipeId = null;
+            this.processingRecipe = null;
+            this.processingStep = -1;
+            this.processingSize = -1;
+            this.processingTotal = -1;
+        }
     }
 
     public void runCommand(@Nullable Player player) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/FishTankBlockEntityRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/blockentity/FishTankBlockEntityRenderer.java
@@ -93,7 +93,13 @@ public class FishTankBlockEntityRenderer implements BlockEntityRenderer<FishTank
         ItemStackHandler handler = tank.getItemHandler();
         this.random.setSeed(ItemHandlerUtil.hash(handler));
         Level level = tank.getLevel();
-        if (level == null) return;
+        if (level == null) {
+            // 滑动方块带来的鱼缸方块实体没有编辑过世界，
+            // 用主客户端世界兑底，否则渲染器会直接跳过内容。
+            level = Minecraft.getInstance().level;
+            if (level == null) return;
+            tank.setLevel(level);
+        }
         FishTankBlockEntityRenderer.drawItemsInTank(
             level,
             ItemHandlerUtil.getNonEmptyItemsFromHandler(handler),

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/entity/SlidingBlockRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/entity/SlidingBlockRenderer.java
@@ -15,8 +15,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.RenderTypeHelper;
 import net.neoforged.neoforge.client.model.data.ModelData;
@@ -58,8 +61,20 @@ public class SlidingBlockRenderer extends EntityRenderer<SlidingBlockEntity> {
         int packedLight
     ) {
         BlockState state = info.state();
-        if (state.getRenderShape() != RenderShape.MODEL) return;
-        if (state == level.getBlockState(center) || state.getRenderShape() == RenderShape.INVISIBLE) return;
+        // 这里不能直接用 state == level.getBlockState(center) 来判断中心方块，
+        // 因为滑动方块总是位于实体坐标处，而中心方块可能正在被活塞恢复中。
+        if (state == level.getBlockState(center)) return;
+        boolean movedPiston = false;
+        if (state.getRenderShape() != RenderShape.MODEL) {
+            // 进程方块（MOVING_PISTON）的真实方块存在 PistonMovingBlockEntity 的 movedState 里，
+            // 从中心位置取实体恢复出来继续渲染。
+            if (!state.is(Blocks.MOVING_PISTON)) return;
+            if (!(level.getBlockEntity(center, BlockEntityType.PISTON).orElse(null) instanceof PistonMovingBlockEntity pbe)) return;
+            BlockState moved = pbe.getMovedState();
+            if (moved.getRenderShape() != RenderShape.MODEL) return;
+            state = moved;
+            movedPiston = true;
+        }
         pose.pushPose();
         final BlockPos pos = info.getPos(center);
         startPos = info.getPos(startPos);
@@ -67,7 +82,11 @@ public class SlidingBlockRenderer extends EntityRenderer<SlidingBlockEntity> {
         pose.translate(info.offsetX(), info.offsetY(), info.offsetZ());
 
         BlockEntity blockEntity = info.blockEntity();
-        if (blockEntity != null) {
+        if (blockEntity != null && !movedPiston) {
+            // 通过网络包反序列化出来的方块实体没有世界和位置，
+            // 不设置的话方块实体渲染器（例如 WIP 方块）会直接跳过渲染。
+            blockEntity.setLevel(level);
+            blockEntity.worldPosition = pos;
             BlockEntityRenderer<BlockEntity> renderer = Minecraft.getInstance()
                 .getBlockEntityRenderDispatcher()
                 .getRenderer(blockEntity);

--- a/src/main/java/dev/dubhe/anvilcraft/entity/ThrownHeavyHalberdEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/entity/ThrownHeavyHalberdEntity.java
@@ -3,6 +3,7 @@ package dev.dubhe.anvilcraft.entity;
 import com.google.common.collect.ImmutableSet;
 import dev.dubhe.anvilcraft.item.HeavyHalberdItem;
 import net.minecraft.core.HolderSet;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -24,6 +25,7 @@ import net.minecraft.world.entity.projectile.AbstractArrow;
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.BlockHitResult;
@@ -152,6 +154,8 @@ public abstract class ThrownHeavyHalberdEntity extends AbstractArrow {
 
             if (this.level() instanceof ServerLevel level) {
                 EnchantmentHelper.doPostAttackEffectsWithItemSource(level, victim, source, this.getWeaponItem());
+                // 投掷的伤害源 isDirect() 为 false，火焰附加的 is_direct 条件不满足，需手动触发火焰附加
+                this.applyFireAspectOnHit(level, victim);
             }
 
             if (victim instanceof LivingEntity livingentity) {
@@ -162,6 +166,20 @@ public abstract class ThrownHeavyHalberdEntity extends AbstractArrow {
 
         this.setDeltaMovement(this.getDeltaMovement().multiply(-0.01, -0.1, -0.01));
         this.playSound(SoundEvents.TRIDENT_HIT, 1.0F, 1.0F);
+    }
+
+    /**
+     * 投掷重枪命中时手动触发火焰附加：投掷伤害源为间接伤害，原版 is_direct 条件无法触发。
+     */
+    private void applyFireAspectOnHit(ServerLevel level, Entity victim) {
+        ItemStack weapon = this.getWeaponItem();
+        if (weapon.isEmpty()) return;
+        int fireAspect = weapon.getEnchantmentLevel(
+            level.holderLookup(Registries.ENCHANTMENT).getOrThrow(Enchantments.FIRE_ASPECT)
+        );
+        if (fireAspect > 0) {
+            victim.igniteForSeconds(4.0F * fireAspect);
+        }
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/block/ModBlocks.java
@@ -1651,7 +1651,7 @@ public class ModBlocks {
             "mass_energy_inverter",
             MassEnergyInverterBlock::new
         )
-        .initialProperties(() -> Blocks.IRON_BLOCK)
+        .initialProperties(() -> Blocks.NETHERITE_BLOCK)
         .properties(properties -> properties.isValidSpawn(Blocks::never).noOcclusion())
         .blockstate(DataGenUtil::simple)
         .tag(BlockTags.MINEABLE_WITH_PICKAXE)

--- a/src/main/java/dev/dubhe/anvilcraft/init/item/ModItems.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/item/ModItems.java
@@ -364,6 +364,8 @@ public class ModItems {
             ItemTags.MACE_ENCHANTABLE,
             ItemTags.TRIDENT_ENCHANTABLE,
             ItemTags.SWORD_ENCHANTABLE,
+            ItemTags.SHARP_WEAPON_ENCHANTABLE,
+            ItemTags.FIRE_ASPECT_ENCHANTABLE,
             ItemTags.WEAPON_ENCHANTABLE,
             ModItemTags.HEAVY_HALBERD,
             ModItemTags.EXPLOSION_PROOF
@@ -377,6 +379,8 @@ public class ModItems {
             ItemTags.MACE_ENCHANTABLE,
             ItemTags.TRIDENT_ENCHANTABLE,
             ItemTags.SWORD_ENCHANTABLE,
+            ItemTags.SHARP_WEAPON_ENCHANTABLE,
+            ItemTags.FIRE_ASPECT_ENCHANTABLE,
             ItemTags.WEAPON_ENCHANTABLE,
             ModItemTags.HEAVY_HALBERD,
             ModItemTags.EXPLOSION_PROOF
@@ -391,6 +395,8 @@ public class ModItems {
             ItemTags.MACE_ENCHANTABLE,
             ItemTags.TRIDENT_ENCHANTABLE,
             ItemTags.SWORD_ENCHANTABLE,
+            ItemTags.SHARP_WEAPON_ENCHANTABLE,
+            ItemTags.FIRE_ASPECT_ENCHANTABLE,
             ItemTags.WEAPON_ENCHANTABLE,
             ModItemTags.HEAVY_HALBERD,
             ModItemTags.EXPLOSION_PROOF

--- a/src/main/java/dev/dubhe/anvilcraft/item/HeavyHalberdItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/HeavyHalberdItem.java
@@ -61,6 +61,7 @@ import net.minecraft.world.item.component.Tool;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -365,6 +366,10 @@ public abstract class HeavyHalberdItem extends TieredItem implements ProjectileI
     }
 
     private static boolean isEnchantmentActive(ItemStack stack, Holder<Enchantment> enchantment) {
+        if (enchantment.is(Enchantments.SWEEPING_EDGE)) {
+            // 横扫之刃是剑模式专属附魔，其他模式不生效
+            return getMode(stack) == SWORD_MODE && stack.is(enchantment.value().definition().supportedItems());
+        }
         return stack.is(enchantment.value().definition().supportedItems());
     }
 
@@ -480,10 +485,7 @@ public abstract class HeavyHalberdItem extends TieredItem implements ProjectileI
         }
 
         private static boolean isModeEnabled(int mode, TagKey<Item> tagKey) {
-            if (tagKey.equals(ItemTags.SWORDS)
-                || tagKey.equals(ItemTags.SWORD_ENCHANTABLE)
-                || tagKey.equals(ItemTags.SHARP_WEAPON_ENCHANTABLE)
-            ) {
+            if (tagKey.equals(ItemTags.SWORDS)) {
                 return mode == SWORD_MODE;
             }
             if (tagKey.equals(ItemTags.TRIDENT_ENCHANTABLE)) {
@@ -492,8 +494,13 @@ public abstract class HeavyHalberdItem extends TieredItem implements ProjectileI
             if (tagKey.equals(ItemTags.MACE_ENCHANTABLE)) {
                 return mode == MACE_MODE;
             }
-            if (tagKey.equals(ItemTags.FIRE_ASPECT_ENCHANTABLE) || tagKey.equals(ItemTags.WEAPON_ENCHANTABLE)) {
-                return mode == SWORD_MODE || mode == MACE_MODE;
+            if (tagKey.equals(ItemTags.SWORD_ENCHANTABLE)
+                || tagKey.equals(ItemTags.SHARP_WEAPON_ENCHANTABLE)
+                || tagKey.equals(ItemTags.FIRE_ASPECT_ENCHANTABLE)
+                || tagKey.equals(ItemTags.WEAPON_ENCHANTABLE)
+            ) {
+                // 通用近战武器附魔（抢夺、锋利、火焰附加等）在所有近战模式下生效
+                return mode == TRIDENT_MODE || mode == SPEAR_MODE || mode == SWORD_MODE || mode == MACE_MODE;
             }
             return true;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/mixin/AnvilBlockMixin.java
+++ b/src/main/java/dev/dubhe/anvilcraft/mixin/AnvilBlockMixin.java
@@ -31,6 +31,10 @@ abstract class AnvilBlockMixin extends FallingBlock {
 
     @Override
     public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        if (state.is(ModBlockTags.NON_MAGNETIC)) {
+            super.tick(state, level, pos, random);
+            return;
+        }
         if (anvilcraft$isAttracts(level.getBlockState(pos.above()))) {
             return;
         }
@@ -47,6 +51,7 @@ abstract class AnvilBlockMixin extends FallingBlock {
         boolean movedByPiston
     ) {
         super.neighborChanged(state, level, pos, neighborBlock, neighborPos, movedByPiston);
+        if (state.is(ModBlockTags.NON_MAGNETIC)) return;
         this.anvilcraft$wasAttracted(state, level, pos);
     }
 
@@ -64,6 +69,7 @@ abstract class AnvilBlockMixin extends FallingBlock {
         boolean movedByPiston
     ) {
         super.onPlace(state, level, pos, oldState, movedByPiston);
+        if (state.is(ModBlockTags.NON_MAGNETIC)) return;
         BlockState state1 = level.getBlockState(pos.above());
         if (!this.anvilcraft$isAttracts(state1)) this.anvilcraft$wasAttracted(state, level, pos);
     }

--- a/src/main/java/dev/dubhe/anvilcraft/network/StructureDiskRequestPacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/StructureDiskRequestPacket.java
@@ -1,0 +1,60 @@
+package dev.dubhe.anvilcraft.network;
+
+import dev.anvilcraft.lib.v2.network.packet.IPacket;
+import dev.anvilcraft.lib.v2.network.packet.IServerboundPacket;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.util.StructureLoadUtil;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * 客户端请求结构磁盘对应的 NBT 结构文件。
+ *
+ * <p>结构磁盘的预览依赖本地 NBT 文件，在纯服务器环境下客户端本地没有该文件，
+ * 因此客户端通过本包向服务器请求，服务器读取并回传 {@link StructureDiskResponsePacket}。</p>
+ *
+ * @param file 结构文件名（形如 {@code name_uuid.nbt}）
+ */
+public record StructureDiskRequestPacket(String file) implements IServerboundPacket {
+    /** 同一玩家请求结构文件的冷却，避免批量探测服务器文件。 */
+    private static final long REQUEST_COOLDOWN_MS = 2000;
+    private static final Map<ServerPlayer, Long> LAST_REQUEST = new WeakHashMap<>();
+
+    public static final Type<StructureDiskRequestPacket> TYPE = IPacket.type(
+        AnvilCraft.of("structure_disk_request")
+    );
+    public static final StreamCodec<ByteBuf, StructureDiskRequestPacket> STREAM_CODEC = StreamCodec.composite(
+        ByteBufCodecs.STRING_UTF8,
+        StructureDiskRequestPacket::file,
+        StructureDiskRequestPacket::new
+    );
+
+    @Override
+    public Type<StructureDiskRequestPacket> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void handleOnServer(Player player) {
+        if (!(player instanceof ServerPlayer serverPlayer)) return;
+        if (!StructureLoadUtil.isValidStructureFile(this.file)) return;
+
+        long now = System.currentTimeMillis();
+        Long last = LAST_REQUEST.put(serverPlayer, now);
+        if (last != null && now - last < REQUEST_COOLDOWN_MS) return;
+
+        CompoundTag tag = StructureLoadUtil.readStructureFileOnServer(serverPlayer.serverLevel(), this.file);
+        PacketDistributor.sendToPlayer(
+            serverPlayer,
+            new StructureDiskResponsePacket(this.file, tag)
+        );
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/network/StructureDiskResponsePacket.java
+++ b/src/main/java/dev/dubhe/anvilcraft/network/StructureDiskResponsePacket.java
@@ -1,0 +1,44 @@
+package dev.dubhe.anvilcraft.network;
+
+import dev.anvilcraft.lib.v2.network.packet.IClientboundPacket;
+import dev.anvilcraft.lib.v2.network.packet.IPacket;
+import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.util.StructureLoadUtil;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * 服务器返回结构磁盘对应的 NBT 结构文件，供客户端本地预览缓存。
+ *
+ * @param file 结构文件名
+ * @param tag  结构 NBT 数据；文件不存在或读取失败时为 {@code null}
+ */
+public record StructureDiskResponsePacket(String file, CompoundTag tag) implements IClientboundPacket {
+    public static final Type<StructureDiskResponsePacket> TYPE = IPacket.type(
+        AnvilCraft.of("structure_disk_response")
+    );
+    public static final StreamCodec<ByteBuf, StructureDiskResponsePacket> STREAM_CODEC = StreamCodec.of(
+        (buffer, packet) -> {
+            ByteBufCodecs.STRING_UTF8.encode(buffer, packet.file());
+            FriendlyByteBuf.writeNbt(buffer, packet.tag());
+        },
+        buffer -> new StructureDiskResponsePacket(
+            ByteBufCodecs.STRING_UTF8.decode(buffer),
+            FriendlyByteBuf.readNbt(buffer)
+        )
+    );
+
+    @Override
+    public Type<StructureDiskResponsePacket> type() {
+        return TYPE;
+    }
+
+    @Override
+    public void handleOnClient(Player player) {
+        StructureLoadUtil.cacheStructureNbt(this.file, this.tag);
+    }
+}

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/FastCookingRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/anvil/wrap/FastCookingRecipe.java
@@ -5,6 +5,8 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.anvilcraft.lib.v2.util.predicate.BlockStatePredicate;
 import dev.anvilcraft.lib.v2.util.predicate.ChanceItemStack;
 import dev.anvilcraft.lib.v2.util.predicate.ItemIngredientPredicate;
+import dev.dubhe.anvilcraft.block.BurningHeaterBlock;
+import dev.dubhe.anvilcraft.init.block.ModBlocks;
 import dev.dubhe.anvilcraft.init.recipe.ModRecipeTypes;
 import dev.dubhe.anvilcraft.recipe.anvil.util.WrapUtils;
 import dev.dubhe.anvilcraft.recipe.component.HasCauldronSimple;
@@ -46,8 +48,10 @@ public class FastCookingRecipe extends AbstractProcessRecipe<FastCookingRecipe> 
                 .setBlockInputOffset(new Vec3i(0, -2, 0))
                 .setInputBlocks(
                     BlockStatePredicate.builder()
-                        .of(Blocks.CAMPFIRE)
+                        .of(Blocks.CAMPFIRE, ModBlocks.BURNING_HEATER.get())
                         .with(CampfireBlock.LIT, true)
+                        .or()
+                        .with(BurningHeaterBlock.LEVEL, 1)
                         .build()
                 )
         );

--- a/src/main/java/dev/dubhe/anvilcraft/util/StructureLoadUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StructureLoadUtil.java
@@ -3,7 +3,11 @@ package dev.dubhe.anvilcraft.util;
 import dev.anvilcraft.lib.v2.util.DistExecutor;
 import dev.dubhe.anvilcraft.init.item.ModComponents;
 import dev.dubhe.anvilcraft.item.property.component.StructureDiskData;
+import dev.dubhe.anvilcraft.network.StructureDiskRequestPacket;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
@@ -25,7 +29,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -48,7 +54,59 @@ public class StructureLoadUtil {
      */
     @Nullable
     public static StructureData loadStructureFromDiskForPreview(Level level, ItemStack diskStack) {
-        return loadStructureFromDisk(level, diskStack);
+        StructureDiskData structureDiskData = diskStack.get(ModComponents.STRUCTURE_DISK_DATA);
+        if (structureDiskData == null || structureDiskData.file().isEmpty()) {
+            return null;
+        }
+        String fileName = structureDiskData.file();
+        CompoundTag tag = getCachedStructureNbt(fileName);
+        if (tag == null) {
+            requestStructureFile(level, structureDiskData);
+            return null;
+        }
+        try {
+            HolderLookup.Provider registry = level.registryAccess();
+            StructureData data = new StructureData(structureDiskData);
+            StructureLoadUtil.parseStructureNBT(data, tag, registry);
+            return data;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse cached structure {}: {}", fileName, e.getMessage());
+            removeCachedStructureNbt(fileName);
+            return null;
+        }
+    }
+
+    /** 客户端已缓存的结构 NBT（服务端通过 {@link dev.dubhe.anvilcraft.network.StructureDiskResponsePacket} 下发）。 */
+    private static final Map<String, CompoundTag> STRUCTURE_NBT_CACHE = new HashMap<>();
+
+    /** 缓存服务端下发的结构 NBT；{@code null} 表示文件不存在，避免反复请求。 */
+    public static void cacheStructureNbt(String fileName, @Nullable CompoundTag tag) {
+        if (tag == null) {
+            STRUCTURE_NBT_CACHE.put(fileName, null);
+        } else {
+            STRUCTURE_NBT_CACHE.put(fileName, tag.copy());
+        }
+    }
+
+    @Nullable
+    private static CompoundTag getCachedStructureNbt(String fileName) {
+        if (!STRUCTURE_NBT_CACHE.containsKey(fileName)) return null;
+        return STRUCTURE_NBT_CACHE.get(fileName);
+    }
+
+    public static void removeCachedStructureNbt(String fileName) {
+        STRUCTURE_NBT_CACHE.remove(fileName);
+    }
+
+    /** 纯服务器环境下客户端本地没有结构文件，向服务器发起请求。 */
+    private static void requestStructureFile(Level level, StructureDiskData data) {
+        if (!isValidStructureFile(data.file())) return;
+        if (!(level instanceof ClientLevel)) return;
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientPacketListener connection = minecraft.getConnection();
+        if (!(minecraft.player instanceof LocalPlayer)) return;
+        if (connection == null) return;
+        connection.send(new StructureDiskRequestPacket(data.file()));
     }
 
     /**
@@ -110,6 +168,24 @@ public class StructureLoadUtil {
 
         } catch (IOException e) {
             LOGGER.error("Failed to load structure file: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @Nullable
+    public static CompoundTag readStructureFileOnServer(net.minecraft.server.level.ServerLevel level, String fileName) {
+        if (!isValidStructureFile(fileName)) {
+            return null;
+        }
+        try {
+            Path baseDir = getStructureDirectory(level);
+            Path structureFile = baseDir.resolve(fileName);
+            if (!isPathWithinBaseDirectory(structureFile, baseDir) || !Files.exists(structureFile)) {
+                return null;
+            }
+            return NbtIo.readCompressed(structureFile, NbtAccounter.unlimitedHeap());
+        } catch (IOException e) {
+            LOGGER.error("Failed to read structure file: {}", e.getMessage(), e);
             return null;
         }
     }
@@ -218,7 +294,7 @@ public class StructureLoadUtil {
      * Validate structure file name to prevent path traversal attacks
      * File names must match the pattern: name_uuid.nbt
      */
-    private static boolean isValidStructureFile(String fileName) {
+    public static boolean isValidStructureFile(String fileName) {
         if (fileName.trim().isEmpty()) {
             return false;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/util/StructureLoadUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/util/StructureLoadUtil.java
@@ -24,14 +24,15 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -44,6 +45,14 @@ public class StructureLoadUtil {
     // Whitelist pattern for structure file names: only allow alphanumeric, underscore, hyphen, and dot (for .nbt extension)
     private static final Pattern VALID_STRUCTURE_FILE = Pattern.compile("^[a-zA-Z0-9_\\-]+_[a-f0-9\\-]+\\.nbt$");
     private static final int MAX_STRUCTURE_FILE_LENGTH = 128;
+    /** 客户端请求同一结构文件的冷却时间（毫秒），避免 tooltip 每帧触发请求风暴。 */
+    private static final long REQUEST_COOLDOWN_MS = 2000;
+    /** 客户端结构 NBT 缓存上限，超出后按插入顺序驱逐最旧条目。 */
+    private static final int MAX_CACHE_ENTRIES = 100;
+    /** 已确认不存在的结构文件标记上限，超出后驱逐最旧条目。 */
+    private static final int MAX_MISSING_ENTRIES = 1000;
+    /** 服务端读取结构文件的最大字节数（128MB），与预览数据读取保持一致。 */
+    private static final long MAX_STRUCTURE_NBT_BYTES = 128L * 1024 * 1024;
 
     /**
      * 从结构磁盘读取结构数据（不过滤多方块方块，用于预览）
@@ -59,7 +68,10 @@ public class StructureLoadUtil {
             return null;
         }
         String fileName = structureDiskData.file();
-        CompoundTag tag = getCachedStructureNbt(fileName);
+        if (isStructureMissing(fileName)) {
+            return null;
+        }
+        CompoundTag tag = STRUCTURE_NBT_CACHE.get(fileName);
         if (tag == null) {
             requestStructureFile(level, structureDiskData);
             return null;
@@ -76,29 +88,53 @@ public class StructureLoadUtil {
         }
     }
 
-    /** 客户端已缓存的结构 NBT（服务端通过 {@link dev.dubhe.anvilcraft.network.StructureDiskResponsePacket} 下发）。 */
-    private static final Map<String, CompoundTag> STRUCTURE_NBT_CACHE = new HashMap<>();
+    /** 请求节流跟踪的最大条目数，超出后驱逐最旧条目。 */
+    private static final int MAX_REQUEST_TRACKER = 1000;
+    private static final Map<String, Long> LAST_REQUEST_TIME = new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
+            return size() > MAX_REQUEST_TRACKER;
+        }
+    };
+
+    /** 已确认不存在的结构文件标记，避免缓存未命中时反复请求。 */
+    private static final Set<String> MISSING_STRUCTURE_FILES = Collections.newSetFromMap(new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, Boolean> eldest) {
+            return size() > MAX_MISSING_ENTRIES;
+        }
+    });
+
+    /** 客户端已缓存的结构 NBT（服务端通过 {@link dev.dubhe.anvilcraft.network.StructureDiskResponsePacket} 下发），FIFO 驱逐。 */
+    private static final Map<String, CompoundTag> STRUCTURE_NBT_CACHE = new LinkedHashMap<>() {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, CompoundTag> eldest) {
+            return size() > MAX_CACHE_ENTRIES;
+        }
+    };
 
     /** 缓存服务端下发的结构 NBT；{@code null} 表示文件不存在，避免反复请求。 */
     public static void cacheStructureNbt(String fileName, @Nullable CompoundTag tag) {
+        LAST_REQUEST_TIME.remove(fileName);
         if (tag == null) {
-            STRUCTURE_NBT_CACHE.put(fileName, null);
+            MISSING_STRUCTURE_FILES.add(fileName);
+            STRUCTURE_NBT_CACHE.remove(fileName);
         } else {
             STRUCTURE_NBT_CACHE.put(fileName, tag.copy());
+            MISSING_STRUCTURE_FILES.remove(fileName);
         }
     }
 
-    @Nullable
-    private static CompoundTag getCachedStructureNbt(String fileName) {
-        if (!STRUCTURE_NBT_CACHE.containsKey(fileName)) return null;
-        return STRUCTURE_NBT_CACHE.get(fileName);
+    private static boolean isStructureMissing(String fileName) {
+        return MISSING_STRUCTURE_FILES.contains(fileName);
     }
 
     public static void removeCachedStructureNbt(String fileName) {
         STRUCTURE_NBT_CACHE.remove(fileName);
+        MISSING_STRUCTURE_FILES.remove(fileName);
     }
 
-    /** 纯服务器环境下客户端本地没有结构文件，向服务器发起请求。 */
+    /** 纯服务器环境下客户端本地没有结构文件，向服务器发起请求（带冷却，避免每帧重复发包）。 */
     private static void requestStructureFile(Level level, StructureDiskData data) {
         if (!isValidStructureFile(data.file())) return;
         if (!(level instanceof ClientLevel)) return;
@@ -106,6 +142,10 @@ public class StructureLoadUtil {
         ClientPacketListener connection = minecraft.getConnection();
         if (!(minecraft.player instanceof LocalPlayer)) return;
         if (connection == null) return;
+        long now = System.currentTimeMillis();
+        Long last = LAST_REQUEST_TIME.get(data.file());
+        if (last != null && now - last < REQUEST_COOLDOWN_MS) return;
+        LAST_REQUEST_TIME.put(data.file(), now);
         connection.send(new StructureDiskRequestPacket(data.file()));
     }
 
@@ -156,7 +196,7 @@ public class StructureLoadUtil {
             }
 
             // 读取 NBT 文件
-            CompoundTag structureTag = NbtIo.readCompressed(structureFile, NbtAccounter.unlimitedHeap());
+            CompoundTag structureTag = NbtIo.readCompressed(structureFile, NbtAccounter.create(MAX_STRUCTURE_NBT_BYTES));
 
             // 解析结构数据
             HolderLookup.Provider registry = level.registryAccess();
@@ -166,7 +206,7 @@ public class StructureLoadUtil {
             // LOGGER.debug("Structure loaded: {} ({} blocks)", structureName, data.blocks.size());
             return data;
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOGGER.error("Failed to load structure file: {}", e.getMessage(), e);
             return null;
         }
@@ -183,8 +223,8 @@ public class StructureLoadUtil {
             if (!isPathWithinBaseDirectory(structureFile, baseDir) || !Files.exists(structureFile)) {
                 return null;
             }
-            return NbtIo.readCompressed(structureFile, NbtAccounter.unlimitedHeap());
-        } catch (IOException e) {
+            return NbtIo.readCompressed(structureFile, NbtAccounter.create(MAX_STRUCTURE_NBT_BYTES));
+        } catch (Exception e) {
             LOGGER.error("Failed to read structure file: {}", e.getMessage(), e);
             return null;
         }


### PR DESCRIPTION
- 服务器环境下，客户端主动拉取结构磁盘的nbt文件并缓存
- resolved #4555 
- fixed #4597
- fixed #4621
- 滑动的鱼缸内容物也可以渲染了
- fixed #4588
- fixed #4627 
- 将大型板条箱 潜影集装箱的选择框和实际碰撞箱分离
- fixed #4504 
- 修改了生存模式下 中键其他加工台的指向方块（现在是全部指向冲压台）