### PR TITLE
Fixed the issue where the game wouldn't start if "curios" wasn't installed. 修复了不安装curios无法启动游戏的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/client/AnvilCraftClient.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/AnvilCraftClient.java
@@ -21,11 +21,9 @@ import dev.dubhe.anvilcraft.config.AnvilCraftClientConfig;
 import dev.dubhe.anvilcraft.init.ModParticles;
 import dev.dubhe.anvilcraft.init.block.ModFluids;
 import dev.dubhe.anvilcraft.init.item.ModItems;
-import dev.dubhe.anvilcraft.integration.curios.client.renderer.GogglesCurioRenderer;
 import dev.dubhe.anvilcraft.item.weapon.AnvilRailgunItem;
 import dev.dubhe.anvilcraft.item.weapon.LaserGunItem;
 import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.client.model.geom.builders.LayerDefinition;
 import net.minecraft.client.particle.FlyTowardsPositionParticle;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -37,7 +35,6 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
-import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.neoforged.neoforge.client.event.RegisterItemDecorationsEvent;
 import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
@@ -63,10 +60,6 @@ public class AnvilCraftClient {
         modBus.addListener(AnvilCraftClient::registerParticleProviders);
         modBus.addListener(ModShaders::register);
         modBus.addListener(ModModelLayers::register);
-        modBus.addListener((EntityRenderersEvent.RegisterLayerDefinitions event) -> event.registerLayerDefinition(
-            GogglesCurioRenderer.LAYER,
-            () -> LayerDefinition.create(GogglesCurioRenderer.mesh(), 1, 1)
-        ));
         modBus.addListener(ModModelLayers::createModel);
         modBus.addListener(ModTooltipComponents::register);
         modBus.addListener(OverworldLikeOrbitalSkyRenderer::cacheModels);

--- a/src/main/java/dev/dubhe/anvilcraft/client/init/ModModelLayers.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/init/ModModelLayers.java
@@ -6,7 +6,13 @@ import dev.dubhe.anvilcraft.entity.model.IonocraftBackpackModel;
 import dev.dubhe.anvilcraft.entity.model.IonocraftModel;
 import dev.dubhe.anvilcraft.entity.model.MagnetizedNodeModel;
 import lombok.Getter;
+import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 
 public class ModModelLayers {
@@ -14,6 +20,7 @@ public class ModModelLayers {
     public static final ModelLayerLocation IONOCRAFT_BACKPACK = new ModelLayerLocation(AnvilCraft.of("ionocraft_backpack"), "main");
     public static final ModelLayerLocation MAGNETIZED_NODE = new ModelLayerLocation(AnvilCraft.of("magnetized_node"), "main");
     public static final ModelLayerLocation CAULDRON_OUTLET = CauldronOutletModel.LAYER_LOCATION;
+    public static final ModelLayerLocation GOGGLES = new ModelLayerLocation(AnvilCraft.of("goggles"), "goggles");
 
     @Getter
     private static IonocraftBackpackModel ionocraftBackpackModel;
@@ -35,9 +42,20 @@ public class ModModelLayers {
             CAULDRON_OUTLET,
             CauldronOutletModel::createBodyLayer
         );
+        event.registerLayerDefinition(
+            GOGGLES,
+            () -> LayerDefinition.create(gogglesMesh(), 1, 1)
+        );
     }
 
     public static void createModel(EntityRenderersEvent.AddLayers event) {
         ionocraftBackpackModel = new IonocraftBackpackModel(event.getContext().bakeLayer(IONOCRAFT_BACKPACK));
+    }
+
+    private static MeshDefinition gogglesMesh() {
+        CubeListBuilder builder = new CubeListBuilder();
+        MeshDefinition mesh = HumanoidModel.createMesh(CubeDeformation.NONE, 0);
+        mesh.getRoot().addOrReplaceChild("head", builder, PartPose.ZERO);
+        return mesh;
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/integration/curios/client/renderer/GogglesCurioRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/integration/curios/client/renderer/GogglesCurioRenderer.java
@@ -2,15 +2,10 @@ package dev.dubhe.anvilcraft.integration.curios.client.renderer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
-import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.client.init.ModModelLayers;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
-import net.minecraft.client.model.geom.ModelLayerLocation;
-import net.minecraft.client.model.geom.PartPose;
-import net.minecraft.client.model.geom.builders.CubeDeformation;
-import net.minecraft.client.model.geom.builders.CubeListBuilder;
-import net.minecraft.client.model.geom.builders.MeshDefinition;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.texture.OverlayTexture;
@@ -22,12 +17,10 @@ import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.client.ICurioRenderer;
 
 public class GogglesCurioRenderer implements ICurioRenderer {
-    public static final ModelLayerLocation LAYER = new ModelLayerLocation(AnvilCraft.of("goggles"), "goggles");
-
     private final HumanoidModel<LivingEntity> model;
 
     public GogglesCurioRenderer() {
-        this.model = new HumanoidModel<>(Minecraft.getInstance().getEntityModels().bakeLayer(GogglesCurioRenderer.LAYER));
+        this.model = new HumanoidModel<>(Minecraft.getInstance().getEntityModels().bakeLayer(ModModelLayers.GOGGLES));
     }
 
     @Override
@@ -72,12 +65,5 @@ public class GogglesCurioRenderer implements ICurioRenderer {
             .renderStatic(stack, ItemDisplayContext.HEAD, light, OverlayTexture.NO_OVERLAY, matrixStack,
                 renderTypeBuffer, mc.level, 0);
         matrixStack.popPose();
-    }
-
-    public static MeshDefinition mesh() {
-        CubeListBuilder builder = new CubeListBuilder();
-        MeshDefinition mesh = HumanoidModel.createMesh(CubeDeformation.NONE, 0);
-        mesh.getRoot().addOrReplaceChild("head", builder, PartPose.ZERO);
-        return mesh;
     }
 }


### PR DESCRIPTION
- 从AnvilCraftClient中移除GogglesCurioRenderer相关的LayerDefinitions注册监听
- 将GogglesCurioRenderer中的模型层引用改为ModModelLayers统一管理
- 在ModModelLayers中添加GOGGLES模型层及其LayerDefinition的注册方法