### PR TITLE
Improved rendering for picking up crab claws, and fix bugs. 优化了蟹钳拿取物品时的渲染，修bug

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/StoragePortBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/StoragePortBlockEntity.java
@@ -309,8 +309,14 @@ public class StoragePortBlockEntity extends BlockEntity implements IItemHandlerH
 
     /**
      * 把缓存与标记写入掉落的方块物品（拆除保留内容）。
+     *
+     * <p>缓存为空且无标记时不写入方块实体数据：否则空端口拆下来会多出一个
+     * 内容为 {@code {buffer: {Size: 32, Items: []}}} 的组件，无法与未放置过的物品堆叠。</p>
      */
     public void saveToDrop(ItemStack stack, HolderLookup.Provider registries) {
+        if (this.isBufferEmpty() && this.markedItem.isEmpty()) {
+            return;
+        }
         CompoundTag tag = this.saveCustomOnly(registries);
         BlockItem.setBlockEntityData(stack, this.getType(), tag);
         stack.applyComponents(this.collectComponents());

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/LargeBlockPlacePreviewEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/LargeBlockPlacePreviewEventListener.java
@@ -18,6 +18,7 @@ import dev.dubhe.anvilcraft.client.init.ModRenderTypes;
 import dev.dubhe.anvilcraft.client.selection.ModelBlockSelection;
 import dev.dubhe.anvilcraft.config.AnvilCraftClientConfig;
 import dev.dubhe.anvilcraft.init.block.ModBlocks;
+import dev.dubhe.anvilcraft.util.BlockPlacementPicking;
 import dev.dubhe.anvilcraft.util.SegmentedActuator;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.Camera;
@@ -37,11 +38,13 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -120,8 +123,6 @@ public class LargeBlockPlacePreviewEventListener {
             failBoundErrorCooldown--;
         }
         renderEntries.clear();
-        BlockHitResult target = event.getTarget();
-        final Direction direction = target.getDirection();
         Inventory inventory = player.getInventory();
         InteractionHand hand = InteractionHand.MAIN_HAND;
         ItemStack item = inventory.getItem(inventory.selected);
@@ -135,49 +136,69 @@ public class LargeBlockPlacePreviewEventListener {
         if (!(blockItem.getBlock() instanceof AbstractMultiPartBlock<?> block)) {
             return;
         }
-        BlockPlaceContext context = new BlockPlaceContext(player, hand, item, new BlockHitResult(
-            event.getTarget().getLocation(),
-            direction,
-            target.getBlockPos(),
-            target.isInside()
-        ));
-        BlockPos pos = context.getClickedPos();
+        // 实际放置会把点击上下文交给 BlockPlacementPicking.forPlacement 重做一次射线检测，
+        // 用的是常规形状（BlockGetter#clip / ClipContext.Block.OUTLINE → BlockState#getShape）；
+        // 而准星射线走的是 CubeSelection 的模型精确箱（CubePicking#pick），两者命中格可能不同。
+        // 预览必须走同一条路径，否则会与实际落点错位。
+        // 注意 click 是 UseOnContext：它的 getClickedPos() 即原始命中格，重试分支用的就是它；
+        // 而 BlockPlaceContext.getClickedPos() 在命中格不可替换时还会沿点击面外移一格。
+        BlockHitResult target = event.getTarget();
+        UseOnContext click = BlockPlacementPicking.forPlacement(new UseOnContext(player, hand, target));
+        BlockPlaceContext context = new BlockPlaceContext(click);
+        final BlockPos hitPos = click.getClickedPos();
+        final Direction face = click.getClickedFace();
         if (block instanceof CelestialForgingAnvilAmplifierBlock amplifierBlock) {
-            BlockPos snapped = amplifierBlock.snapMainPos(mc.level, pos);
+            BlockPos snapped = amplifierBlock.snapMainPos(mc.level, context.getClickedPos());
             if (snapped != null) {
-                pos = snapped;
                 context = new BlockPlaceContext(player, hand, item, new BlockHitResult(
-                    event.getTarget().getLocation(),
-                    direction,
-                    pos,
+                    target.getLocation(),
+                    face,
+                    snapped,
                     target.isInside()
                 ));
             }
         }
+        BlockPos pos = context.getClickedPos();
         validateCanRender(item, blockItem, pos);
         BlockState state = getPlacementState(block, blockItem, context);
-        List<BlockPos> errorPosList = getErrorPosList(mc.level, block, pos, state);
-        if (!errorPosList.isEmpty()) {
+        boolean placeable = isPlaceable(mc.level, player, block, pos, state);
+        if (!placeable) {
+            // 放不下时物品沿点击面退到偏移位置重试（SimpleMultiPartBlockItem#useOn），
+            // 基准格与点击面都取原始命中的 click，与实际一致
             if (blockItem instanceof SimpleMultiPartBlockItem<?> simpleMultiPartBlockItem) {
-                int distance = simpleMultiPartBlockItem.getMaxOffsetDistance(direction);
-                pos = target.getBlockPos().relative(direction, distance);
-            }
-            if (blockItem instanceof FlexibleMultiPartBlockItem<?, ?, ?> flexibleMultiPartBlockItem) {
-                int distance = flexibleMultiPartBlockItem.getMaxOffsetDistance(state, direction);
-                pos = target.getBlockPos().relative(direction, distance);
+                pos = hitPos.relative(face, simpleMultiPartBlockItem.getMaxOffsetDistance(face));
+            } else if (blockItem instanceof FlexibleMultiPartBlockItem<?, ?, ?> flexibleMultiPartBlockItem) {
+                pos = hitPos.relative(face, flexibleMultiPartBlockItem.getMaxOffsetDistance(state, face));
             }
             context = new BlockPlaceContext(player, hand, item, new BlockHitResult(
-                new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5),
-                direction,
+                Vec3.atCenterOf(pos),
+                face,
                 pos,
                 false
             ));
             state = getPlacementState(block, blockItem, context);
-            errorPosList = getErrorPosList(mc.level, block, pos, state);
+            pos = context.getClickedPos();
+            placeable = isPlaceable(mc.level, player, block, pos, state);
         }
-        if (errorPosList.isEmpty()) {
+        if (placeable) {
             collectRenderEntries(block, pos, state);
         }
+    }
+
+    /**
+     * 复刻实际放置的合法性判断：各部件位置可替换，且状态可存活、目标格无实体阻挡
+     * （{@code BlockItem#getPlacementState} → {@code BlockItem#canPlace}）。任一不满足时
+     * 物品会判定放置失败并退回偏移位置，预览做同样判断才能与实际落点一致。
+     */
+    private static boolean isPlaceable(
+        Level level,
+        LocalPlayer player,
+        AbstractMultiPartBlock<?> block,
+        BlockPos pos,
+        BlockState state
+    ) {
+        if (!getErrorPosList(level, block, pos, state).isEmpty()) return false;
+        return state.canSurvive(level, pos) && level.isUnobstructed(state, pos, CollisionContext.of(player));
     }
 
     private static void expandRenderEntriesForGhost() {

--- a/src/main/java/dev/dubhe/anvilcraft/client/event/RegisterAdditionalEventListener.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/event/RegisterAdditionalEventListener.java
@@ -24,6 +24,8 @@ public class RegisterAdditionalEventListener {
     @SubscribeEvent
     public static void registerModels(ModelEvent.RegisterAdditional event) {
         event.register(standaloneItem("crab_claw_holding_block"));
+        event.register(standaloneItem("crab_claw_holding_block_slab"));
+        event.register(standaloneItem("crab_claw_holding_block_panel"));
         event.register(standaloneItem("crab_claw_holding_item"));
         event.register(standaloneBlock("heliostats_head"));
         event.register(standaloneBlock("heliostats_head_sunflower"));

--- a/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/CrabClawItemInHandRenderer.java
+++ b/src/main/java/dev/dubhe/anvilcraft/client/renderer/item/CrabClawItemInHandRenderer.java
@@ -3,29 +3,146 @@ package dev.dubhe.anvilcraft.client.renderer.item;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import dev.dubhe.anvilcraft.AnvilCraft;
+import dev.dubhe.anvilcraft.block.item.CheckValveItem;
+import dev.dubhe.anvilcraft.block.item.PipeBlockItem;
+import dev.dubhe.anvilcraft.client.support.RenderModelSupport;
+import dev.dubhe.anvilcraft.item.HeavyHalberdItem;
 import dev.dubhe.anvilcraft.item.weapon.EnergyWeaponItem;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.FishingRodItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.MaceItem;
+import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
 
 public class CrabClawItemInHandRenderer extends AbstractItemInHandRenderer {
     private static final ModelResourceLocation HOLDING_ITEM =
         ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_item"));
     private static final ModelResourceLocation HOLDING_BLOCK =
         ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_block"));
+    private static final ModelResourceLocation HOLDING_BLOCK_SLAB =
+        ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_block_slab"));
+    private static final ModelResourceLocation HOLDING_BLOCK_PANEL =
+        ModelResourceLocation.standalone(AnvilCraft.of("item/crab_claw_holding_block_panel"));
+    /**
+     * 扁平方块高度上限（模型空间 0~1 的方块坐标）：压力板、地毯、活板门、阳光探测器等
+     * 不高过该值的模型用 panel 档，改用闭合开口并下调握持高度、放大外移量。
+     */
+    private static final float PANEL_MAX_HEIGHT = 0.4f;
+    /**
+     * 台阶档高度上限：台阶（0.5）与管道（0.625）等不高过该值的模型用 slab 档
+     * （张开开口、钳口更靠内），再高则用方块档。
+     */
+    private static final float SLAB_MAX_HEIGHT = 0.625f;
+    /** 方块档与台阶档握持时物品的竖直偏移（缩放前） */
+    private static final float BLOCK_HOLD_Y = 0.4f;
+    /**
+     * 薄片档握持时物品的竖直偏移（缩放前）。<br>
+     * 薄模型比整方块矮得多，沿用方块档高度会顶到蟹钳上颚而被遮挡，故单独下调。
+     */
+    private static final float PANEL_HOLD_Y = 0.2f;
+    /** 握持方块时的水平旋转（缩放前） */
+    private static final float BLOCK_HOLD_YAW = 60f;
+    /** 方块档与台阶档的前后倾角，使方块贴合张开钳口 */
+    private static final float BLOCK_HOLD_PITCH = 25f;
+    /** 薄片档的前后倾角，比方块档更陡以贴合闭合钳口 */
+    private static final float PANEL_HOLD_PITCH = 45f;
+    /** 方块档与台阶档向外的偏移（缩放前） */
+    private static final float BLOCK_HOLD_Z = -0.1f;
+    /**
+     * 薄片档向外的偏移（缩放前）。<br>
+     * 手部变换位于 z = -0.72，即 -Z 指向屏幕内、远离玩家，故更小的值让薄片从钳口往外突出。
+     */
+    private static final float PANEL_HOLD_Z = -0.35f;
+    /** 长柄武器向左的偏移（缩放前） */
+    private static final float SPEAR_HOLD_X = -0.23f;
+    /**
+     * 长柄武器向后的偏移（缩放前）。<br>
+     * 手部变换位于 z = -0.72，即 -Z 指向屏幕内（远离玩家），故 +Z 为向后、靠近玩家。
+     */
+    private static final float SPEAR_HOLD_Z = 0.07f;
+    /**
+     * 投掷蓄力时蟹钳绕 X 轴的偏转角，使钳口与戟柄成直角。<br>
+     * 取反可翻转倾倒方向。
+     */
+    private static final float TRIDENT_THROW_CLAW_PITCH = 90f;
+
+    private @Nullable BakedModel cachedHeightModel;
+    private @Nullable BlockState cachedHeightState;
+    private float cachedHeight;
 
     protected CrabClawItemInHandRenderer(ItemRenderer itemRenderer, IItemRenderer renderer) {
         super(itemRenderer, renderer);
+    }
+
+    /**
+     * 实测模型包围盒的高度（Y 尺寸），整方块为 1.0、台阶为 0.5、压力板为 0.0625。<br>
+     * 用高度而非最薄维度分档：栅栏这类多元素模型的最薄维度等于其立柱宽度 0.25，
+     * 会与薄片混淆，而其高度 1.0 能正确反映它是个立体方块。<br>
+     * 必须带上方块状态：部分多方块模型在状态为 null 时不会返回任何 quad，会量出退化包围盒。
+     * 测不出几何数据时返回 0，由调用方退回方块档。
+     */
+    private float getModelHeight(BakedModel model, @Nullable BlockState state) {
+        if (model != this.cachedHeightModel || state != this.cachedHeightState) {
+            AABB size = state == null
+                ? RenderModelSupport.getSize(model)
+                : RenderModelSupport.getSize(state, model);
+            float height = (float) size.getYsize();
+            // 无几何数据时包围盒会退化成 min>max，尺寸为负；此时视为不可测量
+            this.cachedHeight = Math.max(height, 0.0f);
+            this.cachedHeightModel = model;
+            this.cachedHeightState = state;
+        }
+        return this.cachedHeight;
+    }
+
+    /**
+     * 是否为按方块握持的物品。<br>
+     * 管道、止逆阀这类物品是自定义 {@link Item}（{@link PipeBlockItem}、{@link CheckValveItem}）
+     * 而非 {@link BlockItem}，若只判断 {@link BlockItem} 会被当成普通物品渲染。
+     */
+    private static boolean isBlockLikeItem(ItemStack stack) {
+        return stack.getItem() instanceof BlockItem
+            || stack.getItem() instanceof PipeBlockItem
+            || stack.getItem() instanceof CheckValveItem;
+    }
+
+    /**
+     * 是否为需要向左偏移的长柄武器。<br>
+     * 原版三叉戟等使用 {@link UseAnim#SPEAR} 手持动画的物品由动画类型识别；
+     * 重戟的长矛模式不使用该动画（{@link UseAnim#NONE}），需按模式单独识别。
+     */
+    private static boolean isSpearLike(ItemStack stack) {
+        if (stack.getUseAnimation() == UseAnim.SPEAR) {
+            return true;
+        }
+        return stack.getItem() instanceof HeavyHalberdItem
+            && HeavyHalberdItem.getMode(stack) == HeavyHalberdItem.SPEAR_MODE;
+    }
+
+    /**
+     * 是否为正在蓄力投掷的长柄武器（原版三叉戟、重戟的三叉戟模式）。<br>
+     * 这两类物品都以 {@link UseAnim#SPEAR} 作为手持动画，与重戟长矛模式的 {@link UseAnim#NONE} 区分。
+     */
+    private static boolean isThrowingSpear(AbstractClientPlayer player, ItemStack stack, InteractionHand hand) {
+        return stack.getUseAnimation() == UseAnim.SPEAR
+            && player.isUsingItem()
+            && player.getUseItemRemainingTicks() > 0
+            && player.getUsedItemHand() == hand;
     }
 
     @Override
@@ -64,8 +181,30 @@ public class CrabClawItemInHandRenderer extends AbstractItemInHandRenderer {
             return;
         }
         if (stack.getItem() instanceof EnergyWeaponItem) return;
-        boolean isBlockItem = this.itemRenderer.getModel(this.mainHandItem, player.level(), player, combinedLight).isGui3d()
-            && this.mainHandItem.getItem() instanceof BlockItem;
+        BakedModel mainHandModel = this.itemRenderer.getModel(
+            this.mainHandItem, player.level(), player, combinedLight
+        );
+        boolean isBlockItem = mainHandModel.isGui3d()
+            && CrabClawItemInHandRenderer.isBlockLikeItem(this.mainHandItem);
+        BlockState mainHandState = this.mainHandItem.getItem() instanceof BlockItem blockItem
+            ? blockItem.getBlock().defaultBlockState()
+            : null;
+        // 按实测高度分档：薄片用闭合开口的 panel，台阶用钳口更靠内的 slab，更高的用 block。
+        // 测不出几何数据（高度为 0）时一律按方块档处理，避免被误判成薄片
+        float height = this.getModelHeight(mainHandModel, mainHandState);
+        boolean measurable = height > 0.0f;
+        boolean isPanel = isBlockItem && measurable && height <= PANEL_MAX_HEIGHT;
+        boolean isSlab = isBlockItem && measurable && !isPanel && height <= SLAB_MAX_HEIGHT;
+        ModelResourceLocation holdingModel;
+        if (!isBlockItem) {
+            holdingModel = HOLDING_ITEM;
+        } else if (isPanel) {
+            holdingModel = HOLDING_BLOCK_PANEL;
+        } else if (isSlab) {
+            holdingModel = HOLDING_BLOCK_SLAB;
+        } else {
+            holdingModel = HOLDING_BLOCK;
+        }
         switch (stack.getUseAnimation()) {
             case EAT:
             case DRINK:
@@ -78,11 +217,17 @@ public class CrabClawItemInHandRenderer extends AbstractItemInHandRenderer {
                 }
                 break;
             case NONE:
+            case SPEAR:
                 break;
             default:
                 return;
         }
         if (stack.getItem() instanceof FishingRodItem) return;
+        // 投掷蓄力时蟹钳单独偏转，使钳口与戟柄成直角；只作用于蟹钳，主手物品不受影响
+        poseStack.pushPose();
+        if (CrabClawItemInHandRenderer.isThrowingSpear(player, stack, hand)) {
+            poseStack.mulPose(Axis.XP.rotationDegrees(TRIDENT_THROW_CLAW_PITCH * i));
+        }
         this.itemRenderer.render(
             this.offHandItem,
             ItemDisplayContext.FIRST_PERSON_RIGHT_HAND,
@@ -94,13 +239,18 @@ public class CrabClawItemInHandRenderer extends AbstractItemInHandRenderer {
             this.itemRenderer
                 .getItemModelShaper()
                 .getModelManager()
-                .getModel(isBlockItem ? HOLDING_BLOCK : HOLDING_ITEM)
+                .getModel(holdingModel)
         );
+        poseStack.popPose();
         if (isBlockItem) {
-            poseStack.mulPose(Axis.YP.rotationDegrees(60f * i));
-            poseStack.mulPose(Axis.XP.rotationDegrees(25f));
+            poseStack.mulPose(Axis.YP.rotationDegrees(BLOCK_HOLD_YAW * i));
+            poseStack.mulPose(Axis.XP.rotationDegrees(isPanel ? PANEL_HOLD_PITCH : BLOCK_HOLD_PITCH));
             poseStack.scale(0.5f, 0.5f, 0.5f);
-            poseStack.translate(0.25f * i, 0.4f, -0.1f);
+            poseStack.translate(
+                0.25f * i,
+                isPanel ? PANEL_HOLD_Y : BLOCK_HOLD_Y,
+                isPanel ? PANEL_HOLD_Z : BLOCK_HOLD_Z
+            );
         } else {
             poseStack.mulPose(Axis.ZP.rotationDegrees(5f * i));
             poseStack.scale(0.75f, 0.75f, 0.75f);
@@ -108,6 +258,10 @@ public class CrabClawItemInHandRenderer extends AbstractItemInHandRenderer {
             if (stack.getItem() instanceof MaceItem) {
                 poseStack.mulPose(Axis.YP.rotationDegrees(-10f * i));
                 poseStack.translate(0.08f * i, -0.1f, 0);
+            }
+            // 长柄武器向左、向后偏移，避免与蟹钳持握姿态重叠
+            if (CrabClawItemInHandRenderer.isSpearLike(stack)) {
+                poseStack.translate(SPEAR_HOLD_X * i, 0, SPEAR_HOLD_Z);
             }
         }
     }

--- a/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/DestroyMode.java
+++ b/src/main/java/dev/dubhe/anvilcraft/event/giantanvil/shock/DestroyMode.java
@@ -32,12 +32,18 @@ public abstract class DestroyMode {
         };
     }
 
+    /**
+     * 按挖掘效果创建破坏模式。<br>
+     * 已知的标准效果复用单例；其余（如余烬铁砧的 5 级熔炼）按实际效果构造，
+     * 不能因为等级不同就退化成 {@link #NORMAL}，否则熔炼等效果会整体失效。
+     */
     public static DestroyMode fromEffect(BlockMiningEffect effect) {
+        if (effect.equals(BlockMiningEffect.NORMAL)) return NORMAL;
         if (effect.equals(BlockMiningEffect.SILK_TOUCH)) return SILK_TOUCH;
         if (effect.equals(BlockMiningEffect.DISINTEGRATION)) return DISINTEGRATION;
         if (effect.equals(BlockMiningEffect.SMELTING)) return AUTO_SMELTING;
         if (effect.equals(BlockMiningEffect.FORTUNE_5)) return FORTUNE;
-        return NORMAL;
+        return createForEffect(effect);
     }
 
     /** 根据边框铁砧行为创建破坏模式，并保留其自定义掉落处理器。 */

--- a/src/main/java/dev/dubhe/anvilcraft/rpc/StorageServerStub.java
+++ b/src/main/java/dev/dubhe/anvilcraft/rpc/StorageServerStub.java
@@ -1269,6 +1269,20 @@ public final class StorageServerStub {
             ItemStack result;
             if (stonecutter) {
                 result = StorageServerStub.assembleCraftingResult(player, crafting, true);
+                // 与工作台一致：自动填充时本次点击预算 = 64 / 单次产物个数 × 倍数（约一组），
+                // 使 shift 点击只合成约一组而非把仓储材料一次合成光。
+                // 守卫用 lockedId（随锁定本地更新）：session 是方法开头读取的局部值，
+                // 同一分块内不会变化，若用它做守卫会在每次迭代重复重置预算。
+                if (lockedId == null && result != null && !result.isEmpty() && initialCrafting.autoFill()) {
+                    RecipeHolder<StonecutterRecipe> recipe =
+                        StorageServerStub.selectedStonecutterRecipe(player, crafting);
+                    if (recipe != null) {
+                        lockedId = recipe.id();
+                        remainingCrafts = Math.max(1, 64 / Math.max(1, result.getCount()))
+                            * Math.max(1, multiplier);
+                        StorageServerStub.lockTakeAllSession(playerId, sourcePos, lockedId, remainingCrafts);
+                    }
+                }
             } else {
                 CraftingInput input = CraftingInput.of(3, 3, crafting.craftingInput());
                 if (input.isEmpty()) {
@@ -1474,6 +1488,25 @@ public final class StorageServerStub {
         return 0;
     }
 
+    /** 切石机当前选中配方的持有者；输入为空 / 无可用配方 / 选中索引越界时返回 null。 */
+    @Nullable
+    private static RecipeHolder<StonecutterRecipe> selectedStonecutterRecipe(
+        ServerPlayer player,
+        CraftingStorage crafting
+    ) {
+        ItemStack input = crafting.stonecutterInput();
+        if (input.isEmpty()) {
+            return null;
+        }
+        List<RecipeHolder<StonecutterRecipe>> recipes = player.level().getRecipeManager()
+            .getRecipesFor(RecipeType.STONECUTTING, new SingleRecipeInput(input), player.level());
+        int selected = crafting.stonecutterSelected();
+        if (recipes.isEmpty() || selected < 0 || selected >= recipes.size()) {
+            return null;
+        }
+        return recipes.get(selected);
+    }
+
     /** 计算③/④ 当前配方产物（不消耗输入）；配方无效或产物为空返回 null。 */
     @Nullable
     private static ItemStack assembleCraftingResult(
@@ -1482,18 +1515,15 @@ public final class StorageServerStub {
         boolean stonecutter
     ) {
         if (stonecutter) {
-            ItemStack input = crafting.stonecutterInput();
-            if (input.isEmpty()) {
+            RecipeHolder<StonecutterRecipe> recipe =
+                StorageServerStub.selectedStonecutterRecipe(player, crafting);
+            if (recipe == null) {
                 return null;
             }
-            List<RecipeHolder<StonecutterRecipe>> recipes = player.level().getRecipeManager()
-                .getRecipesFor(RecipeType.STONECUTTING, new SingleRecipeInput(input), player.level());
-            if (recipes.isEmpty() || crafting.stonecutterSelected() < 0
-                || crafting.stonecutterSelected() >= recipes.size()) {
-                return null;
-            }
-            return recipes.get(crafting.stonecutterSelected()).value()
-                .assemble(new SingleRecipeInput(input), player.level().registryAccess());
+            return recipe.value().assemble(
+                new SingleRecipeInput(crafting.stonecutterInput()),
+                player.level().registryAccess()
+            );
         }
         CraftingInput input = CraftingInput.of(3, 3, crafting.craftingInput());
         List<RecipeHolder<CraftingRecipe>> recipes = player.level().getRecipeManager()

--- a/src/main/resources/assets/anvilcraft/models/item/crab_claw_holding_block_panel.json
+++ b/src/main/resources/assets/anvilcraft/models/item/crab_claw_holding_block_panel.json
@@ -1,0 +1,122 @@
+{
+	"format_version": "1.9.0",
+	"credit": "Made by XeKr with Blockbench",
+	"textures": {
+		"0": "anvilcraft:item/crab_claw",
+		"1": "anvilcraft:item/crab_claw_in",
+		"2": "anvilcraft:item/crab_claw_movable",
+		"3": "anvilcraft:item/crab_claw_movable_in",
+		"particle": "anvilcraft:item/crab_claw"
+	},
+	"elements": [
+		{
+			"name": "cube inverted",
+			"from": [11, 11, 9],
+			"to": [5, 5, 2],
+			"rotation": {"angle": 0, "axis": "x", "origin": [8, 5, 10]},
+			"faces": {
+				"north": {"uv": [10, 12, 16, 6], "texture": "#1"},
+				"east": {"uv": [0, 11, 10, 5], "texture": "#1"},
+				"south": {"uv": [10, 6, 16, 0], "texture": "#1"},
+				"west": {"uv": [7, 11, 0, 5], "texture": "#1"},
+				"up": {"uv": [7, 16, 0, 10], "rotation": 90, "texture": "#1"},
+				"down": {"uv": [7, 6, 0, 0], "rotation": 270, "texture": "#1"}
+			}
+		},
+		{
+			"from": [5, 5, 2],
+			"to": [11, 11, 12],
+			"rotation": {"angle": 0, "axis": "x", "origin": [8, 5, 10]},
+			"faces": {
+				"north": {"uv": [10, 0, 16, 6], "texture": "#0"},
+				"east": {"uv": [10, 5, 0, 11], "texture": "#0"},
+				"south": {"uv": [10, 6, 16, 12], "texture": "#0"},
+				"west": {"uv": [0, 5, 10, 11], "texture": "#0"},
+				"up": {"uv": [10, 0, 0, 6], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [10, 10, 0, 16], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5.5, 5.1, 2.1],
+			"to": [10.5, 7.1, 9.1],
+			"rotation": {"angle": 0, "axis": "x", "origin": [8, 5.1, 7.6]},
+			"faces": {
+				"north": {"uv": [7, 0, 12, 2], "texture": "#2"},
+				"east": {"uv": [7, 5, 0, 7], "texture": "#2"},
+				"south": {"uv": [7, 5, 12, 7], "texture": "#2"},
+				"west": {"uv": [0, 5, 7, 7], "texture": "#2"},
+				"up": {"uv": [0, 0, 7, 5], "rotation": 90, "texture": "#2"},
+				"down": {"uv": [0, 7, 7, 12], "rotation": 270, "texture": "#2"}
+			}
+		},
+		{
+			"name": "cube inverted",
+			"from": [10.5, 7.1, 7.1],
+			"to": [5.5, 5.1, 2.1],
+			"rotation": {"angle": 0, "axis": "x", "origin": [8, 5.1, 7.6]},
+			"faces": {
+				"north": {"uv": [7, 7, 12, 5], "texture": "#3"},
+				"east": {"uv": [0, 7, 5, 5], "texture": "#3"},
+				"south": {"uv": [7, 2, 12, 0], "texture": "#3"},
+				"west": {"uv": [5, 7, 0, 5], "texture": "#3"},
+				"up": {"uv": [0, 12, 5, 7], "rotation": 270, "texture": "#3"},
+				"down": {"uv": [0, 5, 5, 0], "rotation": 90, "texture": "#3"}
+			}
+		}
+	],
+	"gui_light": "front",
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 0, -90],
+			"translation": [0, -2, -2],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 0, -90],
+			"translation": [0, -2, -2],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"firstperson_righthand": {
+			"rotation": [28.5, 0, -20],
+			"translation": [1.88, 2.7, 1.63],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"firstperson_lefthand": {
+			"rotation": [28.5, 0, -20],
+			"translation": [1.88, 2.7, 1.63],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"ground": {
+			"translation": [0, 2, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [135, 60, -90],
+			"translation": [0, 0, 0.75]
+		},
+		"head": {
+			"translation": [0, -0.25, -6.5],
+			"scale": [2, 2, 2]
+		},
+		"fixed": {
+			"rotation": [0, -90, 0],
+			"translation": [0, 0, 0.75]
+		}
+	},
+	"groups": [
+		{
+			"name": "group",
+			"origin": [8, 8, 8],
+			"scope": 0,
+			"color": 0,
+			"children": [0, 1]
+		},
+		{
+			"name": "group",
+			"origin": [0, 0, 0],
+			"scope": 0,
+			"color": 0,
+			"children": [2, 3]
+		}
+	]
+}

--- a/src/main/resources/assets/anvilcraft/models/item/crab_claw_holding_block_slab.json
+++ b/src/main/resources/assets/anvilcraft/models/item/crab_claw_holding_block_slab.json
@@ -1,0 +1,122 @@
+{
+	"format_version": "1.21.11",
+	"credit": "Made by XeKr with Blockbench",
+	"textures": {
+		"0": "anvilcraft:item/crab_claw",
+		"1": "anvilcraft:item/crab_claw_in",
+		"2": "anvilcraft:item/crab_claw_movable",
+		"3": "anvilcraft:item/crab_claw_movable_in",
+		"particle": "anvilcraft:item/crab_claw"
+	},
+	"elements": [
+		{
+			"name": "cube inverted",
+			"from": [11, 11, 9],
+			"to": [5, 5, 2],
+			"rotation": {"angle": 0, "axis": "x", "origin": [8, 5, 10]},
+			"faces": {
+				"north": {"uv": [10, 12, 16, 6], "texture": "#1"},
+				"east": {"uv": [0, 11, 10, 5], "texture": "#1"},
+				"south": {"uv": [10, 6, 16, 0], "texture": "#1"},
+				"west": {"uv": [7, 11, 0, 5], "texture": "#1"},
+				"up": {"uv": [7, 16, 0, 10], "rotation": 90, "texture": "#1"},
+				"down": {"uv": [7, 6, 0, 0], "rotation": 270, "texture": "#1"}
+			}
+		},
+		{
+			"from": [5, 5, 2],
+			"to": [11, 11, 12],
+			"rotation": {"angle": 0, "axis": "x", "origin": [8, 5, 10]},
+			"faces": {
+				"north": {"uv": [10, 0, 16, 6], "texture": "#0"},
+				"east": {"uv": [10, 5, 0, 11], "texture": "#0"},
+				"south": {"uv": [10, 6, 16, 12], "texture": "#0"},
+				"west": {"uv": [0, 5, 10, 11], "texture": "#0"},
+				"up": {"uv": [10, 0, 0, 6], "rotation": 270, "texture": "#0"},
+				"down": {"uv": [10, 10, 0, 16], "rotation": 90, "texture": "#0"}
+			}
+		},
+		{
+			"from": [5.5, 5.1, 2.6],
+			"to": [10.5, 7.1, 9.6],
+			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 5.1, 8.1]},
+			"faces": {
+				"north": {"uv": [7, 0, 12, 2], "texture": "#2"},
+				"east": {"uv": [7, 5, 0, 7], "texture": "#2"},
+				"south": {"uv": [7, 5, 12, 7], "texture": "#2"},
+				"west": {"uv": [0, 5, 7, 7], "texture": "#2"},
+				"up": {"uv": [0, 0, 7, 5], "rotation": 90, "texture": "#2"},
+				"down": {"uv": [0, 7, 7, 12], "rotation": 270, "texture": "#2"}
+			}
+		},
+		{
+			"name": "cube inverted",
+			"from": [10.5, 7.1, 7.6],
+			"to": [5.5, 5.1, 2.6],
+			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 5.1, 8.1]},
+			"faces": {
+				"north": {"uv": [7, 7, 12, 5], "texture": "#3"},
+				"east": {"uv": [0, 7, 5, 5], "texture": "#3"},
+				"south": {"uv": [7, 2, 12, 0], "texture": "#3"},
+				"west": {"uv": [5, 7, 0, 5], "texture": "#3"},
+				"up": {"uv": [0, 12, 5, 7], "rotation": 270, "texture": "#3"},
+				"down": {"uv": [0, 5, 5, 0], "rotation": 90, "texture": "#3"}
+			}
+		}
+	],
+	"gui_light": "front",
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 0, -90],
+			"translation": [0, -2, -2],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 0, -90],
+			"translation": [0, -2, -2],
+			"scale": [0.8, 0.8, 0.8]
+		},
+		"firstperson_righthand": {
+			"rotation": [30, 0, -20],
+			"translation": [1.88, 2.7, 1.63],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"firstperson_lefthand": {
+			"rotation": [30, 0, -20],
+			"translation": [1.88, 2.7, 1.63],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"ground": {
+			"translation": [0, 2, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"gui": {
+			"rotation": [135, 60, -90],
+			"translation": [0, 0, 0.75]
+		},
+		"head": {
+			"translation": [0, -0.25, -6.5],
+			"scale": [2, 2, 2]
+		},
+		"fixed": {
+			"rotation": [0, -90, 0],
+			"translation": [0, 0, 0.75]
+		}
+	},
+	"groups": [
+		{
+			"name": "group",
+			"origin": [8, 8, 8],
+			"scope": 0,
+			"color": 0,
+			"children": [0, 1]
+		},
+		{
+			"name": "group",
+			"origin": [0, 0, 0],
+			"scope": 0,
+			"color": 0,
+			"children": [2, 3]
+		}
+	]
+}

--- a/src/main/resources/assets/anvilcraft/models/item/ember_metal_heavy_halberd.json
+++ b/src/main/resources/assets/anvilcraft/models/item/ember_metal_heavy_halberd.json
@@ -521,13 +521,13 @@
 			"scale": [0.667, 0.667, 0.667]
 		},
 		"firstperson_righthand": {
-			"rotation": [-90, -90, 0],
-			"translation": [4, 0, 1.5],
+			"rotation": [0, -89.75, 76.5],
+			"translation": [4.75, 0.5, 0.25],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
-			"rotation": [0, -90, 0],
-			"translation": [4, 0, 1.5],
+			"rotation": [25.5, -89.75, 13.5],
+			"translation": [4.75, 0.5, 0.25],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"ground": {

--- a/src/main/resources/assets/anvilcraft/models/item/ember_metal_heavy_halberd_spear.json
+++ b/src/main/resources/assets/anvilcraft/models/item/ember_metal_heavy_halberd_spear.json
@@ -420,13 +420,13 @@
 			"scale": [0.667, 0.667, 0.667]
 		},
 		"firstperson_righthand": {
-			"rotation": [-90, -90, 0],
-			"translation": [4, 0, 1.5],
+			"rotation": [0, -89.75, 76.5],
+			"translation": [4.75, 0.5, 0.25],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"firstperson_lefthand": {
-			"rotation": [0, -90, 0],
-			"translation": [4, 0, 1.5],
+			"rotation": [25.5, -89.75, 13.5],
+			"translation": [4.75, 0.5, 0.25],
 			"scale": [0.5, 0.5, 0.5]
 		},
 		"ground": {


### PR DESCRIPTION
- 新增薄片（panel）和台阶（slab）两种蟹钳方块握持模型档位，根据模型高度自动选择
- 为薄片和台阶档设置独立的握持偏移、旋转与缩放参数，提升渲染效果贴合度
- 实测模型包围盒高度用于判定方块档位，改用准确测量高度避免误判
- 支持自定义方块类物品（管道、止逆阀）为方块档处理，扩展方块判定逻辑
- 蟹钳渲染时投掷长柄武器时追加钳口绕X轴旋转，达到钳口与戟柄成直角
- 长柄武器在握持时添加向左和向后偏移，避免与蟹钳姿态重叠
- 更新重戟长柄武器JSON模型的第一人称视角旋转与位移参数
- 新增蟹钳不同握持档位专用模型资源（holding_block_slab和holding_block_panel）
- 注册新增蟹钳握持模型资源，确保渲染时正确调用
- 优化储存端口方块实体掉落物处理，避免空缓存时写入多余数据影响堆叠
- fixed #4774
- fixed #4779
- 修复了多方块预览和实际放置位置不一样的bug
- 修复了切石机补货模式消耗全部存量的问题