### PR TITLE
Fix Anvil Hammer not rotating blocks 修复铁砧锤无法旋转方块的问题

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/logistics/chute/SimpleChuteBlock.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/logistics/chute/SimpleChuteBlock.java
@@ -224,20 +224,19 @@ public class SimpleChuteBlock
             default -> oldFacing.getClockWise();
         };
         BlockState facingState = level.getBlockState(pos.relative(newFacing));
-        if (facingState.is(ModBlocks.CHUTE.get()) || facingState.is(ModBlocks.SIMPLE_CHUTE.get())) {
-            if (facingState.getValue(SimpleChuteBlock.FACING).getOpposite() == newFacing) {
-                level.setBlock(pos, Blocks.AIR.defaultBlockState(), 3);
-                level.levelEvent(2001, pos, Block.getId(oldState));
-                Block.dropResources(oldState, level, pos);
-                return true;
-            }
+        if (ChuteBlock.isChuteBlock(facingState)
+            && ChuteBlock.getFacing(facingState) == newFacing.getOpposite()) {
+            level.setBlock(pos, Blocks.AIR.defaultBlockState(), 3);
+            level.levelEvent(2001, pos, Block.getId(oldState));
+            Block.dropResources(oldState, level, pos);
+            return true;
         }
         HammerRotateBehavior.DEFAULT.change(player, pos, level, anvilHammer);
         return true;
     }
 
     @Override
-public Property<?> getChangeableProperty(BlockState blockState) {
+    public Property<?> getChangeableProperty(BlockState blockState) {
         return SimpleChuteBlock.FACING;
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/ClientBlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/ClientBlockEventListener.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -87,7 +88,8 @@ public class ClientBlockEventListener {
         if (event.getLevel().isClientSide() && ClientBlockEventListener.clientHandle(event, state, hand, event.getHitVec())) {
             event.setCancellationResult(InteractionResult.SUCCESS);
             event.setCanceled(true);
-        } else if (!state.is(BlockTags.CAULDRONS) && !state.is(ModBlockTags.ANVIL_HAMMER_BLACKLIST)) {
+        } else if (!state.is(BlockTags.CAULDRONS) && !state.is(ModBlockTags.ANVIL_HAMMER_BLACKLIST)
+                   && !AnvilHammerItem.shouldPlaceOffhandBlock(entity, event.getLevel(), event.getHitVec())) {
             event.setCanceled(true);
         }
     }
@@ -113,5 +115,20 @@ public class ClientBlockEventListener {
             () -> StateUtil.findPossibleStatesForProperty(targetBlockState, property),
             hitVec
         );
+    }
+    
+    /**
+     * 主手铁砧锤、副手持有方块且目标为普通方块时，取消使用物品事件，
+     * 使客户端跳过铁砧锤的长按使用，继续处理副手并放出副手方块。
+     */
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public static void anvilHammerUseItem(PlayerInteractEvent.RightClickItem event) {
+        Player player = event.getEntity();
+        if (event.getHand() != InteractionHand.MAIN_HAND) return;
+        if (!player.getMainHandItem().is(ModItemTags.ANVIL_HAMMER)) return;
+        HitResult hit = player.pick(player.blockInteractionRange(), 1.0F, false);
+        if (hit instanceof BlockHitResult blockHit && AnvilHammerItem.shouldPlaceOffhandBlock(player, event.getLevel(), blockHit)) {
+            event.setCanceled(true);
+        }
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -4,7 +4,6 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import dev.anvilcraft.lib.v2.rendering.gui.GuiRenderExtras;
 import dev.anvilcraft.lib.v2.util.Util;
-import dev.anvilcraft.lib.v2.wheel.api.WheelEntryAction;
 import dev.anvilcraft.lib.v2.wheel.api.WheelMenuBuilder;
 import dev.anvilcraft.lib.v2.wheel.api.WheelMenuModel;
 import dev.anvilcraft.lib.v2.wheel.client.input.WheelScreenController;
@@ -65,6 +64,11 @@ public class WheelLifecycleEventListener {
     private static long hammerKeyTime = -1L;
     private static boolean hammerKeyWasDown = false;
     private static @Nullable Optional<WheelMenuModel> hammerWheelCache = null;
+    // TODO: These three fields should be refactored when the AnvilLib
+    //       adds an "on close without action" handler to the wheel menu model
+    private static @Nullable BlockPos hammerWheelTargetPos = null;
+    private static @Nullable BlockState hammerWheelNextBlockState = null;
+    private static @Nullable Supplier<Boolean> hammerInteraction = null;
 
     private static long multiphaseKeyTime = -1L;
     private static boolean multiphaseKeyWasDown = false;
@@ -116,8 +120,9 @@ public class WheelLifecycleEventListener {
         BlockHitResult hitVec
     ) {
         if (WheelLifecycleEventListener.hammerKeyTime <= 0) return false;
-        if (property == null) {
-            LocalPlayer player = Minecraft.getInstance().player;
+        Minecraft client = Minecraft.getInstance();
+        LocalPlayer player = client.player;
+        WheelLifecycleEventListener.hammerInteraction = () -> {
             boolean interacted = player != null && AnvilHammerItem.interactWithBlock(
                 player,
                 targetPos,
@@ -128,13 +133,10 @@ public class WheelLifecycleEventListener {
             );
             ClientPacketDistributor.sendToServer(new HammerUsePacket(targetPos, hand, hitVec));
             return interacted;
+        };
+        if (property == null) {
+            return WheelLifecycleEventListener.hammerInteraction.get();
         }
-        if (gameTime - WheelLifecycleEventListener.hammerKeyTime <= 4) {
-            ClientPacketDistributor.sendToServer(new HammerUsePacket(targetPos, hand, hitVec));
-            return false;
-        }
-        Minecraft client = Minecraft.getInstance();
-        LocalPlayer player = client.player;
         if (player == null) return false;
         if (WheelLifecycleEventListener.hammerWheelCache == null) {
             if (player.isShiftKeyDown()) {
@@ -156,6 +158,8 @@ public class WheelLifecycleEventListener {
         if (WheelLifecycleEventListener.hammerWheelCache.isEmpty()) return false;
         WheelLifecycleEventListener.CONTROLLER.onHoldKeyPressed(WheelLifecycleEventListener.hammerWheelCache.get());
         WheelLifecycleEventListener.hammerKeyWasDown = true;
+        WheelLifecycleEventListener.hammerWheelTargetPos = targetPos;
+        WheelLifecycleEventListener.hammerWheelNextBlockState = level.getBlockState(targetPos).cycle(property);
         return true;
     }
 
@@ -251,33 +255,9 @@ public class WheelLifecycleEventListener {
         possibleStates
             .forEach(state -> {
                 ModelRenderTarget modelTarget = state.getBlock() instanceof IMultiPartBlockModelHolder holder
-                    ? holder.getModelRenderTarget(level, targetPos, initialState, state)
-                    : new ModelRenderTarget(targetPos, state);
+                                                ? holder.getModelRenderTarget(level, targetPos, initialState, state)
+                                                : new ModelRenderTarget(targetPos, state);
                 String name = property.getName(Util.cast(state.getValue(property)));
-                WheelEntryAction action;
-                if (state.getBlock() instanceof FlexibleMultiPartBlock<?, ?, ?>) {
-                    if (state.hasProperty(BlockStateProperties.FACING)) {
-                        action = _ -> ClientPacketDistributor.sendToServer(new HammerChangeFlexibleMultiPartBlockPacket(
-                            targetPos,
-                            state,
-                            state.getValue(BlockStateProperties.FACING)
-                        ));
-                    } else if (state.hasProperty(BlockStateProperties.HORIZONTAL_FACING)) {
-                        action = _ -> ClientPacketDistributor.sendToServer(new HammerChangeFlexibleMultiPartBlockPacket(
-                            targetPos,
-                            state,
-                            state.getValue(BlockStateProperties.HORIZONTAL_FACING)
-                        ));
-                    } else {
-                        action = _ -> {
-                        };
-                    }
-                } else {
-                    action = _ -> ClientPacketDistributor.sendToServer(new HammerChangeBlockPacket(
-                        targetPos,
-                        state
-                    ));
-                }
                 builder.action(
                     name,
                     Component.literal(name),
@@ -288,7 +268,7 @@ public class WheelLifecycleEventListener {
                         pose.mulPose(Axis.YP.rotationDegrees(camera.y + 180F));
                         GuiRenderExtras.tessellateBlock(graphics, modelTarget.state(), -15f, -5, pose);
                     },
-                    action
+                    _ -> WheelLifecycleEventListener.sendHammerChangeBlockPacketToServer(state, targetPos)
                 );
             });
         return builder.build();
@@ -620,9 +600,31 @@ public class WheelLifecycleEventListener {
             if (WheelLifecycleEventListener.hammerKeyWasDown) {
                 WheelLifecycleEventListener.CONTROLLER.onHoldKeyReleased();
             }
+
+            // TODO: This three fields should be refactored when the AnvilLib
+            //       adds an "on close without action" handler to the wheel menu model
+            BlockPos targetPos = WheelLifecycleEventListener.hammerWheelTargetPos;
+            BlockState state = WheelLifecycleEventListener.hammerWheelNextBlockState;
+            Supplier<Boolean> hammerInteraction = WheelLifecycleEventListener.hammerInteraction;
+            if (
+                client.level.getGameTime() - WheelLifecycleEventListener.hammerKeyTime <= 4 &&
+                targetPos != null && state != null && hammerInteraction != null
+            ) {
+                // On single right-click
+                if (!hammerInteraction.get()) {
+                    WheelLifecycleEventListener.sendHammerChangeBlockPacketToServer(state, targetPos);
+                }
+            }
+
             WheelLifecycleEventListener.hammerKeyWasDown = false;
             WheelLifecycleEventListener.hammerKeyTime = -1L;
             WheelLifecycleEventListener.hammerWheelCache = null;
+
+            // TODO: These three fields should be refactored when the AnvilLib
+            //       adds an "on close without action" handler to the wheel menu model
+            WheelLifecycleEventListener.hammerWheelTargetPos = null;
+            WheelLifecycleEventListener.hammerWheelNextBlockState = null;
+            WheelLifecycleEventListener.hammerInteraction = null;
             return;
         }
         if (Minecraft.getInstance().screen != null) return;
@@ -630,6 +632,29 @@ public class WheelLifecycleEventListener {
             if (!WheelLifecycleEventListener.hammerKeyWasDown) {
                 WheelLifecycleEventListener.hammerKeyTime = client.level.getGameTime();
             }
+        }
+    }
+
+    private static void sendHammerChangeBlockPacketToServer(BlockState state, BlockPos targetPos) {
+        if (state.getBlock() instanceof FlexibleMultiPartBlock<?, ?, ?>) {
+            if (state.hasProperty(BlockStateProperties.FACING)) {
+                ClientPacketDistributor.sendToServer(new HammerChangeFlexibleMultiPartBlockPacket(
+                    targetPos,
+                    state,
+                    state.getValue(BlockStateProperties.FACING)
+                ));
+            } else if (state.hasProperty(BlockStateProperties.HORIZONTAL_FACING)) {
+                ClientPacketDistributor.sendToServer(new HammerChangeFlexibleMultiPartBlockPacket(
+                    targetPos,
+                    state,
+                    state.getValue(BlockStateProperties.HORIZONTAL_FACING)
+                ));
+            }
+        } else {
+            ClientPacketDistributor.sendToServer(new HammerChangeBlockPacket(
+                targetPos,
+                state
+            ));
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -65,8 +65,6 @@ public class WheelLifecycleEventListener {
     private static boolean hammerKeyWasDown = false;
     private static @Nullable Optional<WheelMenuModel> hammerWheelCache = null;
     
-    private static @Nullable BlockPos hammerWheelTargetPos = null;
-    private static @Nullable BlockState hammerWheelNextBlockState = null;
     private static @Nullable Supplier<Boolean> hammerInteraction = null;
 
     private static long multiphaseKeyTime = -1L;
@@ -162,8 +160,6 @@ public class WheelLifecycleEventListener {
             WheelLifecycleEventListener.CONTROLLER.onHoldKeyPressed(WheelLifecycleEventListener.hammerWheelCache.get());
             WheelLifecycleEventListener.hammerKeyWasDown = true;
         }
-        WheelLifecycleEventListener.hammerWheelTargetPos = targetPos;
-        WheelLifecycleEventListener.hammerWheelNextBlockState = level.getBlockState(targetPos).cycle(property);
         return true;
     }
 
@@ -605,25 +601,19 @@ public class WheelLifecycleEventListener {
                 WheelLifecycleEventListener.CONTROLLER.onHoldKeyReleased();
             }
 
-            BlockPos targetPos = WheelLifecycleEventListener.hammerWheelTargetPos;
-            BlockState state = WheelLifecycleEventListener.hammerWheelNextBlockState;
             Supplier<Boolean> hammerInteraction = WheelLifecycleEventListener.hammerInteraction;
             if (
                 client.level.getGameTime() - WheelLifecycleEventListener.hammerKeyTime < 4
-                && targetPos != null && state != null && hammerInteraction != null
+                && hammerInteraction != null
             ) {
                 // On single right-click
-                if (!hammerInteraction.get()) {
-                    WheelLifecycleEventListener.sendHammerChangeBlockPacketToServer(state, targetPos);
-                }
+                hammerInteraction.get();
             }
 
             WheelLifecycleEventListener.hammerKeyWasDown = false;
             WheelLifecycleEventListener.hammerKeyTime = -1L;
             WheelLifecycleEventListener.hammerWheelCache = null;
 
-            WheelLifecycleEventListener.hammerWheelTargetPos = null;
-            WheelLifecycleEventListener.hammerWheelNextBlockState = null;
             WheelLifecycleEventListener.hammerInteraction = null;
             return;
         }

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -155,9 +155,11 @@ public class WheelLifecycleEventListener {
                 client.getCameraEntity().getRotationVector()
             ));
         }
-        if (WheelLifecycleEventListener.hammerWheelCache.isEmpty()) return false;
-        WheelLifecycleEventListener.CONTROLLER.onHoldKeyPressed(WheelLifecycleEventListener.hammerWheelCache.get());
-        WheelLifecycleEventListener.hammerKeyWasDown = true;
+        if (gameTime - WheelLifecycleEventListener.hammerKeyTime >= 4) {
+            if (WheelLifecycleEventListener.hammerWheelCache.isEmpty()) return false;
+            WheelLifecycleEventListener.CONTROLLER.onHoldKeyPressed(WheelLifecycleEventListener.hammerWheelCache.get());
+            WheelLifecycleEventListener.hammerKeyWasDown = true;
+        }
         WheelLifecycleEventListener.hammerWheelTargetPos = targetPos;
         WheelLifecycleEventListener.hammerWheelNextBlockState = level.getBlockState(targetPos).cycle(property);
         return true;
@@ -607,7 +609,7 @@ public class WheelLifecycleEventListener {
             BlockState state = WheelLifecycleEventListener.hammerWheelNextBlockState;
             Supplier<Boolean> hammerInteraction = WheelLifecycleEventListener.hammerInteraction;
             if (
-                client.level.getGameTime() - WheelLifecycleEventListener.hammerKeyTime <= 4
+                client.level.getGameTime() - WheelLifecycleEventListener.hammerKeyTime < 4
                 && targetPos != null && state != null && hammerInteraction != null
             ) {
                 // On single right-click

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -607,8 +607,8 @@ public class WheelLifecycleEventListener {
             BlockState state = WheelLifecycleEventListener.hammerWheelNextBlockState;
             Supplier<Boolean> hammerInteraction = WheelLifecycleEventListener.hammerInteraction;
             if (
-                client.level.getGameTime() - WheelLifecycleEventListener.hammerKeyTime <= 4 &&
-                targetPos != null && state != null && hammerInteraction != null
+                client.level.getGameTime() - WheelLifecycleEventListener.hammerKeyTime <= 4
+                && targetPos != null && state != null && hammerInteraction != null
             ) {
                 // On single right-click
                 if (!hammerInteraction.get()) {

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -64,8 +64,7 @@ public class WheelLifecycleEventListener {
     private static long hammerKeyTime = -1L;
     private static boolean hammerKeyWasDown = false;
     private static @Nullable Optional<WheelMenuModel> hammerWheelCache = null;
-    // TODO: These three fields should be refactored when the AnvilLib
-    //       adds an "on close without action" handler to the wheel menu model
+    
     private static @Nullable BlockPos hammerWheelTargetPos = null;
     private static @Nullable BlockState hammerWheelNextBlockState = null;
     private static @Nullable Supplier<Boolean> hammerInteraction = null;
@@ -605,8 +604,6 @@ public class WheelLifecycleEventListener {
                 WheelLifecycleEventListener.CONTROLLER.onHoldKeyReleased();
             }
 
-            // TODO: This three fields should be refactored when the AnvilLib
-            //       adds an "on close without action" handler to the wheel menu model
             BlockPos targetPos = WheelLifecycleEventListener.hammerWheelTargetPos;
             BlockState state = WheelLifecycleEventListener.hammerWheelNextBlockState;
             Supplier<Boolean> hammerInteraction = WheelLifecycleEventListener.hammerInteraction;
@@ -624,8 +621,6 @@ public class WheelLifecycleEventListener {
             WheelLifecycleEventListener.hammerKeyTime = -1L;
             WheelLifecycleEventListener.hammerWheelCache = null;
 
-            // TODO: These three fields should be refactored when the AnvilLib
-            //       adds an "on close without action" handler to the wheel menu model
             WheelLifecycleEventListener.hammerWheelTargetPos = null;
             WheelLifecycleEventListener.hammerWheelNextBlockState = null;
             WheelLifecycleEventListener.hammerInteraction = null;

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -123,16 +123,18 @@ public class WheelLifecycleEventListener {
         Minecraft client = Minecraft.getInstance();
         LocalPlayer player = client.player;
         WheelLifecycleEventListener.hammerInteraction = () -> {
-            boolean interacted = player != null && AnvilHammerItem.interactWithBlock(
+            if (player != null && AnvilHammerItem.interactWithBlock(
                 player,
                 targetPos,
                 level,
                 player.getItemInHand(hand),
                 hand,
                 hitVec
-            );
-            ClientPacketDistributor.sendToServer(new HammerUsePacket(targetPos, hand, hitVec));
-            return interacted;
+            )) {
+                ClientPacketDistributor.sendToServer(new HammerUsePacket(targetPos, hand, hitVec));
+                return true;
+            }
+            return false;
         };
         if (property == null) {
             return WheelLifecycleEventListener.hammerInteraction.get();

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/WheelLifecycleEventListener.java
@@ -122,18 +122,19 @@ public class WheelLifecycleEventListener {
         Minecraft client = Minecraft.getInstance();
         LocalPlayer player = client.player;
         WheelLifecycleEventListener.hammerInteraction = () -> {
-            if (player != null && AnvilHammerItem.interactWithBlock(
-                player,
-                targetPos,
-                level,
-                player.getItemInHand(hand),
-                hand,
-                hitVec
-            )) {
-                ClientPacketDistributor.sendToServer(new HammerUsePacket(targetPos, hand, hitVec));
-                return true;
+            if (player == null) {
+                return false;
             }
-            return false;
+            boolean interacted = AnvilHammerItem.interactWithBlock(
+                player, targetPos, level, player.getItemInHand(hand), hand, hitVec
+            );
+            boolean canChange = player.getAbilities().mayBuild
+                                && AnvilHammerItem.ableToUseAnvilHammer(level, targetPos, player);
+            if (!interacted && !canChange && AnvilHammerItem.shouldPlaceOffhandBlock(player, level, hitVec)) {
+                return false;
+            }
+            ClientPacketDistributor.sendToServer(new HammerUsePacket(targetPos, hand, hitVec));
+            return interacted || canChange;
         };
         if (property == null) {
             return WheelLifecycleEventListener.hammerInteraction.get();

--- a/src/main/java/dev/dubhe/anvilcraft/event/BlockEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/BlockEventListener.java
@@ -4,6 +4,7 @@ import dev.dubhe.anvilcraft.AnvilCraft;
 import dev.dubhe.anvilcraft.api.hammer.IHammerChangeable;
 import dev.dubhe.anvilcraft.block.entity.CreativeCrateBlockEntity;
 import dev.dubhe.anvilcraft.block.power.batch.BaseBatchCraftingBlock;
+import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.item.tool.AnvilHammerItem;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -25,6 +26,8 @@ import net.minecraft.world.level.block.AnvilBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -91,6 +94,21 @@ public class BlockEventListener {
                 event.setUseBlock(TriState.FALSE);
                 event.setUseItem(TriState.FALSE);
             }
+        }
+    }
+    
+    /**
+     * 主手铁砧锤、副手持有方块且目标为普通方块时，取消使用物品事件，
+     * 使服务端不进入铁砧锤长按，配合客户端完成副手方块放置。
+     */
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public static void anvilHammerUseItem(PlayerInteractEvent.RightClickItem event) {
+        Player player = event.getEntity();
+        if (event.getHand() != InteractionHand.MAIN_HAND) return;
+        if (!player.getMainHandItem().is(ModItemTags.ANVIL_HAMMER)) return;
+        HitResult hit = player.pick(player.blockInteractionRange(), 1.0F, false);
+        if (hit instanceof BlockHitResult blockHit && AnvilHammerItem.shouldPlaceOffhandBlock(player, event.getLevel(), blockHit)) {
+            event.setCanceled(true);
         }
     }
 

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/AnvilHammerItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/AnvilHammerItem.java
@@ -271,8 +271,12 @@ public class AnvilHammerItem extends Item {
             }
             return true;
         }
-        if (state.useItemOn(anvilHammer, level, player, hand, result) != InteractionResult.PASS) return true;
-        return state.useWithoutItem(level, player, result) != InteractionResult.PASS;
+        InteractionResult useItemInteractionResult = state.useItemOn(anvilHammer, level, player, hand, result);
+        if (useItemInteractionResult.equals(InteractionResult.TRY_WITH_EMPTY_HAND)) {
+            return state.useWithoutItem(level, player, result) != InteractionResult.PASS;
+        } else {
+            return !useItemInteractionResult.equals(InteractionResult.PASS);
+        }
     }
 
     @Override

--- a/src/main/java/dev/dubhe/anvilcraft/item/tool/AnvilHammerItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/tool/AnvilHammerItem.java
@@ -7,6 +7,7 @@ import dev.dubhe.anvilcraft.api.hammer.IHammerRemovable;
 import dev.dubhe.anvilcraft.client.AnvilCraftClient;
 import dev.dubhe.anvilcraft.init.ModMenuTypes;
 import dev.dubhe.anvilcraft.init.block.ModBlockTags;
+import dev.dubhe.anvilcraft.init.item.ModItemTags;
 import dev.dubhe.anvilcraft.init.item.ModItems;
 import dev.dubhe.anvilcraft.inventory.EmberAnvilMenu;
 import dev.dubhe.anvilcraft.inventory.FrostAnvilMenu;
@@ -28,6 +29,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
@@ -45,6 +47,7 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemUseAnimation;
@@ -149,6 +152,22 @@ public class AnvilHammerItem extends Item {
             return hammerChangeable.checkBlockState(state);
         }
         return AnvilHammerItem.findModifyableProperty(state) != null;
+    }
+
+    /**
+     * 判断是否应放行副手方块放置。
+     *
+     * <p>主手持有铁砧锤、副手持有可放置方块时，对既不能交互、又不能被锤子修改或拆除的普通方块，
+     * 放行原版副手方块放置，使其优先于长按右键打开便携铁砧菜单。
+     */
+    public static boolean shouldPlaceOffhandBlock(Player player, Level level, BlockHitResult hit) {
+        ItemStack offhand = player.getOffhandItem();
+        if (offhand.isEmpty() || offhand.is(ModItemTags.ANVIL_HAMMER)) return false;
+        if (!(offhand.getItem() instanceof BlockItem)) return false;
+        BlockState state = level.getBlockState(hit.getBlockPos());
+        if (state.is(BlockTags.CAULDRONS) || state.is(ModBlockTags.ANVIL_HAMMER_BLACKLIST)) return false;
+        if (state.is(ModBlockTags.HAMMER_REMOVABLE) || state.getBlock() instanceof IHammerRemovable) return false;
+        return findModifyableProperty(state) == null;
     }
 
     @Nullable


### PR DESCRIPTION
本 PR 修复了下列手持铁砧锤时出现的问题：

- 与功能方块交互打开其界面后，等待一小段时间后会跳出铁砧锤的铁砧界面的问题。
- 在可旋转非功能方块上短按交互键时无法旋转方块。
- 在可旋转方块上长按交互键时无法打开旋转轮盘。

这些问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。

此外，本 PR 还摘取了 #4669 的更改，并从 1.21 分支移植了铁砧锤的副手方块放置逻辑。

Fixes #4459