### PR TITLE
Fix mob transform recipes not working 修复生物转化配方全部失效的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/recipe/transform/MobTransformRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/transform/MobTransformRecipe.java
@@ -151,11 +151,7 @@ public record MobTransformRecipe(
             level,
             EntitySpawnReason.CONVERSION,
             e -> {
-                e.moveOrInterpolateTo(
-                    livingEntity.position(),
-                    e.getYRot(),
-                    e.getXRot()
-                );
+                e.copyPosition(livingEntity);
                 return e;
             }
         );

--- a/src/main/java/dev/dubhe/anvilcraft/recipe/transform/MobTransformWithItemRecipe.java
+++ b/src/main/java/dev/dubhe/anvilcraft/recipe/transform/MobTransformWithItemRecipe.java
@@ -181,11 +181,7 @@ public record MobTransformWithItemRecipe(
             level,
             EntitySpawnReason.CONVERSION,
             e -> {
-                e.moveOrInterpolateTo(
-                    livingEntity.position(),
-                    e.getYRot(),
-                    e.getXRot()
-                );
+                e.copyPosition(livingEntity);
                 return e;
             }
         );


### PR DESCRIPTION
由于执行生物转化配方时，`Entity.moveOrInterpolateTo` 方法未能正确将实体移动至目标位置，导致生成的实体留在了坐标 `(0, 0, 0)`。该 PR 修复了上述问题。

该问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。