### PR TITLE
Fix item interaction with fish tank 修复鱼缸的物品交互

### DIFF
--- a/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/itemhandler/ItemHandlerUtil.java
@@ -225,6 +225,11 @@ public class ItemHandlerUtil {
         return null;
     }
 
+    /// 往一个物品处理器内放入一个物品堆。
+    /// @param dest 要放入物品堆的物品处理器。
+    /// @param stack 要放入的物品堆。
+    /// @param simulate 是否为模拟放入。
+    /// @return 放入后剩余的物品堆。
     public static ItemStack insertItem(@Nullable ResourceHandler<ItemResource> dest, ItemStack stack, boolean simulate) {
         if (dest == null || stack.isEmpty()) return stack;
 

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -665,12 +665,12 @@ public class FishTankBlockEntity extends BlockEntity implements IItemResourceHan
         }
     }
 
-    /// 向鱼缸中放入物品
+    /// 向鱼缸中放入物品堆
     ///
     /// @param handler 鱼缸物品处理器
-    /// @param stack   要放入的物品
+    /// @param stack   要放入的物品堆
     ///
-    /// @return 插入的物品
+    /// @return 放入后剩余的物品堆
     public static ItemStack insertItemToTank(@Nullable ResourceHandler<ItemResource> handler, ItemStack stack) {
         if (handler == null) {
             return stack;

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -276,22 +276,8 @@ public class FishTankBlockEntity extends BlockEntity implements IItemResourceHan
 
         @Override
         public boolean isValid(int index, ItemResource resource) {
-            boolean hasSame = false;
-            int sameIndex = -1;
-            for (int i = 0; i < this.size(); i++) {
-                if (!this.getResource(i).equals(resource)) {
-                    continue;
-                }
-
-                if (hasSame) {
-                    return false;
-                } else {
-                    hasSame = true;
-                    sameIndex = i;
-                }
-            }
-            if (!hasSame) return this.getResource(index).isEmpty();
-            return sameIndex == index;
+            ItemResource stackInSlot = this.getResource(index);
+            return stackInSlot.isEmpty() || ItemStack.isSameItemSameComponents(stackInSlot.toStack(), resource.toStack());
         }
 
         @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -277,7 +277,7 @@ public class FishTankBlockEntity extends BlockEntity implements IItemResourceHan
         @Override
         public boolean isValid(int index, ItemResource resource) {
             ItemResource stackInSlot = this.getResource(index);
-            return stackInSlot.isEmpty() || ItemStack.isSameItemSameComponents(stackInSlot.toStack(), resource.toStack());
+            return stackInSlot.isEmpty() || stackInSlot.equals(resource);
         }
 
         @Override

--- a/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
+++ b/src/main/java/dev/dubhe/anvilcraft/block/entity/FishTankBlockEntity.java
@@ -602,10 +602,10 @@ public class FishTankBlockEntity extends BlockEntity implements IItemResourceHan
         if (!this.isValidInsertPos(hitLoc)) return false;
         if (inHand.is(ModItemTags.DISALLOW_HAND_INSERT_INTO_TANK)) return false;
         if (level.isClientSide()) return true;
-        ItemStack inserted = FishTankBlockEntity.insertItemToTank(this.input, inHand.copy());
+        ItemStack remaining = FishTankBlockEntity.insertItemToTank(this.input, inHand.copy());
         int count = inHand.getCount();
-        inHand.setCount(count - inserted.getCount());
-        return inserted.getCount() != count;
+        inHand.setCount(remaining.getCount());
+        return remaining.getCount() != count;
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -657,11 +657,11 @@ public class FishTankBlockEntity extends BlockEntity implements IItemResourceHan
             return;
         }
         ItemStack stack = entity.getItem();
-        ItemStack inserted = FishTankBlockEntity.insertItemToTank(handler, stack.copy());
-        if (inserted.getCount() == stack.getCount()) {
+        ItemStack remaining = FishTankBlockEntity.insertItemToTank(handler, stack.copy());
+        if (remaining.isEmpty()) {
             entity.discard();
         } else {
-            entity.setItem(inserted);
+            entity.setItem(remaining);
         }
     }
 


### PR DESCRIPTION
本 PR 包含以下更改：

- 修复手持物品与鱼缸交互时物品复制的问题。
- 增补及修正部分放入物品堆相关的文档。
- 修复使用鱼缸执行配方时单种产物最多只能产出一组的问题。（#3631）

这些问题仅出现于 26.1 的版本，故请求直接拉取至 26.1 分支。