### PR TITLE
Fix issues with heavy halberds and resonators (26.1) 修复重戟和共振器相关的问题（26.1）

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
@@ -79,7 +79,7 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
         super(
             properties
                 .attributes(HeavyHalberdItem.createAttributes(material, attackDamage, attackSpeed))
-                .component(DataComponents.TOOL, HeavyHalberdItem.createToolProperties(material))
+                .component(DataComponents.TOOL, HeavyHalberdItem.createToolProperties(material, true))
                 .component(DataComponents.WEAPON, new Weapon(1))
                 .component(ModComponents.HEAVY_HALBERD_MODE, HeavyHalberdMode.TRIDENT)
                 .durability(material.durability()).repairable(material.repairItems()).enchantable(material.enchantmentValue())
@@ -121,8 +121,10 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
     }
 
     @SuppressWarnings("deprecation")
-    public static Tool createToolProperties(ToolMaterial material) {
-        HolderGetter<Block> lookup = BuiltInRegistries.acquireBootstrapRegistrationLookup(BuiltInRegistries.BLOCK);
+    public static Tool createToolProperties(ToolMaterial material, boolean isBootstrap) {
+        HolderGetter<Block> lookup = isBootstrap
+                                     ? BuiltInRegistries.acquireBootstrapRegistrationLookup(BuiltInRegistries.BLOCK)
+                                     : BuiltInRegistries.BLOCK;
         ArrayList<Tool.Rule> rules = new ArrayList<>();
         rules.add(Tool.Rule.minesAndDrops(HolderSet.direct(Blocks.COBWEB.builtInRegistryHolder()), 15.0F));
         rules.add(Tool.Rule.overrideSpeed(lookup.getOrThrow(BlockTags.SWORD_INSTANTLY_MINES), Float.MAX_VALUE));
@@ -247,7 +249,7 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
                 stack.set(DataComponents.ATTRIBUTE_MODIFIERS, modifiers);
             }
             if (!stack.has(DataComponents.TOOL)) {
-                stack.set(DataComponents.TOOL, createToolProperties(material));
+                stack.set(DataComponents.TOOL, createToolProperties(material, false));
             }
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
@@ -68,7 +68,6 @@ import net.neoforged.neoforge.common.ItemAbility;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.function.Consumer;
 
 public abstract class HeavyHalberdItem extends Item implements ProjectileItem, IItemTooltipProvider {
@@ -194,9 +193,7 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
                 ItemEnchantments disabledEnchs = stack.getOrDefault(ModComponents.DISABLED_ENCHANTMENTS, ItemEnchantments.EMPTY);
                 ItemEnchantments.Mutable enchsMut = new ItemEnchantments.Mutable(enchs);
                 ItemEnchantments.Mutable disabledEnchsMut = new ItemEnchantments.Mutable(disabledEnchs);
-                for (Iterator<Holder<Enchantment>> it = enchs.keySet().iterator(); it.hasNext(); ) {
-                    Holder<Enchantment> enchantment = it.next();
-
+                for (Holder<Enchantment> enchantment : enchs.keySet()) {
                     if (enchantment.is(ModEnchantmentTags.DISABLED_PASSED)) continue;
 
                     int level = enchs.getLevel(enchantment);
@@ -206,8 +203,8 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
                     } else {
                         level = Math.max(level, storedLevel);
                     }
-                    enchsMut.set(enchantment, level);
-                    it.remove();
+                    enchsMut.removeIf(holder -> holder.equals(enchantment));
+                    disabledEnchsMut.set(enchantment, level);
                 }
                 stack.set(DataComponents.ENCHANTMENTS, enchsMut.toImmutable());
                 stack.set(ModComponents.DISABLED_ENCHANTMENTS, disabledEnchsMut.toImmutable());
@@ -230,10 +227,10 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
                 ItemEnchantments enchs = stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
                 ItemEnchantments.Mutable enchsMut = new ItemEnchantments.Mutable(enchs);
                 for (Holder<Enchantment> enchantment : disabledEnchs.keySet()) {
-                    enchsMut.set(enchantment, enchs.getLevel(enchantment));
+                    enchsMut.set(enchantment, disabledEnchs.getLevel(enchantment));
                 }
                 stack.set(DataComponents.ENCHANTMENTS, enchsMut.toImmutable());
-                stack.set(ModComponents.DISABLED_ENCHANTMENTS, ItemEnchantments.EMPTY);
+                stack.remove(ModComponents.DISABLED_ENCHANTMENTS);
             }
             if (stack.has(DataComponents.ATTRIBUTE_MODIFIERS)) {
                 ItemAttributeModifiers modifiers = stack.get(DataComponents.ATTRIBUTE_MODIFIERS)

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
@@ -370,7 +370,12 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
     @Override
     public <T extends LivingEntity> int damageItem(ItemStack stack, int amount, @Nullable T entity, Consumer<Item> onBroken) {
         int willDamage = super.damageItem(stack, amount, entity, onBroken);
-        return stack.getDamageValue() - willDamage >= stack.getMaxDamage() - 1 ? 0 : willDamage;
+        int damageValue = stack.getDamageValue();
+        int maxDamage = stack.getMaxDamage();
+        if (damageValue + willDamage >= maxDamage - 1) {
+            willDamage = maxDamage - damageValue - 1;
+        }
+        return willDamage;
     }
 
     protected static boolean isTooDamagedToUse(ItemStack stack) {

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/HeavyHalberdItem.java
@@ -82,6 +82,7 @@ public abstract class HeavyHalberdItem extends Item implements ProjectileItem, I
                 .component(DataComponents.TOOL, HeavyHalberdItem.createToolProperties(material))
                 .component(DataComponents.WEAPON, new Weapon(1))
                 .component(ModComponents.HEAVY_HALBERD_MODE, HeavyHalberdMode.TRIDENT)
+                .durability(material.durability()).repairable(material.repairItems()).enchantable(material.enchantmentValue())
                 .rarity(Rarity.EPIC)
         );
         this.material = material;

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/ResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/ResonatorItem.java
@@ -75,7 +75,7 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
         super(
             properties
                 .attributes(ResonatorItem.createAttributes(material, attackDamage, attackSpeed))
-                .component(DataComponents.TOOL, ResonatorItem.createToolProperties(material))
+                .component(DataComponents.TOOL, ResonatorItem.createToolProperties(material, true))
                 .component(DataComponents.WEAPON, new Weapon(2, 0.0F))
                 .durability(material.durability()).repairable(material.repairItems()).enchantable(material.enchantmentValue())
         );
@@ -131,8 +131,10 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
     }
 
     @SuppressWarnings("deprecation")
-    public static Tool createToolProperties(ToolMaterial material) {
-        HolderGetter<Block> lookup = BuiltInRegistries.acquireBootstrapRegistrationLookup(BuiltInRegistries.BLOCK);
+    public static Tool createToolProperties(ToolMaterial material, boolean isBootstrap) {
+        HolderGetter<Block> lookup = isBootstrap
+                                     ? BuiltInRegistries.acquireBootstrapRegistrationLookup(BuiltInRegistries.BLOCK)
+                                     : BuiltInRegistries.BLOCK;
         List<Tool.Rule> rules = new ArrayList<>();
         rules.add(Tool.Rule.minesAndDrops(HolderSet.direct(Blocks.COBWEB.builtInRegistryHolder()), 15.0F));
         rules.add(Tool.Rule.overrideSpeed(lookup.getOrThrow(BlockTags.SWORD_INSTANTLY_MINES), Float.MAX_VALUE));
@@ -152,7 +154,7 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
 
     public static Tool createToolProperties(ResonateMode mode, ToolMaterial material, HolderGetter<Block> lookup) {
         return switch (mode) {
-            case AUTO -> ResonatorItem.createToolProperties(material);
+            case AUTO -> ResonatorItem.createToolProperties(material, false);
             case AXE -> new Tool(
                 List.of(Tool.Rule.minesAndDrops(lookup.getOrThrow(BlockTags.MINEABLE_WITH_AXE), material.speed())),
                 1.0F,

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/ResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/ResonatorItem.java
@@ -61,7 +61,6 @@ import net.neoforged.neoforge.common.ItemAbility;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -195,9 +194,7 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
                 ItemEnchantments disabledEnchs = stack.getOrDefault(ModComponents.DISABLED_ENCHANTMENTS, ItemEnchantments.EMPTY);
                 ItemEnchantments.Mutable enchsMut = new ItemEnchantments.Mutable(enchs);
                 ItemEnchantments.Mutable disabledEnchsMut = new ItemEnchantments.Mutable(disabledEnchs);
-                for (Iterator<Holder<Enchantment>> it = enchs.keySet().iterator(); it.hasNext(); ) {
-                    Holder<Enchantment> enchantment = it.next();
-
+                for (Holder<Enchantment> enchantment : enchs.keySet()) {
                     if (enchantment.is(ModEnchantmentTags.DISABLED_PASSED)) continue;
 
                     int level = enchs.getLevel(enchantment);
@@ -207,8 +204,8 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
                     } else {
                         level = Math.max(level, storedLevel);
                     }
-                    enchsMut.set(enchantment, level);
-                    it.remove();
+                    enchsMut.removeIf(holder -> holder.equals(enchantment));
+                    disabledEnchsMut.set(enchantment, level);
                 }
                 stack.set(DataComponents.ENCHANTMENTS, enchsMut.toImmutable());
                 stack.set(ModComponents.DISABLED_ENCHANTMENTS, disabledEnchsMut.toImmutable());
@@ -231,10 +228,10 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
                 ItemEnchantments enchs = stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
                 ItemEnchantments.Mutable enchsMut = new ItemEnchantments.Mutable(enchs);
                 for (Holder<Enchantment> enchantment : disabledEnchs.keySet()) {
-                    enchsMut.set(enchantment, enchs.getLevel(enchantment));
+                    enchsMut.set(enchantment, disabledEnchs.getLevel(enchantment));
                 }
                 stack.set(DataComponents.ENCHANTMENTS, enchsMut.toImmutable());
-                stack.set(ModComponents.DISABLED_ENCHANTMENTS, ItemEnchantments.EMPTY);
+                stack.remove(ModComponents.DISABLED_ENCHANTMENTS);
             }
             if (stack.has(DataComponents.ATTRIBUTE_MODIFIERS)) {
                 ItemAttributeModifiers modifiers = stack.getAttributeModifiers()

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/ResonatorItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/ResonatorItem.java
@@ -77,6 +77,7 @@ public abstract class ResonatorItem extends Item implements IItemTooltipProvider
                 .attributes(ResonatorItem.createAttributes(material, attackDamage, attackSpeed))
                 .component(DataComponents.TOOL, ResonatorItem.createToolProperties(material))
                 .component(DataComponents.WEAPON, new Weapon(2, 0.0F))
+                .durability(material.durability()).repairable(material.repairItems()).enchantable(material.enchantmentValue())
         );
         this.material = material;
         this.attackDamage = attackDamage;


### PR DESCRIPTION
本 PR 包含以下更改：

- 修复重戟和共振器没有耐久相关属性，导致代码判断其总是损坏状态而使其无法正常使用的问题。
- 修复重戟和共振器初始化或切换模式时，尝试获取游戏启动时用的注册表，但由于其已被冻结，因此游戏崩溃的问题。

这些问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。

此外，本 PR 还从 #4658 摘取了以下更改：

- 修复重戟损坏时会被销毁的问题。
- 修复带有附魔的重戟和共振器损坏时会发生崩溃的问题。

Fixes #4460